### PR TITLE
feat: centralize common option parsing

### DIFF
--- a/bin/agat_convert_minimap2_bam2gff.pl
+++ b/bin/agat_convert_minimap2_bam2gff.pl
@@ -13,15 +13,17 @@ my $config;
 my $opt_in;
 my $opt_bam;
 my $opt_sam;
-my $opt_output=undef;
-my $opt_help = 0;
+my $opt_output = undef;
+my $opt_help   = 0;
+
+my $common = parse_common_options() || {};
+$config     = $common->{config};
+$opt_output = $common->{output};
+$opt_help   = $common->{help};
 
 if ( !GetOptions( 'i|input=s' => \$opt_in,
-                  'b|bam!' => \$opt_bam,
-                  's|sam!' => \$opt_sam,
-                  'o|out|output=s' => \$opt_output,
-                  'c|config=s'               => \$config,
-                  'h|help!'         => \$opt_help ) )
+                  'b|bam!'    => \$opt_bam,
+                  's|sam!'    => \$opt_sam ) )
 {
     pod2usage( { -message => 'Failed to parse command line',
                  -verbose => 1,

--- a/bin/agat_convert_sp_gff2gtf.pl
+++ b/bin/agat_convert_sp_gff2gtf.pl
@@ -12,17 +12,19 @@ my $opt_output;
 my $gff;
 my $relax;
 my $gtf_version;
-my $verbose;
-my $help;
+my $verbose = 0;
+my $help    = 0;
+
+my $common = parse_common_options() || {};
+$config     = $common->{config};
+$opt_output = $common->{output};
+$verbose    = $common->{verbose} // 0;
+$help       = $common->{help};
 
 
 if( !GetOptions(
-    'c|config=s'               => \$config,
-    "h|help"                   => \$help,
-    "gff|gtf|i=s"              => \$gff,
-	"gtf_version=s"            => \$gtf_version,
-	"verbose|v!"               => \$verbose,
-    "outfile|output|o|out=s"   => \$opt_output))
+    "gff|gtf|i=s"      => \$gff,
+    "gtf_version=s"    => \$gtf_version ))
 {
     pod2usage( { -message => "Failed to parse command line.",
                  -verbose => 1,

--- a/bin/agat_convert_sp_gff2zff.pl
+++ b/bin/agat_convert_sp_gff2zff.pl
@@ -12,17 +12,19 @@ use AGAT::AGAT;
 my $header = get_agat_header();
 my $config;
 my $outfile = undef;
-my $gff = undef;
+my $gff     = undef;
 my $model_id = -1;
-my $fasta = undef;
-my $help;
+my $fasta   = undef;
+my $help    = 0;
+
+my $common = parse_common_options() || {};
+$config  = $common->{config};
+$outfile = $common->{output};
+$help    = $common->{help};
 
 if( !GetOptions(
-    'c|config=s'               => \$config,
-    "h|help" => \$help,
-    "gff=s" => \$gff,
-		"fasta=s" => \$fasta,
-    "outfile|output|out|o=s" => \$outfile))
+    "gff=s"   => \$gff,
+    "fasta=s" => \$fasta))
 {
     pod2usage( { -message => "Failed to parse command line.",
                  -verbose => 1,

--- a/bin/agat_sp_add_splice_sites.pl
+++ b/bin/agat_sp_add_splice_sites.pl
@@ -12,16 +12,19 @@ use AGAT::AGAT;
 
 my $header = get_agat_header();
 my $config;
-my $spliceID = 1;
+my $spliceID  = 1;
 my $opt_file;
-my $opt_output=undef;
-my $opt_help = 0;
+my $opt_output = undef;
+my $opt_help   = 0;
+my @copyARGV;
 
-my @copyARGV=@ARGV;
-if ( !GetOptions( 'f|gff|ref|reffile=s' => \$opt_file,
-                  'o|out|output=s'      => \$opt_output,
-                  'c|config=s'          => \$config,
-                  'h|help!'             => \$opt_help ) )
+my $common = parse_common_options() || {};
+$config     = $common->{config};
+$opt_output = $common->{output};
+$opt_help   = $common->{help};
+@copyARGV   = @{$common->{argv}};
+
+if ( !GetOptions( 'f|gff|ref|reffile=s' => \$opt_file ) )
 {
     pod2usage( { -message => 'Failed to parse command line',
                  -verbose => 1,

--- a/bin/agat_sp_compare_two_annotations.pl
+++ b/bin/agat_sp_compare_two_annotations.pl
@@ -24,7 +24,7 @@ $config     = $common->{config};
 $opt_output = $common->{output};
 $verbose    = $common->{verbose};
 
-my @copyARGV = @ARGV;
+my @copyARGV = @{$common->{argv} // \@ARGV};
 if (
     !GetOptions(
         "h|help"   => \$opt_help,

--- a/bin/agat_sp_compare_two_annotations.pl
+++ b/bin/agat_sp_compare_two_annotations.pl
@@ -11,32 +11,26 @@ use Sort::Naturally;
 use AGAT::AGAT;
 
 my $header = get_agat_header();
-my $config;
-my $opt_output = undef;
-my $gff1 = undef;
-my $gff2 = undef;
-my $verbose = undef;
-my $debug = undef;
-my $opt_help= 0;
+my ( $config, $opt_output, $gff1, $gff2, $verbose, $debug, $opt_help );
 
 my $common = parse_common_options() || {};
 $config     = $common->{config};
 $opt_output = $common->{output};
 $verbose    = $common->{verbose};
+$debug      = $common->{debug};
+$opt_help   = $common->{help};
 
-my @copyARGV = @{$common->{argv} // \@ARGV};
+my @copyARGV = @{ $common->{argv} // [@ARGV] };
 if (
     !GetOptions(
-        "h|help"   => \$opt_help,
-        "gff1=s"   => \$gff1,
-        "gff2=s"   => \$gff2,
-        "debug|d!" => \$debug,
+        "gff1=s" => \$gff1,
+        "gff2=s" => \$gff2,
     )
   )
 {
-    pod2usage({-message => 'Failed to parse command line',
+    pod2usage({ -message => 'Failed to parse command line',
                 -verbose => 1,
-                -exitval => 1});
+                -exitval => 1 });
 }
 
 # Print Help and exit

--- a/bin/agat_sp_compare_two_annotations.pl
+++ b/bin/agat_sp_compare_two_annotations.pl
@@ -19,20 +19,24 @@ my $verbose = undef;
 my $debug = undef;
 my $opt_help= 0;
 
-my @copyARGV=@ARGV;
-if ( !GetOptions(
-    'c|config=s'               => \$config,
-    "h|help"         => \$opt_help,
-    "gff1=s"         => \$gff1,
-    "gff2=s"         => \$gff2,
-	"debug|d!"       => \$debug,
-    "verbose|v!"     => \$verbose,
-    "output|out|o=s" => \$opt_output))
+my $common = parse_common_options() || {};
+$config     = $common->{config};
+$opt_output = $common->{output};
+$verbose    = $common->{verbose};
 
+my @copyARGV = @ARGV;
+if (
+    !GetOptions(
+        "h|help"   => \$opt_help,
+        "gff1=s"   => \$gff1,
+        "gff2=s"   => \$gff2,
+        "debug|d!" => \$debug,
+    )
+  )
 {
-    pod2usage( { -message => 'Failed to parse command line',
-                 -verbose => 1,
-                 -exitval => 1 } );
+    pod2usage({-message => 'Failed to parse command line',
+                -verbose => 1,
+                -exitval => 1});
 }
 
 # Print Help and exit

--- a/bin/agat_sp_fix_fusion.pl
+++ b/bin/agat_sp_fix_fusion.pl
@@ -21,27 +21,23 @@ my $PREFIX_CPT_EXON=1;
 my $PREFIX_CPT_MRNA=1;
 
 my $header = get_agat_header();
-my $config;
-my $outfile = undef;
-my $gff = undef;
-my $file_fasta=undef;
-my $opt_codonTableID=1;
-my $stranded=undef;
-my $threshold=undef;
-my $verbose=undef;
-my $opt_help= 0;
+my ($config, $outfile, $gff, $file_fasta, $opt_codonTableID, $stranded,
+    $threshold, $verbose, $opt_help);
 
-my @copyARGV=@ARGV;
+my $common = parse_common_options() || {};
+$config   = $common->{config};
+$outfile  = $common->{output};
+$verbose  = $common->{verbose};
+$opt_help = $common->{help};
+my @copyARGV = @{ $common->{argv} // [@ARGV] };
+
 if ( !GetOptions(
-    'c|config=s'               => \$config,
-    "h|help"           => \$opt_help,
     "gff=s"            => \$gff,
     "fasta|fa=s"       => \$file_fasta,
     "stranded|s"       => \$stranded,
     "table|codon|ct=i" => \$opt_codonTableID,
-    "verbose|v"        => \$verbose,
     "threshold|t=i"    => \$threshold,
-    "output|outfile|out|o=s" => \$outfile))
+    ))
 
 {
     pod2usage( { -message => 'Failed to parse command line',

--- a/bin/agat_sp_fix_longest_ORF.pl
+++ b/bin/agat_sp_fix_longest_ORF.pl
@@ -25,27 +25,23 @@ use AGAT::AGAT;
 my $SIZE_OPT=21;
 
 my $header = get_agat_header();
-my $config;
-my $outfile = undef;
-my $gff = undef;
-my $model_to_test = undef;
-my $file_fasta=undef;
-my $split_opt=undef;
-my $codonTable=1;
-my $verbose = 0;
-my $opt_help= 0;
+my ($config, $outfile, $gff, $model_to_test, $file_fasta, $split_opt,
+    $codonTable, $verbose, $opt_help);
 
-my @copyARGV=@ARGV;
+my $common = parse_common_options() || {};
+$config   = $common->{config};
+$outfile  = $common->{output};
+$verbose  = $common->{verbose};
+$opt_help = $common->{help};
+my @copyARGV = @{ $common->{argv} // [@ARGV] };
+
 if ( !GetOptions(
-    'c|config=s'               => \$config,
-    "h|help" => \$opt_help,
     "gff=s" => \$gff,
     "fasta|fa|f=s" => \$file_fasta,
     "split|s" => \$split_opt,
     "table|codon|ct=i" => \$codonTable,
     "m|model=s" => \$model_to_test,
-    "v=i" => \$verbose,
-    "output|outfile|out|o=s" => \$outfile))
+    ))
 
 {
     pod2usage( { -message => 'Failed to parse command line',

--- a/bin/agat_sp_fix_overlaping_genes.pl
+++ b/bin/agat_sp_fix_overlaping_genes.pl
@@ -12,18 +12,20 @@ use AGAT::AGAT;
 my $header = get_agat_header();
 my $config;
 my $outfile = undef;
-my $ref = undef;
+my $ref     = undef;
 my $opt_merge;
-my $verbose;
+my $verbose = 0;
 my $opt_help = 0;
 
+my $common = parse_common_options() || {};
+$config   = $common->{config};
+$outfile  = $common->{output};
+$verbose  = $common->{verbose} // 0;
+$opt_help = $common->{help};
+
 if ( !GetOptions(
-		'c|config=s'               => \$config,
-		"h|help"                 => \$opt_help,
-		"f|file|gff3|gff=s"      => \$ref,
-		"merge|m!"               => \$opt_merge,
-		"output|outfile|out|o=s" => \$outfile,
-		"verbose|v!"             => \$verbose))
+                "f|file|gff3|gff=s"      => \$ref,
+                "merge|m!"               => \$opt_merge))
 
 {
     pod2usage( { -message => 'Failed to parse command line',

--- a/bin/agat_sp_keep_longest_isoform.pl
+++ b/bin/agat_sp_keep_longest_isoform.pl
@@ -9,17 +9,14 @@ use List::MoreUtils qw(uniq);
 use AGAT::AGAT;
 
 my $header = get_agat_header();
-my $config;
-my $gff = undef;
-my $opt_output = undef;
-my $opt_genomeSize = undef;
-my $opt_plot = undef;
-my $opt_help= 0;
+my ($config, $gff, $opt_output, $opt_genomeSize, $opt_plot, $opt_help);
+
+my $common = parse_common_options() || {};
+$config     = $common->{config};
+$opt_output = $common->{output};
+$opt_help   = $common->{help};
 
 if ( !GetOptions(
-    'c|config=s'               => \$config,
-    "h|help"          => \$opt_help,
-    'o|output=s'      => \$opt_output,
     "gff|f=s"         => \$gff))
 
 {

--- a/bin/agat_sp_manage_IDs.pl
+++ b/bin/agat_sp_manage_IDs.pl
@@ -8,23 +8,17 @@ use Pod::Usage;
 use AGAT::AGAT;
 
 my $header = get_agat_header();
-my $config;
-my $opt_gff = undef;
-my $opt_help= 0;
-my $opt_gap=0;
-my $opt_tair=undef;
-my @opt_tag=();
-my $outfile=undef;
-my $opt_ensembl=undef;
-my $opt_prefix=undef;
-my $opt_collective=undef;
-my $opt_nbIDstart=1;
-my $opt_type_dependent = undef;
-my $verbose;
+my ($config, $opt_gff, $opt_help, $opt_gap, $opt_tair, @opt_tag, $outfile,
+    $opt_ensembl, $opt_prefix, $opt_collective, $opt_nbIDstart,
+    $opt_type_dependent, $verbose);
+
+my $common = parse_common_options() || {};
+$config   = $common->{config};
+$outfile  = $common->{output};
+$verbose  = $common->{verbose};
+$opt_help = $common->{help};
 
 if ( !GetOptions(
-    'c|config=s'     => \$config,
-    "h|help!"        => \$opt_help,
     "gff|f=s"        => \$opt_gff,
     "nb=i"           => \$opt_nbIDstart,
     "gap=i"          => \$opt_gap,
@@ -33,9 +27,8 @@ if ( !GetOptions(
     "prefix=s"       => \$opt_prefix,
     "p|t|l=s"        => \@opt_tag,
     "type_dependent!" => \$opt_type_dependent,
-		"collective!"    => \$opt_collective,
-    "verbose|v!"     => \$verbose,
-    "output|outfile|out|o=s" => \$outfile))
+    "collective!"    => \$opt_collective,
+    ))
 
 {
     pod2usage( { -message => 'Failed to parse command line',

--- a/bin/agat_sp_manage_IDs.pl
+++ b/bin/agat_sp_manage_IDs.pl
@@ -12,6 +12,8 @@ my ($config, $opt_gff, $opt_help, $opt_gap, $opt_tair, @opt_tag, $outfile,
     $opt_ensembl, $opt_prefix, $opt_collective, $opt_nbIDstart,
     $opt_type_dependent, $verbose);
 
+$opt_nbIDstart = 1;
+
 my $common = parse_common_options() || {};
 $config   = $common->{config};
 $outfile  = $common->{output};

--- a/bin/agat_sp_manage_introns.pl
+++ b/bin/agat_sp_manage_introns.pl
@@ -11,6 +11,8 @@ use AGAT::AGAT;
 my $header = get_agat_header();
 my ($config, @opt_files, $opt_output, $opt_plot, $opt_breaks, $Xpercent, $opt_help);
 
+$Xpercent = 1;
+
 my $common = parse_common_options() || {};
 $config     = $common->{config};
 $opt_output = $common->{output};

--- a/bin/agat_sp_manage_introns.pl
+++ b/bin/agat_sp_manage_introns.pl
@@ -9,23 +9,18 @@ use Pod::Usage;
 use AGAT::AGAT;
 
 my $header = get_agat_header();
-my $config;
+my ($config, @opt_files, $opt_output, $opt_plot, $opt_breaks, $Xpercent, $opt_help);
 
-my @opt_files;
-my $opt_output=undef;
-my $opt_plot;
-my $opt_breaks;
-my $Xpercent=1;
-my $opt_help = 0;
+my $common = parse_common_options() || {};
+$config     = $common->{config};
+$opt_output = $common->{output};
+$opt_help   = $common->{help};
+my @copyARGV = @{ $common->{argv} // [@ARGV] };
 
-my @copyARGV=@ARGV;
 if ( !GetOptions( 'f|gff|ref|reffile=s' => \@opt_files,
-                  'o|out|output=s'      => \$opt_output,
                   'w|window|b|break|breaks=i'  => \$opt_breaks,
                   'x|p=f'               => \$Xpercent,
-                  'plot!'               => \$opt_plot,
-                  'c|config=s'               => \$config,
-                  'h|help!'             => \$opt_help ) )
+                  'plot!'               => \$opt_plot ) )
 {
     pod2usage( { -message => 'Failed to parse command line',
                  -verbose => 1,

--- a/bin/agat_sp_move_attributes_within_records.pl
+++ b/bin/agat_sp_move_attributes_within_records.pl
@@ -11,24 +11,27 @@ use AGAT::AGAT;
 
 my $header = get_agat_header();
 my $config;
-my $primaryTagCopy="level2";
-my $primaryTagPaste="level3";
-my $opt_output= undef;
-my $attributes="all_attributes";
-my $opt_gff = undef;
-my $opt_verbose = undef;
-my $opt_help;
+my $primaryTagCopy  = "level2";
+my $primaryTagPaste = "level3";
+my $opt_output      = undef;
+my $attributes      = "all_attributes";
+my $opt_gff         = undef;
+my $opt_verbose     = undef;
+my $opt_help        = 0;
+my @copyARGV;
+
+my $common = parse_common_options() || {};
+$config     = $common->{config};
+$opt_output = $common->{output};
+$opt_verbose = $common->{verbose} // 0;
+$opt_help   = $common->{help};
+@copyARGV   = @{$common->{argv}};
 
 # OPTION MANAGMENT
-my @copyARGV=@ARGV;
 if ( !GetOptions( 'f|ref|reffile|gff=s'  => \$opt_gff,
                   "feature_copy|fc=s"    => \$primaryTagCopy,
                   "feature_paste|fp=s"   => \$primaryTagPaste,
-                  'o|output=s'           => \$opt_output,
-                  "a|tag|att|attribute=s"  => \$attributes,
-                  'v|verbose!'           => \$opt_verbose,
-                  'c|config=s'           => \$config,
-                  'h|help!'              => \$opt_help ) )
+                  "a|tag|att|attribute=s"  => \$attributes ) )
 {
     pod2usage( { -message => 'Failed to parse command line',
                  -verbose => 1,

--- a/bin/agat_sp_sensitivity_specificity.pl
+++ b/bin/agat_sp_sensitivity_specificity.pl
@@ -10,21 +10,18 @@ use Sort::Naturally;
 use AGAT::AGAT;
 
 my $header = get_agat_header();
-my $config;
-my $outfile = undef;
-my $gff1 = undef;
-my $gff2 = undef;
-my $verbose = undef;
-my $opt_help= 0;
+my ($config, $outfile, $gff1, $gff2, $verbose, $opt_help);
 
-my @copyARGV=@ARGV;
+my $common = parse_common_options() || {};
+$config   = $common->{config};
+$outfile  = $common->{output};
+$verbose  = $common->{verbose};
+$opt_help = $common->{help};
+my @copyARGV = @{ $common->{argv} // [@ARGV] };
+
 if ( !GetOptions(
-    'c|config=s'               => \$config,
-    "h|help"      => \$opt_help,
     "gff1=s"      => \$gff1,
-    "gff2=s"      => \$gff2,
-    "v!"          => \$verbose,
-    "output|outfile|out|o=s" => \$outfile))
+    "gff2=s"      => \$gff2,))
 
 {
     pod2usage( { -message => 'Failed to parse command line',

--- a/bin/agat_sq_add_attributes_from_tsv.pl
+++ b/bin/agat_sq_add_attributes_from_tsv.pl
@@ -20,14 +20,16 @@ my $verbose;
 my $csv;
 my $opt_help = 0;
 
-Getopt::Long::Configure ('bundling');
+my $common = parse_common_options() || {};
+$config     = $common->{config};
+$outputFile = $common->{output};
+$verbose    = $common->{verbose};
+$opt_help   = $common->{help};
+
 if ( !GetOptions (  'gff=s' => \$input_gff,
-                    'o|output=s' => \$outputFile,
-			        'tsv=s' => \$input_tsv,
+                                'tsv=s' => \$input_tsv,
                     'csv!' => \$csv,
-			        'v|verbose!' => \$verbose,
-                    'c|config=s'               => \$config,
-                    'h|help!'         => \$opt_help )  )
+                    )  )
 {
     pod2usage( { -message => 'Failed to parse command line',
                  -verbose => 1,

--- a/bin/agat_sq_add_hash_tag.pl
+++ b/bin/agat_sq_add_hash_tag.pl
@@ -16,14 +16,16 @@ my $outfile=undef;
 my $opt_help = 0;
 my $interval=1;
 
-Getopt::Long::Configure ('bundling');
+my $common = parse_common_options() || {};
+$config   = $common->{config};
+$outfile  = $common->{output};
+$opt_help = $common->{help};
+
 if ( !GetOptions (
       'file|input|gff=s' => \$inputFile,
       'i|interval=i'     => \$interval,
-      'o|output=s'       => \$outfile,
-      'c|config=s'       => \$config,
-      'h|help!'          => \$opt_help )  )
-{
+      )  )
+{ 
     pod2usage( { -message => 'Failed to parse command line',
                  -verbose => 1,
                  -exitval => 1 } );

--- a/bin/agat_sq_add_locus_tag.pl
+++ b/bin/agat_sq_add_locus_tag.pl
@@ -20,16 +20,18 @@ my $quiet = undef;
 my $locus_cpt=1;
 my $tag_in=undef;
 
-Getopt::Long::Configure ('bundling');
+my $common = parse_common_options() || {};
+$config    = $common->{config};
+$outfile   = $common->{output};
+$opt_help  = $common->{help};
+
 if ( !GetOptions ('file|input|gff=s'  => \$inputFile,
                   'to|lo=s'           => \$locus_tag,
                   'ti|li=s'           => \$tag_in,
                   "p|type|l=s"        => \$primaryTag,
-                  'o|output=s'        => \$outfile,
                   'q|quiet!'          => \$quiet,
-                  'c|config=s'               => \$config,
-                  'h|help!'           => \$opt_help )  )
-{
+                  )  )
+{ 
     pod2usage( { -message => 'Failed to parse command line',
                  -verbose => 1,
                  -exitval => 1 } );

--- a/bin/agat_sq_count_attributes.pl
+++ b/bin/agat_sq_count_attributes.pl
@@ -18,12 +18,15 @@ my $start_run = time();
 my $outfile=undef;
 my $cpt_case=0;
 
+my $common = parse_common_options() || {};
+$config   = $common->{config};
+$outfile  = $common->{output};
+$opt_help = $common->{help};
+
 if ( !GetOptions(
-    'c|config=s'  => \$config,
-    "h|help"      => \$opt_help,
     "gff|f=s"     => \$gff,
     "tag|att=s"   => \$attribute,
-    "output|outfile|out|o=s" => \$outfile))
+    ))
 
 {
     pod2usage( { -message => 'Failed to parse command line',

--- a/bin/agat_sq_filter_feature_from_fasta.pl
+++ b/bin/agat_sq_filter_feature_from_fasta.pl
@@ -19,13 +19,15 @@ my $outfile=undef;
 my $opt_help = 0;
 
 
-Getopt::Long::Configure ('bundling');
+my $common = parse_common_options() || {};
+$config   = $common->{config};
+$outfile  = $common->{output};
+$verbose  = $common->{verbose};
+$opt_help = $common->{help};
+
 if ( !GetOptions ('file|input|gff=s' => \$opt_gfffile,
       'f|fasta=s' => \$opt_fastafile,
-      'o|output=s' => \$outfile,
-      'v|verbose!' => \$verbose,
-      'c|config=s'               => \$config,
-      'h|help!'         => \$opt_help )  )
+      )  )
 {
     pod2usage( { -message => "$header\nFailed to parse command line",
                  -verbose => 1,

--- a/bin/agat_sq_list_attributes.pl
+++ b/bin/agat_sq_list_attributes.pl
@@ -19,14 +19,17 @@ my $opt_help= 0;
 my $primaryTag=undef;
 my $outfile=undef;
 
+my $common = parse_common_options() || {};
+$config   = $common->{config};
+$outfile  = $common->{output};
+$opt_help = $common->{help};
+
 if ( !GetOptions(
-    'c|config=s'             => \$config,
-    "h|help"                 => \$opt_help,
     "gff|f=s"                => \$gff,
     "p|t|l=s"                => \$primaryTag,
-    "output|outfile|out|o=s" => \$outfile))
+    ))
 
-{
+{ 
     pod2usage( { -message => 'Failed to parse command line',
                  -verbose => 1,
                  -exitval => 1 } );

--- a/bin/agat_sq_manage_IDs.pl
+++ b/bin/agat_sq_manage_IDs.pl
@@ -16,13 +16,15 @@ my $outfile=undef;
 my $outformat=undef;
 my $opt_help = 0;
 
-Getopt::Long::Configure ('bundling');
+my $common = parse_common_options() || {};
+$config   = $common->{config};
+$outfile  = $common->{output};
+$opt_help = $common->{help};
+
 if ( !GetOptions ('file|input|gff|i=s' => \$inputFile,
       'of=i' => \$outformat,
-      'o|output=s' => \$outfile,
-      'c|config=s'               => \$config,
-      'h|help!'         => \$opt_help )  )
-{
+      )  )
+{ 
     pod2usage( { -message => 'Failed to parse command line',
                  -verbose => 1,
                  -exitval => 1 } );

--- a/bin/agat_sq_manage_attributes.pl
+++ b/bin/agat_sq_manage_attributes.pl
@@ -24,20 +24,23 @@ my $cp = undef;
 my $overwrite = undef;
 my $cpt_case=0;
 
+my $common = parse_common_options() || {};
+$config   = $common->{config};
+$outfile  = $common->{output};
+$opt_help = $common->{help};
+
 if ( !GetOptions(
-    'c|config=s'  => \$config,
-    "h|help"      => \$opt_help,
     "gff|f=s"     => \$gff,
     "add"         => \$add,
-		"overwrite"   => \$overwrite,
+                "overwrite"   => \$overwrite,
     "cp"          => \$cp,
     "value=s"     => \$value,
     "strategy=s"  => \$strategy,
     "p|type|l=s"  => \$primaryTag,
     "tag|att=s"   => \$attributes,
-    "output|outfile|out|o=s" => \$outfile))
+    ))
 
-{
+{ 
     pod2usage( { -message => 'Failed to parse command line',
                  -verbose => 1,
                  -exitval => 1 } );

--- a/bin/agat_sq_mask.pl
+++ b/bin/agat_sq_mask.pl
@@ -23,14 +23,17 @@ my $hardMaskChar;
 my $width = 60; # line length printed
 
 # OPTION MANAGMENT
+my $common = parse_common_options() || {};
+$config     = $common->{config};
+$opt_output = $common->{output};
+$opt_help   = $common->{help};
+
 if ( !GetOptions( 'g|gff=s'         => \$opt_gfffile,
                   'f|fa|fasta=s'    => \$opt_fastafile,
                   'hm:s'            => \$opt_HardMask,
                   'sm'              => \$opt_SoftMask,
-                  'o|output=s'      => \$opt_output,
-                  'c|config=s'               => \$config,
-                  'h|help!'         => \$opt_help ) )
-{
+                  ) )
+{ 
     pod2usage( { -message => 'Failed to parse command line',
                  -verbose => 1,
                  -exitval => 1 } );

--- a/bin/agat_sq_remove_redundant_entries.pl
+++ b/bin/agat_sq_remove_redundant_entries.pl
@@ -16,13 +16,15 @@ my $verbose;
 my $outfile;
 my $opt_help = 0;
 
-Getopt::Long::Configure ('bundling');
+my $common = parse_common_options() || {};
+$config   = $common->{config};
+$outfile  = $common->{output};
+$verbose  = $common->{verbose};
+$opt_help = $common->{help};
+
 if ( !GetOptions ('i|file|input|gff=s' => \$inputFile,
-                    'v|verbose!' => \$verbose,
-                    'o|output=s' => \$outfile,
-                    'c|config=s'               => \$config,
-                    'h|help!'         => \$opt_help )  )
-{
+                    )  )
+{ 
     pod2usage( { -message => 'Failed to parse command line',
                  -verbose => 1,
                  -exitval => 1 } );

--- a/bin/agat_sq_rename_seqid.pl
+++ b/bin/agat_sq_rename_seqid.pl
@@ -20,14 +20,16 @@ my $verbose;
 my $csv;
 my $opt_help = 0;
 
-Getopt::Long::Configure ('bundling');
+my $common = parse_common_options() || {};
+$config     = $common->{config};
+$outputFile = $common->{output};
+$verbose    = $common->{verbose};
+$opt_help   = $common->{help};
+
 if ( !GetOptions (  'gff=s' => \$input_gff,
-                    'o|output=s' => \$outputFile,
-	                'tsv=s' => \$input_tsv,
+                        'tsv=s' => \$input_tsv,
                     'csv!' => \$csv,
-			        'v|verbose!' => \$verbose,
-                    'c|config=s'               => \$config,
-                    'h|help!'         => \$opt_help )  )
+                    )  )
 {
     pod2usage( { -message => 'Failed to parse command line',
                  -verbose => 1,

--- a/bin/agat_sq_repeats_analyzer.pl
+++ b/bin/agat_sq_repeats_analyzer.pl
@@ -18,13 +18,15 @@ my $outputFile;
 my $genome;
 my $opt_help = 0;
 
-Getopt::Long::Configure ('bundling');
+my $common = parse_common_options() || {};
+$config     = $common->{config};
+$outputFile = $common->{output};
+$opt_help   = $common->{help};
+
 if ( !GetOptions ('i|file|input|gff=s' => \@inputFile,
-      'o|output=s' => \$outputFile,
       'g|genome=s' => \$genome,
-      'c|config=s'               => \$config,
-      'h|help!'         => \$opt_help )  )
-{
+      )  )
+{ 
     pod2usage( { -message => 'Failed to parse command line',
                  -verbose => 1,
                  -exitval => 1 } );

--- a/bin/agat_sq_reverse_complement.pl
+++ b/bin/agat_sq_reverse_complement.pl
@@ -20,13 +20,15 @@ my $outfile=undef;
 my $opt_help = 0;
 
 
-Getopt::Long::Configure ('bundling');
+my $common = parse_common_options() || {};
+$config  = $common->{config};
+$outfile = $common->{output};
+$verbose = $common->{verbose};
+$opt_help= $common->{help};
+
 if ( !GetOptions ('file|input|gff=s' => \$opt_gfffile,
                         'f|fasta=s'  => \$opt_fastafile,
-                        'o|output=s' => \$outfile,
-                        'v|verbose!' => \$verbose,
-                        'c|config=s' => \$config,
-                        'h|help!'    => \$opt_help )  )
+                        )  )
 {
     pod2usage( { -message => "$header\nFailed to parse command line",
                  -verbose => 1,

--- a/bin/agat_sq_rfam_analyzer.pl
+++ b/bin/agat_sq_rfam_analyzer.pl
@@ -17,13 +17,15 @@ my $outputFile;
 my $genome;
 my $opt_help = 0;
 
-Getopt::Long::Configure ('bundling');
+my $common = parse_common_options() || {};
+$config     = $common->{config};
+$outputFile = $common->{output};
+$opt_help   = $common->{help};
+
 if ( !GetOptions ('i|file|input|gff=s' => \@inputFile,
-      'o|output=s' => \$outputFile,
       'g|genome=s' => \$genome,
-      'c|config=s'               => \$config,
-      'h|help!'         => \$opt_help )  )
-{
+      )  )
+{ 
     pod2usage( { -message => "Failed to parse command line",
                  -verbose => 1,
                  -exitval => 1 } );

--- a/bin/agat_sq_split.pl
+++ b/bin/agat_sq_split.pl
@@ -18,14 +18,16 @@ my $opt_help = 0;
 my $interval=10;
 my $feature_type="gene";
 
-Getopt::Long::Configure ('bundling');
+my $common = parse_common_options() || {};
+$config    = $common->{config};
+$outfolder = $common->{output};
+$opt_help  = $common->{help};
+
 if ( !GetOptions ('file|input|gff=s' => \$inputFile,
       'ft|feature_type=s'        => \$feature_type,
       'i|interval=i'             => \$interval,
-      'o|output=s'               => \$outfolder,
-      'c|config=s'               => \$config,
-      'h|help!'                  => \$opt_help )  )
-{
+      )  )
+{ 
     pod2usage( { -message => 'Failed to parse command line',
                  -verbose => 1,
                  -exitval => 1 } );

--- a/bin/agat_sq_stat_basic.pl
+++ b/bin/agat_sq_stat_basic.pl
@@ -19,15 +19,17 @@ my $genome;
 my $inflate;
 my $opt_help = 0;
 
-Getopt::Long::Configure ('bundling');
+my $common = parse_common_options() || {};
+$config     = $common->{config};
+$outputFile = $common->{output};
+$opt_help   = $common->{help};
+
 if ( !GetOptions (
       'i|file|input|gff=s' => \@inputFile,
-      'o|output=s'      => \$outputFile,
-			'inflate!'        => \$inflate,
+                        'inflate!'        => \$inflate,
       'g|genome=s'      => \$genome,
-      'c|config=s'      => \$config,
-      'h|help!'         => \$opt_help )  )
-{
+      )  )
+{ 
     pod2usage( { -message => 'Failed to parse command line',
                  -verbose => 1,
                  -exitval => 1 } );

--- a/lib/AGAT/AGAT.pm
+++ b/lib/AGAT/AGAT.pm
@@ -15,7 +15,7 @@ use AGAT::OmniscientStat;
 use AGAT::Utilities;
 use AGAT::PlotR;
 use Bio::Tools::GFF;
-use Getopt::Long qw(GetOptionsFromArray);
+use Getopt::Long;
 
 our $VERSION     = "v1.5.1";
 our $CONFIG; # This variable will be used to store the config and will be available from everywhere.
@@ -152,12 +152,16 @@ sub parse_common_options {
         $argv //= \@ARGV;
         my @original = @{$argv};
         my %options;
-        my $parser = Getopt::Long::Parser->new(config => ['pass_through']);
-        $parser->getoptionsfromarray($argv, \%options,
+        my $parser = Getopt::Long::Parser->new( config => ['pass_through'] );
+        $parser->getoptionsfromarray(
+                $argv, \%options,
                 'config|c=s',
                 'output|out|o=s',
-                'verbose|v!'
-        ) or return;
+                'verbose|v!',
+                'debug|d!',
+                'help|h'
+        )
+          or return;
         $options{argv} = \@original;
         return \%options;
 }

--- a/lib/AGAT/AGAT.pm
+++ b/lib/AGAT/AGAT.pm
@@ -15,11 +15,12 @@ use AGAT::OmniscientStat;
 use AGAT::Utilities;
 use AGAT::PlotR;
 use Bio::Tools::GFF;
+use Getopt::Long qw(GetOptionsFromArray);
 
 our $VERSION     = "v1.5.1";
 our $CONFIG; # This variable will be used to store the config and will be available from everywhere.
 our @ISA         = qw( Exporter );
-our @EXPORT      = qw( get_agat_header print_agat_version get_agat_config handle_levels );
+our @EXPORT      = qw( get_agat_header print_agat_version get_agat_config handle_levels parse_common_options );
 sub import {
     AGAT::AGAT->export_to_level(1, @_); # to be able to load the EXPORT functions when direct call; (normal case)
     AGAT::OmniscientI->export_to_level(1, @_);
@@ -142,6 +143,21 @@ The configuration can be used to change output format, to merge loci,
 to activate tabix output, etc. (For _sq_ scripts only input/output format 
 configuration parameters are used).
 MESSAGE
+}
+
+# Parse common command-line options shared by many scripts.
+# Options removed from @ARGV to allow further processing by callers.
+sub parse_common_options {
+        my ($argv) = @_;
+        $argv //= \@ARGV;
+        my %options;
+        my $parser = Getopt::Long::Parser->new(config => ['pass_through']);
+        $parser->getoptionsfromarray($argv, \%options,
+                'config|c=s',
+                'output|out|o=s',
+                'verbose|v!'
+        ) or return;
+        return \%options;
 }
 
 # load configuration file from local file if any either the one shipped with AGAT

--- a/lib/AGAT/AGAT.pm
+++ b/lib/AGAT/AGAT.pm
@@ -150,6 +150,7 @@ MESSAGE
 sub parse_common_options {
         my ($argv) = @_;
         $argv //= \@ARGV;
+        my @original = @{$argv};
         my %options;
         my $parser = Getopt::Long::Parser->new(config => ['pass_through']);
         $parser->getoptionsfromarray($argv, \%options,
@@ -157,6 +158,7 @@ sub parse_common_options {
                 'output|out|o=s',
                 'verbose|v!'
         ) or return;
+        $options{argv} = \@original;
         return \%options;
 }
 

--- a/t/parse_common_options.t
+++ b/t/parse_common_options.t
@@ -1,0 +1,12 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More tests => 2;
+use AGAT::AGAT;
+
+{
+    local @ARGV = ('--config','foo.yaml','--output','bar','--verbose','--extra','val');
+    my $opts = parse_common_options();
+    is_deeply($opts, {config=>'foo.yaml', output=>'bar', verbose=>1}, 'parsed values');
+    is_deeply(\@ARGV, ['--extra','val'], 'remaining args preserved');
+}

--- a/t/parse_common_options.t
+++ b/t/parse_common_options.t
@@ -5,12 +5,19 @@ use Test::More tests => 3;
 use AGAT::AGAT;
 
 {
-    my @args = ('--config','foo.yaml','--output','bar','--verbose','--extra','val');
+    my @args = (
+        '--config', 'foo.yaml', '--output', 'bar',
+        '--verbose', '--debug', '--help', '--extra', 'val'
+    );
     local @ARGV = @args;
     my $opts = parse_common_options();
     my $orig = delete $opts->{argv};
-    is_deeply($opts, {config=>'foo.yaml', output=>'bar', verbose=>1}, 'parsed values');
-    is_deeply(\@ARGV, ['--extra','val'], 'remaining args preserved');
-    is_deeply($orig, \@args, 'original argv captured');
+    is_deeply(
+        $opts,
+        { config => 'foo.yaml', output => 'bar', verbose => 1, debug => 1, help => 1 },
+        'parsed values'
+    );
+    is_deeply( \@ARGV, [ '--extra', 'val' ], 'remaining args preserved' );
+    is_deeply( $orig, \@args, 'original argv captured' );
 }
 

--- a/t/parse_common_options.t
+++ b/t/parse_common_options.t
@@ -1,12 +1,16 @@
 #!/usr/bin/env perl
 use strict;
 use warnings;
-use Test::More tests => 2;
+use Test::More tests => 3;
 use AGAT::AGAT;
 
 {
-    local @ARGV = ('--config','foo.yaml','--output','bar','--verbose','--extra','val');
+    my @args = ('--config','foo.yaml','--output','bar','--verbose','--extra','val');
+    local @ARGV = @args;
     my $opts = parse_common_options();
+    my $orig = delete $opts->{argv};
     is_deeply($opts, {config=>'foo.yaml', output=>'bar', verbose=>1}, 'parsed values');
     is_deeply(\@ARGV, ['--extra','val'], 'remaining args preserved');
+    is_deeply($orig, \@args, 'original argv captured');
 }
+


### PR DESCRIPTION
## Summary
- add `parse_common_options` helper to AGAT core module to parse --debug, --help, --output, --verbose, --config
- use common option parser in scripts, remove redundant options
- test parsing of shared CLI flags