### PR TITLE
Respect verbose level 0 configuration

### DIFF
--- a/bin/agat_convert_embl2gff.pl
+++ b/bin/agat_convert_embl2gff.pl
@@ -52,10 +52,18 @@ if ( ! (defined($embl)) ){
 $config = get_agat_config({config_file_in => $config});
 my $throw_fasta=$config->{"throw_fasta"};
 
+my $log;
+if ($config->{log}) {
+  my ($file) = $0 =~ /([^\/]+)$/;
+  my $log_name = $file . ".agat.log";
+  open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+  dual_print($log, $header, 0);
+}
+
 ##################
 # MANAGE OPTION  #
 if($discard and $keep){
-  print "Cannot discard and keep the same primary tag. You have to choose if you want to discard it or to keep it.\n";
+  dual_print($log, "Cannot discard and keep the same primary tag. You have to choose if you want to discard it or to keep it.\n", 1);
 }
 
 ### If primaryTags given, parse them:
@@ -65,18 +73,20 @@ if ($primaryTags){
   @listprimaryTags= split(/,/, $primaryTags);
 
   if($discard){
-    print "We will not keep the following primary tag:\n";
+    dual_print($log, "We will not keep the following primary tag:\n");
     foreach my $tag (@listprimaryTags){
-      print $tag,"\n";
+      dual_print($log, $tag."\n");
     }
   }
   elsif($keep){ # Attribute we have to replace by a new name
-    print "We will keep only the following primary tag:\n";
+    dual_print($log, "We will keep only the following primary tag:\n");
     foreach my $tag (@listprimaryTags){
-      print $tag,"\n";
+      dual_print($log, $tag."\n");
     }
   }
-  else{print "You gave a list of primary tag wihtout telling me what you want I do with. Discard them or keep only them ?\n";}
+  else{dual_print($log, "You gave a list of primary tag wihtout telling me what you want I do with. Discard them or keep only them ?\n", 1);}
+
+close $log if $log;
 }
 
 

--- a/bin/agat_sp_Prokka_inferNameFromAttributes.pl
+++ b/bin/agat_sp_Prokka_inferNameFromAttributes.pl
@@ -46,6 +46,14 @@ if ( ! (defined($gff)) ){
 # --- Manage config ---
 $config = get_agat_config({config_file_in => $config});
 
+my $log;
+if ($config->{log}) {
+  my ($file) = $0 =~ /([^\/]+)$/;
+  my $log_name = $file . ".agat.log";
+  open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+  dual_print($log, $header, 0);
+}
+
 # Prepare output
 my $gffout = prepare_gffout($config, $outfile);
 
@@ -56,7 +64,7 @@ my $gffout = prepare_gffout($config, $outfile);
 my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $gff,
                                                                  config => $config
                                                               });
-print ("GFF3 file parsed\n");
+dual_print($log, "GFF3 file parsed\n");
 
 my $nbNameAdded=0;
 
@@ -82,9 +90,9 @@ foreach my $tag (keys %{$hash_omniscient->{'level1'}}){
         $nbNameAdded++;
       }
       elsif($feature->has_tag('Name') and ( ! $force)){
-        print "Feature contains already an attribute Name. You can force it replacement by using the option --force\n";
+        dual_print($log, "Feature contains already an attribute Name. You can force it replacement by using the option --force\n");
       }
-      print "Name found in gene attribute = $name\n";
+      dual_print($log, "Name found in gene attribute = $name\n");
     }# Name not found in gene attribute. So we try to get the name included in the inference attribute.
     elsif($feature->has_tag('inference')){
       my @inferenceAtt=$feature->get_tag_values('inference');
@@ -111,14 +119,16 @@ foreach my $tag (keys %{$hash_omniscient->{'level1'}}){
           $nbNameAdded++;
         }
         elsif($feature->has_tag('Name') and ( ! $force)){
-          print "Feature contains already an attribute Name. You can force it replacement by using the option --force\n";
+          dual_print($log, "Feature contains already an attribute Name. You can force it replacement by using the option --force\n");
         }
-        print "My Name get in inference attribute = $name\n";
+        dual_print($log, "My Name get in inference attribute = $name\n");
       }
     }
   }
 }
-print "We added $nbNameAdded Name attributes\n";
+dual_print($log, "We added $nbNameAdded Name attributes\n");
+
+close $log if $log;
 
 print_omniscient( {omniscient => $hash_omniscient, output => $gffout} );
 

--- a/bin/agat_sp_clipN_seqExtremities_and_fixCoordinates.pl
+++ b/bin/agat_sp_clipN_seqExtremities_and_fixCoordinates.pl
@@ -51,6 +51,14 @@ if ( (! (defined($opt_gfffile)) ) or (! (defined($opt_fastafile)) ) ){
 # --- Manage config ---
 $config = get_agat_config({config_file_in => $config});
 
+my $log;
+if ($config->{log}) {
+  my ($file) = $0 =~ /([^\/]+)$/;
+  my $log_name = $file . ".agat.log";
+  open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+  dual_print($log, $header, 0);
+}
+
 ######################
 # Manage output file #
 my $ostream;
@@ -68,11 +76,11 @@ my $gffout = prepare_gffout($config, $opt_output_gff);
 #### read gff file and save info in memory
 ######################
 ### Parse GFF input #
-print "Reading file $opt_gfffile\n";
+dual_print($log, "Reading file $opt_gfffile\n");
 my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $opt_gfffile,
                                                                  config => $config
                                                               });
-print "Parsing Finished\n";
+dual_print($log, "Parsing Finished\n");
 ### END Parse GFF input #
 #########################
 
@@ -163,13 +171,15 @@ foreach my $seq_id (@ids ){
 # print annotation whith shifter location
 print_omniscient( {omniscient => $hash_omniscient, output => $gffout} );
 
-print "We found $cpt_Nleft sequence(s) starting with N\n";
-print "We found $cpt_Nright sequence(s) ending with N\n";
-print "We found $cpt_Nboth sequence(s) having N both extremities\n";
+dual_print($log, "We found $cpt_Nleft sequence(s) starting with N\n");
+dual_print($log, "We found $cpt_Nright sequence(s) ending with N\n");
+dual_print($log, "We found $cpt_Nboth sequence(s) having N both extremities\n");
 
 my $end_run = time();
 my $run_time = $end_run - $start_run;
-print "Job done in $run_time seconds\n";
+dual_print($log, "Job done in $run_time seconds\n");
+
+close $log if $log;
 
 
 ########################################################################################

--- a/bin/agat_sp_filter_by_mrnaBlastValue.pl
+++ b/bin/agat_sp_filter_by_mrnaBlastValue.pl
@@ -48,6 +48,14 @@ if ( ! (defined($gff)) or !(defined($blast)) ){
 # --- Manage config ---
 $config = get_agat_config({config_file_in => $config});
 
+my $log;
+if ($config->{log}) {
+  my ($file) = $0 =~ /([^\/]+)$/;
+  my $log_name = $file . ".agat.log";
+  open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+  dual_print($log, $header, 0);
+}
+
 # Open Output files #
 my $out = prepare_gffout($config, $outfile);
 
@@ -57,11 +65,11 @@ my $out = prepare_gffout($config, $outfile);
 my $killlist = parse_blast($blast);
 
 ### Parse GFF input #
-print ("Parse file $gff\n");
+dual_print($log, "Parse file $gff\n");
 my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $gff,
                                                                  config => $config
                                                               });
-print ("$gff file parsed\n");
+dual_print($log, "$gff file parsed\n");
 
 # Remove all mRNA specified by the kill-list from their (gene-) parents.
 remove_omniscient_elements_from_level2_ID_list ($hash_omniscient, $killlist);
@@ -168,7 +176,9 @@ sub parse_blast
 
     #print "We will removed $cptCount more.\n";
     my $nbremove = @answer;
-    print "$nbremove gene will be removed !\n";
+    dual_print($log, "$nbremove gene will be removed !\n");
+
+close $log if $log;
 
     return \@answer;
 } ## end sub parse_blast

--- a/bin/agat_sp_filter_feature_by_attribute_presence.pl
+++ b/bin/agat_sp_filter_feature_by_attribute_presence.pl
@@ -52,6 +52,14 @@ if ( ! $opt_gff or ! $opt_attribute ){
 # --- Manage config ---
 $config = get_agat_config({config_file_in => $config});
 
+my $log;
+if ($config->{log}) {
+  my ($file) = $0 =~ /([^\/]+)$/;
+  my $log_name = $file . ".agat.log";
+  open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+  dual_print($log, $header, 0);
+}
+
 ###############
 # Manage Output
 
@@ -105,10 +113,10 @@ if ($opt_attribute){
 
   foreach my $attribute (@attList){
       push @attListOk, $attribute;
-      print "$attribute attribute will be processed.\n";
+      dual_print($log, "$attribute attribute will be processed.\n");
 
   }
-  print "\n";
+  dual_print($log, "\n");
 }
 
 # start with some interesting information
@@ -116,11 +124,8 @@ my $stringPrint = strftime "%m/%d/%Y at %Hh%Mm%Ss", localtime;
 $stringPrint .= "\nusage: $0 @copyARGV\n";
 $stringPrint .= "We will discard $print_feature_string that have the attribute $opt_attribute.\n";
 
-if ($opt_output){
-  print $ostreamReport $stringPrint;
-  print $stringPrint;
-}
-else{ print $stringPrint; }
+dual_print($log, $stringPrint);
+print $ostreamReport $stringPrint if $ostreamReport;
 
 													#######################
 # >>>>>>>>>>>>>>>>>>>>>>>>#        MAIN         #<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
@@ -132,7 +137,7 @@ my %all_cases = ('l1' => 0, 'l2' => 0, 'l3' => 0, 'all' => 0);
 my ($hash_omniscient, $hash_mRNAGeneLink) =  slurp_gff3_file_JD({ input => $opt_gff,
                                                                   config => $config
                                                                 });
-print("Parsing Finished\n");
+dual_print($log, "Parsing Finished\n");
 ### END Parse GFF input #
 #########################
 # sort by seq id
@@ -224,10 +229,10 @@ $stringPrint = $all_cases{'all'}." features removed:\n";
 $stringPrint .= $all_cases{'l1'}." features level1 (e.g. gene) removed\n";
 $stringPrint .= $all_cases{'l2'}." features level2 (e.g. mRNA) removed\n";
 $stringPrint .= $all_cases{'l3'}." features level3 (e.g. exon) removed\n";
-if ($opt_output){
-  print $ostreamReport $stringPrint;
-  print $stringPrint;
-} else{ print $stringPrint; }
+dual_print($log, $stringPrint);
+print $ostreamReport $stringPrint if $ostreamReport;
+
+close $log if $log;
 
 #######################################################################################################################
         ####################

--- a/bin/agat_sp_filter_feature_from_kill_list.pl
+++ b/bin/agat_sp_filter_feature_from_kill_list.pl
@@ -52,6 +52,14 @@ if ( ! $opt_gff or ! $opt_kill_list ){
 # --- Manage config ---
 $config = get_agat_config({config_file_in => $config});
 
+my $log;
+if ($config->{log}) {
+  my ($file) = $0 =~ /([^\/]+)$/;
+  my $log_name = $file . ".agat.log";
+  open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+  dual_print($log, $header, 0);
+}
+
 ###############
 # Manage Output
 
@@ -110,11 +118,8 @@ $stringPrint .= "\nusage: $0 @copyARGV\n";
 $stringPrint .= "We will discard $print_feature_string that share the value of the $opt_attribute attribute with the kill list.\n";
 $stringPrint .= "The kill list contains $nb_to_kill uniq IDs\n";
 
-if ($opt_output){
-  print $ostreamReport $stringPrint;
-  print $stringPrint;
-}
-else{ print $stringPrint; }
+dual_print($log, $stringPrint);
+print $ostreamReport $stringPrint if $ostreamReport;
                           #######################
 # >>>>>>>>>>>>>>>>>>>>>>>>#        MAIN         #<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                           #######################
@@ -124,7 +129,7 @@ my %all_cases = ('l1' => 0, 'l2' => 0, 'l3' => 0, 'all' => 0);
 my ($hash_omniscient, $hash_mRNAGeneLink) =  slurp_gff3_file_JD({ input => $opt_gff,
                                                                   config => $config
                                                                 });
-print("Parsing Finished\n");
+dual_print($log, "Parsing Finished\n");
 ### END Parse GFF input #
 #########################
 # sort by seq id
@@ -216,10 +221,10 @@ $stringPrint = $all_cases{'all'}." features removed:\n";
 $stringPrint .= $all_cases{'l1'}." features level1 (e.g. gene) removed\n";
 $stringPrint .= $all_cases{'l2'}." features level2 (e.g. mRNA) removed\n";
 $stringPrint .= $all_cases{'l3'}." features level3 (e.g. exon) removed\n";
-if ($opt_output){
-  print $ostreamReport $stringPrint;
-  print $stringPrint;
-} else{ print $stringPrint; }
+dual_print($log, $stringPrint);
+print $ostreamReport $stringPrint if $ostreamReport;
+
+close $log if $log;
 
 #######################################################################################################################
         ####################

--- a/bin/agat_sp_filter_gene_by_intron_numbers.pl
+++ b/bin/agat_sp_filter_gene_by_intron_numbers.pl
@@ -49,6 +49,14 @@ if ( ! $opt_gff ){
 # --- Manage config ---
 $config = get_agat_config({config_file_in => $config});
 
+my $log;
+if ($config->{log}) {
+  my ($file) = $0 =~ /([^\/]+)$/;
+  my $log_name = $file . ".agat.log";
+  open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+  dual_print($log, $header, 0);
+}
+
 ###############
 # Manage Output
 
@@ -72,7 +80,8 @@ my $ostreamReport = prepare_fileout($ostreamReport_file);
 
 #Manage test option
 if($opt_test ne "<" and $opt_test ne ">" and $opt_test ne "<=" and $opt_test ne ">=" and $opt_test ne "="){
-  print "The test to apply is Wrong: $opt_test.\nWe want something among this list: <,>,<=,>= or =.";exit;
+  dual_print($log, "The test to apply is Wrong: $opt_test.\nWe want something among this list: <,>,<=,>= or =.");
+  exit;
 }
 
 # start with some interesting information
@@ -80,11 +89,8 @@ my $stringPrint = strftime "%m/%d/%Y at %Hh%Mm%Ss", localtime;
 $stringPrint .= "\nusage: $0 @copyARGV\n";
 $stringPrint .= "We will select genes that contain $opt_test $opt_nb introns.\n";
 
-if ($opt_output){
-  print $ostreamReport $stringPrint;
-  print $stringPrint;
-}
-else{ print $stringPrint; }
+dual_print($log, $stringPrint);
+print $ostreamReport $stringPrint if $ostreamReport;
                           #######################
 # >>>>>>>>>>>>>>>>>>>>>>>>#        MAIN         #<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                           #######################
@@ -94,7 +100,7 @@ else{ print $stringPrint; }
 my ($hash_omniscient, $hash_mRNAGeneLink) =  slurp_gff3_file_JD({ input => $opt_gff,
                                                                   config => $config
                                                                 });
-print("Parsing Finished\n");
+dual_print($log, "Parsing Finished\n");
 ### END Parse GFF input #
 #########################
 # sort by seq id
@@ -165,10 +171,10 @@ my $test_fail = scalar @list2;
 
 $stringPrint = "$test_success genes selected with at least one RNA with $opt_test $opt_nb intron(s).\n";
 $stringPrint .= "$test_fail remaining genes that not pass the test.\n";
-if ($opt_output){
-  print $ostreamReport $stringPrint;
-  print $stringPrint;
-} else{ print $stringPrint; }
+dual_print($log, $stringPrint);
+print $ostreamReport $stringPrint if $ostreamReport;
+
+close $log if $log;
 
 #######################################################################################################################
         ####################

--- a/bin/agat_sp_fix_cds_phases.pl
+++ b/bin/agat_sp_fix_cds_phases.pl
@@ -48,6 +48,14 @@ if (! defined($opt_gfffile) or ! defined($opt_fasta)){
 # --- Manage config ---
 $config = get_agat_config({config_file_in => $config});
 
+my $log;
+if ($config->{log}) {
+  my ($file) = $0 =~ /([^\/]+)$/;
+  my $log_name = $file . ".agat.log";
+  open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+  dual_print($log, $header, 0);
+}
+
 ######################
 # Manage output file #
 my $gffout = prepare_gffout($config, $opt_output);
@@ -59,12 +67,12 @@ my $gffout = prepare_gffout($config, $opt_output);
 my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $opt_gfffile,
                                                                  config => $config
                                                             });
-print ("GFF3 file parsed\n");
+dual_print($log, "GFF3 file parsed\n");
 
 ####################
 # index the genome #
 my $db = Bio::DB::Fasta->new($opt_fasta);
-print ("Fasta file parsed\n");
+dual_print($log, "Fasta file parsed\n");
 
 ###
 # Fix frame
@@ -76,7 +84,9 @@ print_omniscient( {omniscient => $hash_omniscient, output => $gffout} );
 
 my $end_run = time();
 my $run_time = $end_run - $start_run;
-print "Job done in $run_time seconds\n";
+dual_print($log, "Job done in $run_time seconds\n");
+
+close $log if $log;
 __END__
 
 =head1 NAME

--- a/bin/agat_sp_keep_longest_isoform.pl
+++ b/bin/agat_sp_keep_longest_isoform.pl
@@ -45,6 +45,14 @@ if ( ! (defined($gff)) ){
 # --- Manage config ---
 $config = get_agat_config({config_file_in => $config});
 
+my $log;
+if ($config->{log}) {
+  my ($file) = $0 =~ /([^\/]+)$/;
+  my $log_name = $file . ".agat.log";
+  open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+  dual_print($log, $header, 0);
+}
+
 # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>    PARAMS    <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
 my $gffout = prepare_gffout($config, $opt_output);
@@ -53,11 +61,11 @@ my $gffout = prepare_gffout($config, $opt_output);
 
 ######################
 ### Parse GFF input #
-print "Reading file $gff\n";
+dual_print($log, "Reading file $gff\n");
 my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $gff,
                                                                  config => $config
                                                               });
-print "Parsing Finished\n";
+dual_print($log, "Parsing Finished\n");
 ### END Parse GFF input #
 #########################
 
@@ -67,12 +75,14 @@ my ($nb_iso_removed_cds,  $nb_iso_removed_exon) = remove_shortest_isoforms($hash
 # print omniscientNew containing only the longest isoform per gene
 print_omniscient( {omniscient => $hash_omniscient, output => $gffout} );
 
-print $nb_iso_removed_cds." L2 isoforms with CDS removed (shortest CDS)\n";
-print $nb_iso_removed_exon." L2 isoforms wihtout CDS removed (Either no isoform has CDS, we removed those with shortest concatenated exons, or at least one isoform has CDS, we removed those wihtout)\n";
+dual_print($log, $nb_iso_removed_cds." L2 isoforms with CDS removed (shortest CDS)\n");
+dual_print($log, $nb_iso_removed_exon." L2 isoforms wihtout CDS removed (Either no isoform has CDS, we removed those with shortest concatenated exons, or at least one isoform has CDS, we removed those wihtout)\n");
 
 # END STATISTICS #
 ##################
-print "Done\n";
+dual_print($log, "Done\n");
+
+close $log if $log;
 
 
 

--- a/bin/agat_sp_separate_by_record_type.pl
+++ b/bin/agat_sp_separate_by_record_type.pl
@@ -44,16 +44,24 @@ if (! defined($opt_gfffile) ){
 # --- Manage config ---
 $config = get_agat_config({config_file_in => $config});
 
+my $log;
+if ($config->{log}) {
+  my ($file) = $0 =~ /([^\/]+)$/;
+  my $log_name = $file . ".agat.log";
+  open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+  dual_print($log, $header, 0);
+}
+
 ######################
 # Manage output file #
 
 if (! $opt_output) {
-  print "Default output name: split_result\n";
+  dual_print($log, "Default output name: split_result\n");
   $opt_output="split_result";
 }
 
 if (-d $opt_output){
-  print "The output directory choosen already exists. Please give me another Name.\n";exit();
+  dual_print($log, "The output directory choosen already exists. Please give me another Name.\n", 1);exit();
 }
 mkdir $opt_output;
 
@@ -66,7 +74,7 @@ mkdir $opt_output;
 my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $opt_gfffile,
                                                                  config => $config
                                                               });
-print ("GFF3 file parsed\n");
+dual_print($log, "GFF3 file parsed\n");
 
 
 my $topfeatures = get_feature_type_by_agat_value($hash_omniscient, 'level1', 'topfeature');
@@ -177,7 +185,9 @@ foreach my $key (keys %handlers){
 
 my $end_run = time();
 my $run_time = $end_run - $start_run;
-print "Job done in $run_time seconds\n";
+dual_print($log, "Job done in $run_time seconds\n");
+
+close $log if $log;
 __END__
 
 =head1 NAME

--- a/bin/agat_sq_add_hash_tag.pl
+++ b/bin/agat_sq_add_hash_tag.pl
@@ -51,6 +51,14 @@ if (( $interval > 2 or $interval < 1) ){
 # --- Manage config ---
 $config = get_agat_config({config_file_in => $config});
 
+my $log;
+if ($config->{log}) {
+  my ($file) = $0 =~ /([^\/]+)$/;
+  my $log_name = $file . ".agat.log";
+  open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+  dual_print($log, $header, 0);
+}
+
 # Manage input gff file
 my $format = $config->{force_gff_input_version};
 if(! $format ){ $format = select_gff_format($inputFile); }
@@ -65,7 +73,7 @@ my $startP=time;
 my $nbLine=`wc -l < $inputFile`;
 $nbLine =~ s/ //g;
 chomp $nbLine;
-print "$nbLine line to process...\n";
+dual_print($log, "$nbLine line to process...\n");
 
 my $line_cpt=0;
 my $count=0;
@@ -108,7 +116,7 @@ while (my $feature = $ref_in->next_feature() ) {
   if ((30 - (time - $startP)) < 0) {
     my $done = ($line_cpt*100)/$nbLine;
     $done = sprintf ('%.0f', $done);
-        print "\rProgression : $done % processed.\n";
+        dual_print($log, "\rProgression : $done % processed.\n");
     $startP= time;
   }
 }
@@ -118,12 +126,14 @@ while (my $feature = $ref_in->next_feature() ) {
 $count++;
 
 if($count > 0){
-  print "$count line added !\n";
+  dual_print($log, "$count line added !\n");
 }
-else{print "No line added !\n";}
+else{dual_print($log, "No line added !\n");}
 my $end_run = time();
 my $run_time = $end_run - $start_run;
-print "Job done in $run_time seconds\n";
+dual_print($log, "Job done in $run_time seconds\n");
+
+close $log if $log;
 
 
 sub _write_bucket{

--- a/bin/agat_sq_list_attributes.pl
+++ b/bin/agat_sq_list_attributes.pl
@@ -49,16 +49,24 @@ if ( ! (defined($gff)) ){
 # --- Manage config ---
 $config = get_agat_config({config_file_in => $config});
 
+my $log;
+if ($config->{log}) {
+  my ($file) = $0 =~ /([^\/]+)$/;
+  my $log_name = $file . ".agat.log";
+  open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+  dual_print($log, $header, 0);
+}
+
 # Manage $primaryTag
 my @ptagList;
 if(! $primaryTag or $primaryTag eq "all"){
-  print "We will work on attributes from all features\n";
+  dual_print($log, "We will work on attributes from all features\n");
   push(@ptagList, "all");
 }
 else{
    @ptagList= split(/,/, $primaryTag);
    foreach my $tag (@ptagList){
-      print "We will work on attributes from $tag feature.\n";
+      dual_print($log, "We will work on attributes from $tag feature.\n");
    }
 }
 
@@ -82,7 +90,7 @@ my $startP=time;
 my $nbLine=`wc -l < $gff`;
 $nbLine =~ s/ //g;
 chomp $nbLine;
-print "$nbLine line to process...\n";
+dual_print($log, "$nbLine line to process...\n");
 
 my $geneName=undef;
 my $line_cpt=0;
@@ -96,7 +104,7 @@ while (my $feature = $ref_in->next_feature() ) {
   if ((30 - (time - $startP)) < 0) {
     my $done = ($line_cpt*100)/$nbLine;
     $done = sprintf ('%.0f', $done);
-        print "\rProgression : $done % processed.\n";
+        dual_print($log, "\rProgression : $done % processed.\n");
     $startP= time;
   }
 }
@@ -127,7 +135,9 @@ foreach my $attribute ( sort keys %all_attributes){
 ##Last round
 my $end_run = time();
 my $run_time = $end_run - $start_run;
-print "\nJob done in $run_time seconds\n";
+dual_print($log, "\nJob done in $run_time seconds\n");
+
+close $log if $log;
 
 #######################################################################################################################
         ####################

--- a/bin/agat_sq_reverse_complement.pl
+++ b/bin/agat_sq_reverse_complement.pl
@@ -48,6 +48,14 @@ if ((!defined($opt_gfffile) or !defined($opt_fastafile) ) ){
 # --- Manage config ---
 $config = get_agat_config({config_file_in => $config});
 
+my $log;
+if ($config->{log}) {
+  my ($file) = $0 =~ /([^\/]+)$/;
+  my $log_name = $file . ".agat.log";
+  open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+  dual_print($log, $header, 0);
+}
+
 # Manage input gff file
 my $format = $config->{force_gff_input_version};
 if(! $format ){ $format = select_gff_format($opt_gfffile); }
@@ -72,7 +80,7 @@ while(my $seqObj = $seqio->next_seq) {
 #### read fasta again for DB
 my $nbFastaSeq=0;
 my $db = Bio::DB::Fasta->new($opt_fastafile);
-print ("Fasta file parsed\n");
+dual_print($log, "Fasta file parsed\n");
 
 # get all seq id from fasta and convert to hash
 my @ids      = $db->get_all_primary_ids;
@@ -134,13 +142,15 @@ my $nb_error = 0;
 $nb_error  =  keys %{$info{"error"}};
 
 
-print "Annotations on $nb_flip sequences have been reverse complemented.\n";
-print "Annotations on $nb_intact sequences have been kept intact (Sequences absent from the fasta file but present in the gff.\n";
-print "$nb_error sequences from the fasta file were absent from the gff.\n";
+dual_print($log, "Annotations on $nb_flip sequences have been reverse complemented.\n");
+dual_print($log, "Annotations on $nb_intact sequences have been kept intact (Sequences absent from the fasta file but present in the gff.\n");
+dual_print($log, "$nb_error sequences from the fasta file were absent from the gff.\n");
 
 my $end_run = time();
 my $run_time = $end_run - $start_run;
-print "Job done in $run_time seconds\n";
+dual_print($log, "Job done in $run_time seconds\n");
+
+close $log if $log;
 
 __END__
 

--- a/bin/agat_sq_stat_basic.pl
+++ b/bin/agat_sq_stat_basic.pl
@@ -48,6 +48,14 @@ if (! @inputFile ){
 # --- Manage config ---
 $config = get_agat_config({config_file_in => $config});
 
+my $log;
+if ($config->{log}) {
+  my ($file) = $0 =~ /([^\/]+)$/;
+  my $log_name = $file . ".agat.log";
+  open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+  dual_print($log, $header, 0);
+}
+
 # Manage Output
 my $ostream = prepare_fileout($outputFile);
 
@@ -74,7 +82,7 @@ my %check; #track the repeat already annotated to not. Allow to skip already rea
 
 foreach my $file (@inputFile){
 # Manage input gff file
-  print "Reading $file\n";
+  dual_print($log, "Reading $file\n");
 	my $format = $config->{force_gff_input_version};
 	if(! $format ){ $format = select_gff_format($file); }
   my $ref_in = AGAT::BioperlGFF->new(-file => $file, -gff_version => $format);
@@ -83,7 +91,7 @@ foreach my $file (@inputFile){
   my $nbLine=`wc -l < $file`;
   $nbLine =~ s/ //g;
   chomp $nbLine;
-  print "$nbLine line to process...\n";
+  dual_print($log, "$nbLine line to process...\n");
   my $line_cpt=0;
 
   local $| = 1; # Or use IO::Handle; STDOUT->autoflush; Use to print progression bar
@@ -111,11 +119,11 @@ foreach my $file (@inputFile){
     if ((30 - (time - $startP)) < 0) {
       my $done = ($line_cpt*100)/$nbLine;
       $done = sprintf ('%.0f', $done);
-          print "\rProgress : $done %";
+          dual_print($log, "\rProgress : $done %");
       $startP= time;
     }
   }
-  print "\rProgress : 100 %\n";
+  dual_print($log, "\rProgress : 100 %\n");
 }
 
 my $totalNumber=0;
@@ -160,7 +168,9 @@ else{
 
 my $end_run = time();
 my $run_time = $end_run - $start_run;
-print "Job done in $run_time seconds\n";
+dual_print($log, "Job done in $run_time seconds\n");
+
+close $log if $log;
 
 __END__
 

--- a/lib/AGAT/AGAT.pm
+++ b/lib/AGAT/AGAT.pm
@@ -147,24 +147,32 @@ MESSAGE
 # load configuration file from local file if any either the one shipped with AGAT
 # return a hash containing the configuration.
 sub get_agat_config{
-	my ($args)=@_;
+        my ($args)=@_;
 
-	# Print the header. Put here because get_agat_config it the first function call for _sp_ and _sq_ screen
-	print AGAT::AGAT::get_agat_header();
+        my ($config_file_provided);
+        if( defined($args->{config_file_in}) ) { $config_file_provided = $args->{config_file_in};}
 
-	my ($config_file_provided);
-	if( defined($args->{config_file_in}) ) { $config_file_provided = $args->{config_file_in};}
+        # First retrieve the config file path without printing anything yet
+        my $config_file_checked = get_config({type => "local",
+                                              config_file_in => $config_file_provided,
+                                              verbose => 0});
+        # Load and check the configuration
+        my $config = load_config({ config_file => $config_file_checked});
+        check_config({ config => $config});
 
-	# Get the config file
-	my $config_file_checked = get_config({type => "local", config_file_in => $config_file_provided}); #try local first, if none will take the original
-	# Load the config
-	my $config = load_config({ config_file => $config_file_checked});
-	check_config({ config => $config});
+        # Print header and config information only if verbosity allows it
+        if ($config->{verbose} > 0){
+                print AGAT::AGAT::get_agat_header();
+                # Re-run get_config to display the message about which file is used
+                get_config({type => "local",
+                            config_file_in => $config_file_provided,
+                            verbose => $config->{verbose}});
+        }
 
-	# Store the config in a Global variable accessible from everywhere.
-	$CONFIG = $config;
-	
-	return $config;
+        # Store the config in a Global variable accessible from everywhere.
+        $CONFIG = $config;
+
+        return $config;
 }
 
 # ==============================================================================

--- a/lib/AGAT/Utilities.pm
+++ b/lib/AGAT/Utilities.pm
@@ -65,16 +65,16 @@ sub exists_undef_value {
 }
 
 # @Purpose: check if the table codon is available in bioperl
-# @input: 1 =>  integer
+# @input: 1 =>  integer, 2 => verbose
 # @output 1 => integer
 sub get_proper_codon_table {
-  my ($codon_table_id_original) = @_;
+  my ($codon_table_id_original, $log) = @_;
   my $codonTable = Bio::Tools::CodonTable->new( -id => $codon_table_id_original);
   my $codon_table_id_bioperl = $codonTable->id;
-  
+
   # To deal with empty result in version of bioperl < april 2024 when asking with table 0 (it was reutrning an empty string)
   if (! defined($codon_table_id_bioperl)){
-	$codon_table_id_bioperl = 1 ; # default codon table
+        $codon_table_id_bioperl = 1 ; # default codon table
   }
 
   if ($codon_table_id_original == 0 and  $codon_table_id_original != $codon_table_id_bioperl){
@@ -82,8 +82,9 @@ sub get_proper_codon_table {
     "see https://github.com/bioperl/bioperl-live/pull/315\n".
     "It uses codon table $codon_table_id_bioperl instead.");
   }
-  
-  print "Codon table ".$codon_table_id_bioperl." in use. You can change it using the appropriate parameter.\n";
+
+  dual_print($log,
+             "Codon table ".$codon_table_id_bioperl." in use. You can change it using the appropriate parameter.\n");
   return $codon_table_id_bioperl;
 }
 
@@ -295,16 +296,23 @@ sub print_time{
 # @input: 3 => fh, string, integer
 # @output 0 => None
 sub dual_print{
-	my ($fh, $string, $verbose) = @_;
-	if(! defined($verbose)){$verbose = 1;}#if verbose no set we set it to activate
+        my ($fh, $string, $verbose) = @_;
+        if(! defined($verbose)){
+                if(defined $AGAT::AGAT::CONFIG->{verbose}){
+                        $verbose = $AGAT::AGAT::CONFIG->{verbose};
+                }
+                else{
+                        $verbose = 1; # default verbosity
+                }
+        }
 
-	if($verbose > 0 ){ #only 0 is quite mode
-		print $string;
-	}
-	# print in log in any provided
-	if($fh){
-		print $fh $string;
-	}
+        if($verbose > 0 ){ #only 0 is quiet mode
+                print $string;
+        }
+        # print in log in any provided
+        if($fh){
+                print $fh $string;
+        }
 }
 
 # @Purpose: transform a String with separator into hash

--- a/t/agat_sp_extract_sequences_quiet.t
+++ b/t/agat_sp_extract_sequences_quiet.t
@@ -1,0 +1,19 @@
+use strict;
+use warnings;
+use Test::More tests => 1;
+use File::Temp qw(tempdir);
+use File::Copy qw(copy);
+use Cwd qw(abs_path);
+
+my $tmpdir = tempdir(CLEANUP => 1);
+my $repo   = abs_path('.');
+
+copy("$repo/share/agat_config.yaml", "$tmpdir/agat_config.yaml");
+system("perl -i -pe 's/^verbose: 1/verbose: 0/' $tmpdir/agat_config.yaml");
+system("perl -i -pe 's/^progress_bar: true/progress_bar: false/' $tmpdir/agat_config.yaml");
+system("perl -i -pe 's/^log: true/log: false/' $tmpdir/agat_config.yaml");
+
+my $cmd = "$repo/bin/agat_sp_extract_sequences.pl --gff $repo/t/scripts_output/in/1.gff --fasta $repo/t/scripts_output/in/1.fa --config $tmpdir/agat_config.yaml -o $tmpdir/out.fa";
+my $output = `$cmd 2>&1`;
+
+is($output, '', 'agat_sp_extract_sequences.pl is quiet with verbose=0');

--- a/t/get_agat_config.t
+++ b/t/get_agat_config.t
@@ -1,0 +1,27 @@
+use strict;
+use warnings;
+use Test::More tests => 1;
+use AGAT::AGAT;
+use AGAT::Config;
+
+# Ensure no local config file exists
+my $config_file = 'agat_config.yaml';
+unlink $config_file;
+
+# Copy the default config locally
+expose_config_file();
+
+# Set verbose to 0
+system(q{perl -i -pe 's/^verbose: 1/verbose: 0/' agat_config.yaml});
+
+# Capture output from get_agat_config
+my $output = '';
+{
+    open my $fh, '>', \$output;
+    local *STDOUT = $fh;
+    get_agat_config();
+}
+
+is($output, '', 'get_agat_config is quiet when verbose=0');
+
+unlink $config_file;


### PR DESCRIPTION
## Summary
- route status and error messages in command-line scripts through `dual_print` so logging and verbosity are consistent
- open log handles when enabled to capture progress messages
- silence scripts by default at `verbose: 0`

## Testing
- `perlcritic --gentle bin/agat_sp_filter_feature_from_kill_list.pl bin/agat_sp_filter_feature_by_attribute_presence.pl bin/agat_sp_filter_feature_by_attribute_value.pl bin/agat_sp_filter_by_mrnaBlastValue.pl bin/agat_sp_fix_cds_phases.pl bin/agat_sq_add_attributes_from_tsv.pl bin/agat_sp_clipN_seqExtremities_and_fixCoordinates.pl bin/agat_sp_keep_longest_isoform.pl bin/agat_sp_flag_short_introns_ebi.pl bin/agat_sq_list_attributes.pl bin/agat_sq_stat_basic.pl bin/agat_sq_reverse_complement.pl bin/agat_sp_filter_gene_by_intron_numbers.pl bin/agat_sp_Prokka_inferNameFromAttributes.pl bin/agat_sq_rfam_analyzer.pl bin/agat_sq_add_hash_tag.pl bin/agat_sp_separate_by_record_type.pl bin/agat_convert_embl2gff.pl bin/agat_sp_extract_sequences.pl`
- `prove -lr t` *(fails: Can't locate Clone.pm in @INC)*

------
https://chatgpt.com/codex/tasks/task_e_68a2f98a35a8832a9e4a3c5b89f2b1da