### PR TITLE
AGAT.pm & agat_sp_extract_sequences.pl: respect verbose level 0 configuration 

### DIFF
--- a/bin/agat_sp_extract_sequences.pl
+++ b/bin/agat_sp_extract_sequences.pl
@@ -109,7 +109,7 @@ if ($config->{log}) {
 
 # --- Check codon table
 # --- Check codon table
-$opt_codonTable = get_proper_codon_table($opt_codonTable, $log, $config->{verbose});
+$opt_codonTable = get_proper_codon_table($opt_codonTable, $log);
 
 # activate warnings limit
 my %warnings;
@@ -133,7 +133,7 @@ else{
   $ostream = Bio::SeqIO->new(-fh => \*STDOUT, -format => 'Fasta');
 }
 
-dual_print($log, "We will extract the $opt_type sequences.\n", $config->{verbose});
+dual_print($log, "We will extract the $opt_type sequences.\n");
 $opt_type=lc($opt_type);
 
 # deal with OFS
@@ -151,11 +151,11 @@ if ($opt_keep_parent_attributes){
 #### read gff file and save info in memory
 ######################
 ### Parse GFF input #
-dual_print($log, "Reading file $opt_gfffile\n", $config->{verbose});
+dual_print($log, "Reading file $opt_gfffile\n");
 my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $opt_gfffile,
                                                                  config => $config
                                                               });
-dual_print($log, "Parsing Finished\n", $config->{verbose});
+dual_print($log, "Parsing Finished\n");
 ### END Parse GFF input #
 #########################
 
@@ -171,7 +171,7 @@ my %allIDs; # save ID in lower case to avoid cast problems
 foreach my $id (@ids ){$allIDs{lc($id)}=$id;}
 
 
-dual_print($log, "Fasta file parsed\n", $config->{verbose});
+dual_print($log, "Fasta file parsed\n");
 # ----------------------------------- LEVEL 1 ----------------------------------
 foreach my $seqname (sort { (($a =~ /(\d+)$/)[0] || 0) <=> (($b =~ /(\d+)$/)[0] || 0) } keys %{$hash_l1_grouped}) {
 
@@ -238,30 +238,27 @@ foreach my $seqname (sort { (($a =~ /(\d+)$/)[0] || 0) <=> (($b =~ /(\d+)$/)[0] 
 }
 
 #END
-dual_print($log, "usage: $0 @copyARGV\n", $config->{verbose});
+dual_print($log, "usage: $0 @copyARGV\n");
 
 if($opt_upstreamRegion and $opt_downRegion){
   dual_print($log,
-              "$nbFastaSeq $opt_type converted in fasta with $opt_upstreamRegion upstream nucleotides and $opt_downRegion downstream nucleotides.\n",
-              $config->{verbose});
+              "$nbFastaSeq $opt_type converted in fasta with $opt_upstreamRegion upstream nucleotides and $opt_downRegion downstream nucleotides.\n");
 }
 elsif($opt_upstreamRegion){
   dual_print($log,
-              "$nbFastaSeq $opt_type converted in fasta with $opt_upstreamRegion upstream nucleotides.\n",
-              $config->{verbose});
+              "$nbFastaSeq $opt_type converted in fasta with $opt_upstreamRegion upstream nucleotides.\n");
 }
 elsif($opt_downRegion){
   dual_print($log,
-              "$nbFastaSeq $opt_type converted in fasta with $opt_downRegion downstream nucleotides.\n",
-              $config->{verbose});
+              "$nbFastaSeq $opt_type converted in fasta with $opt_downRegion downstream nucleotides.\n");
 }
 else{
-  dual_print($log, "$nbFastaSeq $opt_type converted in fasta.\n", $config->{verbose});
+  dual_print($log, "$nbFastaSeq $opt_type converted in fasta.\n");
 }
 
 my $end_run = time();
 my $run_time = $end_run - $start_run;
-dual_print($log, "Job done in $run_time seconds\n", $config->{verbose});
+dual_print($log, "Job done in $run_time seconds\n");
 close $log if $log;
 
 #######################################################################################################################
@@ -450,7 +447,7 @@ sub extract_sequences{
     # create object
     my $seqObj = create_seqObj($sequence, $id_seq, $description, $minus, $info);
     # print object
-    print_seqObj($ostream, $seqObj, $opt_AA, $opt_codonTable, $phase, $config->{verbose}, $log);
+    print_seqObj($ostream, $seqObj, $opt_AA, $opt_codonTable, $phase, $log);
   }
   # --------------------------------------
 
@@ -516,7 +513,7 @@ sub extract_sequences{
       }
 
       #print object
-      print_seqObj($ostream, $seqObj, $opt_AA, $opt_codonTable, $phase, $config->{verbose}, $log);
+      print_seqObj($ostream, $seqObj, $opt_AA, $opt_codonTable, $phase, $log);
     }
   }
   # --------------------------------------
@@ -596,7 +593,7 @@ sub extract_sequences{
       #create object
       my $seqObj = create_seqObj($sequence, $id_seq, $description, $minus, $info);
       #print object
-      print_seqObj($ostream, $seqObj, $opt_AA, $opt_codonTable, $phase, $config->{verbose}, $log);
+      print_seqObj($ostream, $seqObj, $opt_AA, $opt_codonTable, $phase, $log);
     }
 
     # ---- Non spreaded feature extract them one by one
@@ -645,7 +642,7 @@ sub extract_sequences{
         }
 
         #print object
-        print_seqObj($ostream, $seqObj, $opt_AA, $opt_codonTable, $phase, $config->{verbose}, $log);
+        print_seqObj($ostream, $seqObj, $opt_AA, $opt_codonTable, $phase, $log);
       }
     }
   }
@@ -786,7 +783,7 @@ sub  get_sequence{
 
 # Print the sequence object
 sub print_seqObj{
-  my($ostream, $seqObj, $opt_AA, $opt_codonTable, $phase, $verbose, $log) = @_;
+  my($ostream, $seqObj, $opt_AA, $opt_codonTable, $phase, $log) = @_;
 
 
   if($opt_AA){ #translate if asked
@@ -804,8 +801,7 @@ sub print_seqObj{
           my $translated_seq = substr($transObj->seq(),1); # removing first AA
           $transObj->seq("M".$translated_seq);  # adding M as first AA
           dual_print($log,
-                     "Replacing valid alternative start codon (AA=$first_AA) by a methionine (AA=M) for ".$seqObj->id().".\n",
-                     $verbose);
+                     "Replacing valid alternative start codon (AA=$first_AA) by a methionine (AA=M) for ".$seqObj->id().".\n");
         }
       }
 

--- a/lib/AGAT/AGAT.pm
+++ b/lib/AGAT/AGAT.pm
@@ -147,24 +147,32 @@ MESSAGE
 # load configuration file from local file if any either the one shipped with AGAT
 # return a hash containing the configuration.
 sub get_agat_config{
-	my ($args)=@_;
+        my ($args)=@_;
 
-	# Print the header. Put here because get_agat_config it the first function call for _sp_ and _sq_ screen
-	print AGAT::AGAT::get_agat_header();
+        my ($config_file_provided);
+        if( defined($args->{config_file_in}) ) { $config_file_provided = $args->{config_file_in};}
 
-	my ($config_file_provided);
-	if( defined($args->{config_file_in}) ) { $config_file_provided = $args->{config_file_in};}
+        # First retrieve the config file path without printing anything yet
+        my $config_file_checked = get_config({type => "local",
+                                              config_file_in => $config_file_provided,
+                                              verbose => 0});
+        # Load and check the configuration
+        my $config = load_config({ config_file => $config_file_checked});
+        check_config({ config => $config});
 
-	# Get the config file
-	my $config_file_checked = get_config({type => "local", config_file_in => $config_file_provided}); #try local first, if none will take the original
-	# Load the config
-	my $config = load_config({ config_file => $config_file_checked});
-	check_config({ config => $config});
+        # Print header and config information only if verbosity allows it
+        if ($config->{verbose} > 0){
+                print AGAT::AGAT::get_agat_header();
+                # Re-run get_config to display the message about which file is used
+                get_config({type => "local",
+                            config_file_in => $config_file_provided,
+                            verbose => $config->{verbose}});
+        }
 
-	# Store the config in a Global variable accessible from everywhere.
-	$CONFIG = $config;
-	
-	return $config;
+        # Store the config in a Global variable accessible from everywhere.
+        $CONFIG = $config;
+
+        return $config;
 }
 
 # ==============================================================================

--- a/lib/AGAT/Utilities.pm
+++ b/lib/AGAT/Utilities.pm
@@ -68,14 +68,18 @@ sub exists_undef_value {
 # @input: 1 =>  integer, 2 => verbose
 # @output 1 => integer
 sub get_proper_codon_table {
-  my ($codon_table_id_original, $verbose) = @_;
+  my ($codon_table_id_original, $log, $verbose) = @_;
+  if (defined $log && !ref($log) && !defined $verbose) {
+    $verbose = $log;
+    $log     = undef;
+  }
   if (! defined $verbose) { $verbose = 1; }
   my $codonTable = Bio::Tools::CodonTable->new( -id => $codon_table_id_original);
   my $codon_table_id_bioperl = $codonTable->id;
-  
+
   # To deal with empty result in version of bioperl < april 2024 when asking with table 0 (it was reutrning an empty string)
   if (! defined($codon_table_id_bioperl)){
-	$codon_table_id_bioperl = 1 ; # default codon table
+        $codon_table_id_bioperl = 1 ; # default codon table
   }
 
   if ($codon_table_id_original == 0 and  $codon_table_id_original != $codon_table_id_bioperl){
@@ -84,8 +88,7 @@ sub get_proper_codon_table {
     "It uses codon table $codon_table_id_bioperl instead.");
   }
 
-  dual_print(undef, "Codon table ".$codon_table_id_bioperl.
-                     " in use. You can change it using the appropriate parameter.\n",
+  dual_print($log, "Codon table ".$codon_table_id_bioperl." in use. You can change it using the appropriate parameter.\n",
              $verbose);
   return $codon_table_id_bioperl;
 }

--- a/lib/AGAT/Utilities.pm
+++ b/lib/AGAT/Utilities.pm
@@ -65,10 +65,11 @@ sub exists_undef_value {
 }
 
 # @Purpose: check if the table codon is available in bioperl
-# @input: 1 =>  integer
+# @input: 1 =>  integer, 2 => verbose
 # @output 1 => integer
 sub get_proper_codon_table {
-  my ($codon_table_id_original) = @_;
+  my ($codon_table_id_original, $verbose) = @_;
+  if (! defined $verbose) { $verbose = 1; }
   my $codonTable = Bio::Tools::CodonTable->new( -id => $codon_table_id_original);
   my $codon_table_id_bioperl = $codonTable->id;
   
@@ -82,8 +83,10 @@ sub get_proper_codon_table {
     "see https://github.com/bioperl/bioperl-live/pull/315\n".
     "It uses codon table $codon_table_id_bioperl instead.");
   }
-  
-  print "Codon table ".$codon_table_id_bioperl." in use. You can change it using the appropriate parameter.\n";
+
+  dual_print(undef, "Codon table ".$codon_table_id_bioperl.
+                     " in use. You can change it using the appropriate parameter.\n",
+             $verbose);
   return $codon_table_id_bioperl;
 }
 

--- a/lib/AGAT/Utilities.pm
+++ b/lib/AGAT/Utilities.pm
@@ -68,12 +68,7 @@ sub exists_undef_value {
 # @input: 1 =>  integer, 2 => verbose
 # @output 1 => integer
 sub get_proper_codon_table {
-  my ($codon_table_id_original, $log, $verbose) = @_;
-  if (defined $log && !ref($log) && !defined $verbose) {
-    $verbose = $log;
-    $log     = undef;
-  }
-  if (! defined $verbose) { $verbose = 1; }
+  my ($codon_table_id_original, $log) = @_;
   my $codonTable = Bio::Tools::CodonTable->new( -id => $codon_table_id_original);
   my $codon_table_id_bioperl = $codonTable->id;
 
@@ -88,8 +83,8 @@ sub get_proper_codon_table {
     "It uses codon table $codon_table_id_bioperl instead.");
   }
 
-  dual_print($log, "Codon table ".$codon_table_id_bioperl." in use. You can change it using the appropriate parameter.\n",
-             $verbose);
+  dual_print($log,
+             "Codon table ".$codon_table_id_bioperl." in use. You can change it using the appropriate parameter.\n");
   return $codon_table_id_bioperl;
 }
 
@@ -301,16 +296,23 @@ sub print_time{
 # @input: 3 => fh, string, integer
 # @output 0 => None
 sub dual_print{
-	my ($fh, $string, $verbose) = @_;
-	if(! defined($verbose)){$verbose = 1;}#if verbose no set we set it to activate
+        my ($fh, $string, $verbose) = @_;
+        if(! defined($verbose)){
+                if(defined $AGAT::AGAT::CONFIG->{verbose}){
+                        $verbose = $AGAT::AGAT::CONFIG->{verbose};
+                }
+                else{
+                        $verbose = 1; # default verbosity
+                }
+        }
 
-	if($verbose > 0 ){ #only 0 is quite mode
-		print $string;
-	}
-	# print in log in any provided
-	if($fh){
-		print $fh $string;
-	}
+        if($verbose > 0 ){ #only 0 is quiet mode
+                print $string;
+        }
+        # print in log in any provided
+        if($fh){
+                print $fh $string;
+        }
 }
 
 # @Purpose: transform a String with separator into hash

--- a/t/agat_sp_extract_sequences_quiet.t
+++ b/t/agat_sp_extract_sequences_quiet.t
@@ -11,6 +11,7 @@ my $repo   = abs_path('.');
 copy("$repo/share/agat_config.yaml", "$tmpdir/agat_config.yaml");
 system("perl -i -pe 's/^verbose: 1/verbose: 0/' $tmpdir/agat_config.yaml");
 system("perl -i -pe 's/^progress_bar: true/progress_bar: false/' $tmpdir/agat_config.yaml");
+system("perl -i -pe 's/^log: true/log: false/' $tmpdir/agat_config.yaml");
 
 my $cmd = "$repo/bin/agat_sp_extract_sequences.pl --gff $repo/t/scripts_output/in/1.gff --fasta $repo/t/scripts_output/in/1.fa --config $tmpdir/agat_config.yaml -o $tmpdir/out.fa";
 my $output = `$cmd 2>&1`;

--- a/t/agat_sp_extract_sequences_quiet.t
+++ b/t/agat_sp_extract_sequences_quiet.t
@@ -1,0 +1,18 @@
+use strict;
+use warnings;
+use Test::More tests => 1;
+use File::Temp qw(tempdir);
+use File::Copy qw(copy);
+use Cwd qw(abs_path);
+
+my $tmpdir = tempdir(CLEANUP => 1);
+my $repo   = abs_path('.');
+
+copy("$repo/share/agat_config.yaml", "$tmpdir/agat_config.yaml");
+system("perl -i -pe 's/^verbose: 1/verbose: 0/' $tmpdir/agat_config.yaml");
+system("perl -i -pe 's/^progress_bar: true/progress_bar: false/' $tmpdir/agat_config.yaml");
+
+my $cmd = "$repo/bin/agat_sp_extract_sequences.pl --gff $repo/t/scripts_output/in/1.gff --fasta $repo/t/scripts_output/in/1.fa --config $tmpdir/agat_config.yaml -o $tmpdir/out.fa";
+my $output = `$cmd 2>&1`;
+
+is($output, '', 'agat_sp_extract_sequences.pl is quiet with verbose=0');

--- a/t/get_agat_config.t
+++ b/t/get_agat_config.t
@@ -1,0 +1,27 @@
+use strict;
+use warnings;
+use Test::More tests => 1;
+use AGAT::AGAT;
+use AGAT::Config;
+
+# Ensure no local config file exists
+my $config_file = 'agat_config.yaml';
+unlink $config_file;
+
+# Copy the default config locally
+expose_config_file();
+
+# Set verbose to 0
+system(q{perl -i -pe 's/^verbose: 1/verbose: 0/' agat_config.yaml});
+
+# Capture output from get_agat_config
+my $output = '';
+{
+    open my $fh, '>', \$output;
+    local *STDOUT = $fh;
+    get_agat_config();
+}
+
+is($output, '', 'get_agat_config is quiet when verbose=0');
+
+unlink $config_file;


### PR DESCRIPTION
## Summary
- avoid printing AGAT banner and config message when verbosity is zero
- cover silent config loading with regression test

## Testing
- `perlcritic --gentle lib/AGAT/AGAT.pm t/get_agat_config.t`
- `prove -lbr t` *(fails: t/gff_other.t, t/scripts_output.t)*

------
https://chatgpt.com/codex/tasks/task_e_68a2f98a35a8832a9e4a3c5b89f2b1da