### PR TITLE
feat: configurable log file path

### DIFF
--- a/bin/agat_convert_bed2gff.pl
+++ b/bin/agat_convert_bed2gff.pl
@@ -18,6 +18,12 @@ my $inflate_type = "exon";
 my $verbose = undef;
 my $help;
 
+my $common = parse_common_options() || {};
+$config   = $common->{config};
+$outfile  = $common->{output};
+$verbose  = $common->{verbose};
+$help     = $common->{help};
+
 
 if( !GetOptions(  	'c|config=s'     => \$config,
 					"h|help"         => \$help,
@@ -50,6 +56,11 @@ if ( ! (defined($bed)) ){
 
 # --- Manage config ---
 $config = get_agat_config({config_file_in => $config});
+
+my $log;
+my $log_name = get_log_path($common, $config);
+open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+dual_print($log, $header, 0);
 
 ## Manage output file
 my $gffout = prepare_gffout($config, $outfile);

--- a/bin/agat_convert_embl2gff.pl
+++ b/bin/agat_convert_embl2gff.pl
@@ -19,15 +19,19 @@ my $discard;
 my $keep;
 my $help;
 
+my $common = parse_common_options() || {};
+$config  = $common->{config};
+$outfile = $common->{output};
+my $verbose = $common->{verbose};
+$help   = $common->{help};
+
 if( !GetOptions(
-    'c|config=s'                 => \$config,
-    "h|help"                     => \$help,
     "embl=s"                     => \$embl,
     "primary_tag|pt|t=s"         => \$primaryTags,
     "d!"                         => \$discard,
     "k!"                         => \$keep,
     "emblmygff3!"                => \$emblmygff3,
-    "outfile|output|o|out|gff=s" => \$outfile))
+    "gff=s"                      => \$outfile))
 {
     pod2usage( { -message => "Failed to parse command line\n$header",
                  -verbose => 1,
@@ -53,12 +57,9 @@ $config = get_agat_config({config_file_in => $config});
 my $throw_fasta=$config->{"throw_fasta"};
 
 my $log;
-if ($config->{log}) {
-  my ($file) = $0 =~ /([^\/]+)$/;
-  my $log_name = $file . ".agat.log";
-  open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
-  dual_print($log, $header, 0);
-}
+my $log_name = get_log_path($common, $config);
+open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+dual_print($log, $header, 0);
 
 ##################
 # MANAGE OPTION  #

--- a/bin/agat_convert_genscan2gff.pl
+++ b/bin/agat_convert_genscan2gff.pl
@@ -19,6 +19,12 @@ my %hash_uniqID;
 my $verbose = undef;
 my $help;
 
+my $common = parse_common_options() || {};
+$config   = $common->{config};
+$outfile  = $common->{output};
+$verbose  = $common->{verbose};
+$help     = $common->{help};
+
 
 if( !GetOptions(    'c|config=s'                => \$config,
 					"h|help"                    => \$help,
@@ -48,6 +54,11 @@ if ( ! (defined($genscan)) ){
 
 # --- Manage config ---
 $config = get_agat_config({config_file_in => $config});
+
+my $log;
+my $log_name = get_log_path($common, $config);
+open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+dual_print($log, $header, 0);
 
 ## Manage output file
 my $gffout = prepare_gffout($config, $outfile);

--- a/bin/agat_convert_mfannot2gff.pl
+++ b/bin/agat_convert_mfannot2gff.pl
@@ -14,6 +14,7 @@ my $config;
 my $mfannot_file;
 my $verbose;
 my $gff_file;
+my $opt_help;
 my %startend_hash;     # Stores start and end positions of each feature reported
 my %sorted_hash;
 my %hash_uniqID;
@@ -21,14 +22,24 @@ my %filtered_result;
 my $omniscient={}; #Hash where all the features will be saved
 my $hashID={}; # ex %miscCount;# Hash to store any counter.
 
+my $common = parse_common_options() || {};
+$config   = $common->{config};
+$gff_file = $common->{output};
+$verbose  = $common->{verbose};
+$opt_help = $common->{help};
+
 GetOptions(
     'mfannot|m|i=s'  => \$mfannot_file,
     'gff|g|o=s'      => \$gff_file,
-	'v|verbose!'     => \$verbose,
+    'v|verbose!'     => \$verbose,
     'c|config=s'     => \$config,
-    'h|help'         => sub { pod2usage( -exitstatus=>0, -verbose=>99, -message => "$header\n" ); },
+    'h|help!'        => \$opt_help,
     'man'            => sub { pod2usage(-exitstatus=>0, -verbose=>2); }
 ) or pod2usage ( -exitstatus=>2, -verbose=>2 );
+
+if ($opt_help) {
+    pod2usage( -exitstatus=>0, -verbose=>99, -message => "$header\n" );
+}
 
 if (!defined $mfannot_file) {
     pod2usage( -message=>"Insufficient options supplied", -exitstatus=>2 );
@@ -36,6 +47,11 @@ if (!defined $mfannot_file) {
 
 # --- Manage config ---
 $config = get_agat_config({config_file_in => $config});
+
+my $log;
+my $log_name = get_log_path($common, $config);
+open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+dual_print($log, $header, 0);
 
 ## Manage output file
 my $gffout = prepare_gffout($config, $gff_file);

--- a/bin/agat_convert_sp_gff2bed.pl
+++ b/bin/agat_convert_sp_gff2bed.pl
@@ -14,6 +14,11 @@ my $sub = "exon";
 my $opt_nc = "keep";
 my $help;
 
+my $common = parse_common_options() || {};
+$config  = $common->{config};
+$outfile = $common->{output};
+$help    = $common->{help};
+
 if( !GetOptions(
     'c|config=s'               => \$config,
     "h|help" => \$help,
@@ -42,6 +47,11 @@ if ( ! (defined($gff)) ){
 
 # --- Manage config ---
 $config = get_agat_config({config_file_in => $config});
+
+my $log;
+my $log_name = get_log_path($common, $config);
+open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+dual_print($log, $header, 0);
 
 ## Manage output file
 my $bedout;

--- a/bin/agat_convert_sp_gff2tsv.pl
+++ b/bin/agat_convert_sp_gff2tsv.pl
@@ -17,6 +17,11 @@ my $opt_help= 0;
 my $primaryTag=undef;
 my $attributes=undef;
 my $opt_output=undef;
+my $common = parse_common_options() || {};
+$config   = $common->{config};
+$opt_output = $common->{output};
+$opt_help  = $common->{help};
+
 my $add = undef;
 my $cp = undef;
 
@@ -48,6 +53,11 @@ if ( ! (defined($gff)) ){
 
 # --- Manage config ---
 $config = get_agat_config({config_file_in => $config});
+
+my $log;
+my $log_name = get_log_path($common, $config);
+open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+dual_print($log, $header, 0);
 
 # Manage Output
 my $ostream     = IO::File->new();

--- a/bin/agat_convert_sp_gxf2gxf.pl
+++ b/bin/agat_convert_sp_gxf2gxf.pl
@@ -16,6 +16,11 @@ my $opt_gfffile;
 my $opt_output;
 my $opt_help;
 
+my $common = parse_common_options() || {};
+$config     = $common->{config};
+$opt_output = $common->{output};
+$opt_help   = $common->{help};
+
 # OPTION MANAGMENT
 my @copyARGV=@ARGV;
 if ( !GetOptions( 'g|gxf|gtf|gff=s'          => \$opt_gfffile,
@@ -45,6 +50,11 @@ if (! defined($opt_gfffile) ){
 
 # --- Manage config ---
 $config = get_agat_config({config_file_in => $config});
+
+my $log;
+my $log_name = get_log_path($common, $config);
+open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+dual_print($log, $header, 0);
 
 ######################
 # Manage output file #

--- a/bin/agat_sp_Prokka_inferNameFromAttributes.pl
+++ b/bin/agat_sp_Prokka_inferNameFromAttributes.pl
@@ -16,12 +16,15 @@ my $opt_help= 0;
 my $force=undef;
 my $outfile=undef;
 
+my $common = parse_common_options() || {};
+$config   = $common->{config};
+$outfile  = $common->{output};
+my $verbose = $common->{verbose};
+$opt_help = $common->{help};
+
 if ( !GetOptions(
-    'c|config=s'               => \$config,
-    "h|help" => \$opt_help,
     "gff|f=s" => \$gff,
-    "force" => \$force,
-    "output|outfile|out|o=s" => \$outfile))
+    "force" => \$force))
 
 {
     pod2usage( { -message => 'Failed to parse command line',
@@ -47,12 +50,9 @@ if ( ! (defined($gff)) ){
 $config = get_agat_config({config_file_in => $config});
 
 my $log;
-if ($config->{log}) {
-  my ($file) = $0 =~ /([^\/]+)$/;
-  my $log_name = $file . ".agat.log";
-  open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
-  dual_print($log, $header, 0);
-}
+my $log_name = get_log_path($common, $config);
+open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+dual_print($log, $header, 0);
 
 # Prepare output
 my $gffout = prepare_gffout($config, $outfile);

--- a/bin/agat_sp_add_attribute_shortest_intron_size.pl
+++ b/bin/agat_sp_add_attribute_shortest_intron_size.pl
@@ -17,12 +17,14 @@ my $opt_output=undef;
 my $verbose=undef;
 my $opt_help = 0;
 
+my $common = parse_common_options() || {};
+$config     = $common->{config};
+$opt_output = $common->{output};
+$verbose    = $common->{verbose};
+$opt_help   = $common->{help};
+
 my @copyARGV=@ARGV;
-if ( !GetOptions( 'f|gff|ref|reffile=s' => \$opt_file,
-                  'o|out|output=s' => \$opt_output,
-                  'v|verbose!'      => \$verbose,
-                  'c|config=s'               => \$config,
-                  'h|help!'         => \$opt_help ) )
+if ( !GetOptions( 'f|gff|ref|reffile=s' => \$opt_file ) )
 {
     pod2usage( { -message => 'Failed to parse command line',
                  -verbose => 1,
@@ -45,6 +47,11 @@ if ( ! defined($opt_file) ) {
 
 # --- Manage config ---
 $config = get_agat_config({config_file_in => $config});
+
+my $log;
+my $log_name = get_log_path($common, $config);
+open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+dual_print($log, $header, 0);
 
 # #######################
 # # START Manage Option #

--- a/bin/agat_sp_add_start_and_stop.pl
+++ b/bin/agat_sp_add_start_and_stop.pl
@@ -27,16 +27,18 @@ my $opt_no_iupac=undef;
 my $verbose=undef;
 my $opt_help = 0;
 
+my $common = parse_common_options() || {};
+$config    = $common->{config};
+$opt_output = $common->{output};
+$verbose   = $common->{verbose};
+$opt_help  = $common->{help};
+
 my @copyARGV=@ARGV;
 if ( !GetOptions( 'i|g|gff=s'        => \$opt_file,
                   "fasta|fa|f=s"     => \$file_fasta,
                   "table|codon|ct=i" => \$codon_table_id,
-                  'o|out|output=s'   => \$opt_output,
                   'e|extend!'        => \$opt_extend,
-                  'ni|na!'           => \$opt_no_iupac,
-                  'v|verbose!'       => \$verbose,
-                  'c|config=s'       => \$config,
-                  'h|help!'          => \$opt_help ) )
+                  'ni|na!'           => \$opt_no_iupac ) )
 {
     pod2usage( { -message => 'Failed to parse command line',
                  -verbose => 1,
@@ -59,6 +61,11 @@ if(! $opt_file or ! $file_fasta ) {
 
 # --- Manage config ---
 $config = get_agat_config({config_file_in => $config});
+
+my $log;
+my $log_name = get_log_path($common, $config);
+open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+dual_print($log, $header, 0);
 
 # #######################
 # # START Manage Option #

--- a/bin/agat_sp_alignment_output_style.pl
+++ b/bin/agat_sp_alignment_output_style.pl
@@ -15,11 +15,14 @@ my $opt_verbose=undef;
 my $opt_output;
 my $opt_help = 0;
 
+my $common = parse_common_options() || {};
+$config     = $common->{config};
+$opt_output = $common->{output};
+$opt_verbose = $common->{verbose};
+$opt_help   = $common->{help};
+
 # OPTION MANAGMENT
-if ( !GetOptions( 'g|gff=s'     => \$opt_gfffile,
-                  'o|output=s'  => \$opt_output,
-                  'c|config=s'  => \$config,
-                  'h|help!'     => \$opt_help ) )
+if ( !GetOptions( 'g|gff=s'     => \$opt_gfffile ) )
 {
     pod2usage( { -message => 'Failed to parse command line',
                  -verbose => 1,
@@ -43,6 +46,11 @@ if (! defined($opt_gfffile) ){
 
 # --- Manage config ---
 $config = get_agat_config({config_file_in => $config});
+
+my $log;
+my $log_name = get_log_path($common, $config);
+open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+dual_print($log, $header, 0);
 
 ######################
 # Manage output file #

--- a/bin/agat_sp_clipN_seqExtremities_and_fixCoordinates.pl
+++ b/bin/agat_sp_clipN_seqExtremities_and_fixCoordinates.pl
@@ -19,14 +19,18 @@ my $opt_output_gff;
 my $opt_help;
 my $width = 60; # line length printed
 
+my $common = parse_common_options() || {};
+$config        = $common->{config};
+$opt_output_gff = $common->{output};
+my $verbose    = $common->{verbose};
+$opt_help      = $common->{help};
+
 # OPTION MANAGMENT
 my @copyARGV=@ARGV;
 if ( !GetOptions( 'g|gff=s'         => \$opt_gfffile,
                   'f|fa|fasta=s'    => \$opt_fastafile,
                   'of=s'            => \$opt_output_fasta,
-                  'og=s'            => \$opt_output_gff,
-                  'c|config=s'      => \$config,
-                  'h|help!'         => \$opt_help ) )
+                  'og=s'            => \$opt_output_gff ) )
 {
     pod2usage( { -message => "Failed to parse command line",
                  -verbose => 1,
@@ -52,12 +56,9 @@ if ( (! (defined($opt_gfffile)) ) or (! (defined($opt_fastafile)) ) ){
 $config = get_agat_config({config_file_in => $config});
 
 my $log;
-if ($config->{log}) {
-  my ($file) = $0 =~ /([^\/]+)$/;
-  my $log_name = $file . ".agat.log";
-  open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
-  dual_print($log, $header, 0);
-}
+my $log_name = get_log_path($common, $config);
+open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+dual_print($log, $header, 0);
 
 ######################
 # Manage output file #

--- a/bin/agat_sp_complement_annotations.pl
+++ b/bin/agat_sp_complement_annotations.pl
@@ -17,15 +17,18 @@ my $ref = undef;
 my $size_min = 0;
 my $opt_help= undef;
 
+my $common = parse_common_options() || {};
+$config    = $common->{config};
+$opt_output = $common->{output};
+my $verbose = $common->{verbose};
+$opt_help  = $common->{help};
+
 # OPTION MANAGMENT
 my @copyARGV=@ARGV;
 if ( !GetOptions(
-    'c|config=s'               => \$config,
-    "h|help" => \$opt_help,
     "ref|r|i=s" => \$ref,
     "add|a=s" => \@opt_files,
-    "size_min|s=i" => \$size_min,
-    "output|outfile|out|o=s" => \$opt_output))
+    "size_min|s=i" => \$size_min))
 
 {
     pod2usage( { -message => 'Failed to parse command line',
@@ -49,6 +52,11 @@ if (! $ref or ! @opt_files ){
 
 # --- Manage config ---
 $config = get_agat_config({config_file_in => $config});
+
+my $log;
+my $log_name = get_log_path($common, $config);
+open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+dual_print($log, $header, 0);
 
 ######################
 # Manage output file #

--- a/bin/agat_sp_extract_sequences.pl
+++ b/bin/agat_sp_extract_sequences.pl
@@ -44,10 +44,15 @@ my $opt_type = 'cds';
 my $opt_upstreamRegion=undef;
 my $opt_verbose=undef;
 
+my $common = parse_common_options() || {};
+$config       = $common->{config};
+$opt_output   = $common->{output};
+$opt_verbose  = $common->{verbose};
+$opt_help     = $common->{help};
+
 # OPTION MANAGMENT
 my @copyARGV=@ARGV;
 if ( !GetOptions( 'alternative_start_codon|asc!' => \$opt_alternative_start_codon,
-                  'c|config=s'                   => \$config,
                   'cdna!'                        => \$opt_cdna,
                   'cfs|clean_final_stop!'        => \$opt_cleanFinalStop,
                   'cis|clean_internal_stop!'     => \$opt_cleanInternalStop,
@@ -56,13 +61,11 @@ if ( !GetOptions( 'alternative_start_codon|asc!' => \$opt_alternative_start_codo
                   'f|fa|fasta=s'                 => \$opt_fastafile,
                   'full!'                        => \$opt_full,
                   'g|gff=s'                      => \$opt_gfffile,
-                  'h|help!'                      => \$opt_help,
                   'keep_attributes!'             => \$opt_keep_attributes,
                   'keep_parent_attributes!'      => \$opt_keep_parent_attributes,
                   'merge!'                       => \$opt_merge,
                   'mrna|transcript!'             => \$opt_mrna,
                   'ofs=s'                        => \$opt_OFS,
-                  'o|output=s'                   => \$opt_output,
                   'plus_strand_only!'            => \$opt_plus_strand_only,
                   'p|protein|aa!'                => \$opt_AA,
                   'q|quiet!'                     => \$opt_quiet,
@@ -71,8 +74,7 @@ if ( !GetOptions( 'alternative_start_codon|asc!' => \$opt_alternative_start_codo
                   'split!'                       => \$opt_split,
                   'table|codon|ct=i'             => \$opt_codonTable,
                   't|type=s'                     => \$opt_type,
-                  'up|5|five|upstream=i'         => \$opt_upstreamRegion,
-                  'verbose|v!'                   => \$opt_verbose ) )
+                  'up|5|five|upstream=i'         => \$opt_upstreamRegion ) )
 {
     pod2usage( { -message => "$header\nFailed to parse command line",
                  -verbose => 1,
@@ -96,16 +98,12 @@ if ( (! (defined($opt_gfffile)) ) or (! (defined($opt_fastafile)) ) ){
 }
 
 # --- Manage config ---
-# --- Manage config ---
 $config = get_agat_config({config_file_in => $config});
 
 my $log;
-if ($config->{log}) {
-  my ($file,$path,$ext) = fileparse($opt_gfffile, qr/\.[^.]*/);
-  my $log_name = $file.".agat.log";
-  open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
-  dual_print($log, $header, 0);
-}
+my $log_name = get_log_path($common, $config);
+open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+dual_print($log, $header, 0);
 
 # --- Check codon table
 # --- Check codon table

--- a/bin/agat_sp_filter_by_mrnaBlastValue.pl
+++ b/bin/agat_sp_filter_by_mrnaBlastValue.pl
@@ -18,12 +18,15 @@ my $gff     = undef;
 my $blast   = undef;
 my $opt_help;
 
+my $common = parse_common_options() || {};
+$config  = $common->{config};
+$outfile = $common->{output};
+my $verbose = $common->{verbose};
+$opt_help = $common->{help};
 
-if ( !GetOptions(   'c|config=s'=> \$config,
-                    "h|help"    => \$opt_help,
-                    "gff=s"     => \$gff,
-                    "blast=s"   => \$blast,
-                    "outfile=s" => \$outfile ))
+
+if ( !GetOptions(   "gff=s"     => \$gff,
+                    "blast=s"   => \$blast ))
 
 {
     pod2usage( { -message => 'Failed to parse command line',
@@ -49,12 +52,9 @@ if ( ! (defined($gff)) or !(defined($blast)) ){
 $config = get_agat_config({config_file_in => $config});
 
 my $log;
-if ($config->{log}) {
-  my ($file) = $0 =~ /([^\/]+)$/;
-  my $log_name = $file . ".agat.log";
-  open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
-  dual_print($log, $header, 0);
-}
+my $log_name = get_log_path($common, $config);
+open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+dual_print($log, $header, 0);
 
 # Open Output files #
 my $out = prepare_gffout($config, $outfile);

--- a/bin/agat_sp_filter_feature_by_attribute_presence.pl
+++ b/bin/agat_sp_filter_feature_by_attribute_presence.pl
@@ -19,16 +19,18 @@ my $opt_gff = undef;
 my $opt_verbose = undef;
 my $opt_help;
 
+my $common = parse_common_options() || {};
+$config      = $common->{config};
+$opt_output  = $common->{output};
+$opt_verbose = $common->{verbose};
+$opt_help    = $common->{help};
+
 # OPTION MANAGMENT
 my @copyARGV=@ARGV;
 if ( !GetOptions( 'f|ref|reffile|gff=s' => \$opt_gff,
                   "p|type|l=s"          => \$primaryTag,
                   'a|att|attribute=s'   => \$opt_attribute,
-                  'flip!'               => \$opt_test,
-                  'o|output=s'          => \$opt_output,
-                  'v|verbose!'          => \$opt_verbose,
-                  'c|config=s'               => \$config,
-                  'h|help!'             => \$opt_help ) )
+                  'flip!'               => \$opt_test ) )
 {
     pod2usage( { -message => 'Failed to parse command line',
                  -verbose => 1,
@@ -53,12 +55,9 @@ if ( ! $opt_gff or ! $opt_attribute ){
 $config = get_agat_config({config_file_in => $config});
 
 my $log;
-if ($config->{log}) {
-  my ($file) = $0 =~ /([^\/]+)$/;
-  my $log_name = $file . ".agat.log";
-  open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
-  dual_print($log, $header, 0);
-}
+my $log_name = get_log_path($common, $config);
+open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+dual_print($log, $header, 0);
 
 ###############
 # Manage Output

--- a/bin/agat_sp_filter_feature_by_attribute_value.pl
+++ b/bin/agat_sp_filter_feature_by_attribute_value.pl
@@ -24,20 +24,22 @@ my $opt_gff = undef;
 my $opt_verbose = undef;
 my $opt_help;
 
+my $common = parse_common_options() || {};
+$config      = $common->{config};
+$opt_output  = $common->{output};
+$opt_verbose = $common->{verbose};
+$opt_help    = $common->{help};
+
 # OPTION MANAGMENT
 my @copyARGV=@ARGV;
 if ( !GetOptions( 'f|ref|reffile|gff=s' => \$opt_gff,
                   'value=s'             => \$opt_value,
                   'value_insensitive!'  => \$opt_value_insensitive,
                   'keep_parental!'      => \$opt_keep_parental,
-                  'na_aside!'           => \$opt_na_aside, 
+                  'na_aside!'           => \$opt_na_aside,
                   "p|type|l=s"          => \$primaryTag,
                   'a|attribute=s'       => \$opt_attribute,
-                  't|test=s'            => \$opt_test,
-                  'o|output=s'          => \$opt_output,
-                  'v|verbose!'          => \$opt_verbose,
-                  'c|config=s'          => \$config,
-                  'h|help!'             => \$opt_help ) )
+                  't|test=s'            => \$opt_test ) )
 {
     pod2usage( { -message => 'Failed to parse command line',
                  -verbose => 1,
@@ -62,12 +64,9 @@ if ( ! $opt_gff or ! defined($opt_value) or ! $opt_attribute ){
 $config = get_agat_config({config_file_in => $config});
 
 my $log;
-if ($config->{log}) {
-  my ($file) = $0 =~ /([^\/]+)$/;
-  my $log_name = $file . ".agat.log";
-  open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
-  dual_print($log, $header, 0);
-}
+my $log_name = get_log_path($common, $config);
+open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+dual_print($log, $header, 0);
 
 ###############
 # Test options

--- a/bin/agat_sp_filter_feature_from_kill_list.pl
+++ b/bin/agat_sp_filter_feature_from_kill_list.pl
@@ -19,16 +19,18 @@ my $opt_gff = undef;
 my $opt_verbose = undef;
 my $opt_help;
 
+my $common = parse_common_options() || {};
+$config      = $common->{config};
+$opt_output  = $common->{output};
+$opt_verbose = $common->{verbose};
+$opt_help    = $common->{help};
+
 # OPTION MANAGMENT
 my @copyARGV=@ARGV;
 if ( !GetOptions( 'f|ref|reffile|gff=s' => \$opt_gff,
                   'kl|kill_list=s'      => \$opt_kill_list,
                   "p|type|l=s"          => \$primaryTag,
-                  'o|output=s'          => \$opt_output,
-                  'a|attribute=s'       => \$opt_attribute,
-                  'v|verbose!'          => \$opt_verbose,
-                  'c|config=s'               => \$config,
-                  'h|help!'             => \$opt_help ) )
+                  'a|attribute=s'       => \$opt_attribute ) )
 {
     pod2usage( { -message => 'Failed to parse command line',
                  -verbose => 1,
@@ -53,12 +55,9 @@ if ( ! $opt_gff or ! $opt_kill_list ){
 $config = get_agat_config({config_file_in => $config});
 
 my $log;
-if ($config->{log}) {
-  my ($file) = $0 =~ /([^\/]+)$/;
-  my $log_name = $file . ".agat.log";
-  open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
-  dual_print($log, $header, 0);
-}
+my $log_name = get_log_path($common, $config);
+open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+dual_print($log, $header, 0);
 
 ###############
 # Manage Output

--- a/bin/agat_sp_filter_gene_by_intron_numbers.pl
+++ b/bin/agat_sp_filter_gene_by_intron_numbers.pl
@@ -18,15 +18,17 @@ my $opt_gff = undef;
 my $opt_verbose = undef;
 my $opt_help;
 
+my $common = parse_common_options() || {};
+$config      = $common->{config};
+$opt_output  = $common->{output};
+$opt_verbose = $common->{verbose};
+$opt_help    = $common->{help};
+
 # OPTION MANAGMENT
 my @copyARGV=@ARGV;
 if ( !GetOptions( 'f|ref|reffile|gff=s' => \$opt_gff,
                   't|test=s'            => \$opt_test,
-                  "nb|number|n=i"       => \$opt_nb,
-                  'o|output=s'          => \$opt_output,
-                  'v|verbose!'          => \$opt_verbose,
-                  'c|config=s'               => \$config,
-                  'h|help!'             => \$opt_help ) )
+                  "nb|number|n=i"       => \$opt_nb ) )
 {
     pod2usage( { -message => 'Failed to parse command line',
                  -verbose => 1,
@@ -50,12 +52,9 @@ if ( ! $opt_gff ){
 $config = get_agat_config({config_file_in => $config});
 
 my $log;
-if ($config->{log}) {
-  my ($file) = $0 =~ /([^\/]+)$/;
-  my $log_name = $file . ".agat.log";
-  open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
-  dual_print($log, $header, 0);
-}
+my $log_name = get_log_path($common, $config);
+open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+dual_print($log, $header, 0);
 
 ###############
 # Manage Output

--- a/bin/agat_sp_filter_gene_by_length.pl
+++ b/bin/agat_sp_filter_gene_by_length.pl
@@ -18,15 +18,17 @@ my $opt_gff = undef;
 my $opt_verbose = undef;
 my $opt_help;
 
+my $common = parse_common_options() || {};
+$config      = $common->{config};
+$opt_output  = $common->{output};
+$opt_verbose = $common->{verbose};
+$opt_help    = $common->{help};
+
 # OPTION MANAGMENT
 my @copyARGV=@ARGV;
 if ( !GetOptions( 'f|ref|reffile|gff=s' => \$opt_gff,
                   't|test=s'            => \$opt_test,
-                  "s|size=i"            => \$opt_size,
-                  'o|output=s'          => \$opt_output,
-                  'v|verbose!'          => \$opt_verbose,
-                  'c|config=s'               => \$config,
-                  'h|help!'             => \$opt_help ) )
+                  "s|size=i"            => \$opt_size ) )
 {
     pod2usage( { -message => 'Failed to parse command line',
                  -verbose => 1,
@@ -48,6 +50,11 @@ if ( ! $opt_gff ){
 
 # --- Manage config ---
 $config = get_agat_config({config_file_in => $config});
+
+my $log;
+my $log_name = get_log_path($common, $config);
+open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+dual_print($log, $header, 0);
 
 ###############
 # Manage Output

--- a/bin/agat_sp_fix_cds_phases.pl
+++ b/bin/agat_sp_fix_cds_phases.pl
@@ -17,13 +17,15 @@ my $opt_verbose;
 my $opt_output;
 my $opt_help = 0;
 
+my $common = parse_common_options() || {};
+$config     = $common->{config};
+$opt_output = $common->{output};
+$opt_verbose = $common->{verbose};
+$opt_help   = $common->{help};
+
 # OPTION MANAGMENT
 if ( !GetOptions( 'g|gff=s'         => \$opt_gfffile,
-                  'o|output=s'      => \$opt_output,
-                  "f|fa|fasta=s"      => \$opt_fasta,
-                  "v|verbose!"       => \$opt_verbose,
-                  'c|config=s'               => \$config,
-                  'h|help!'         => \$opt_help ) )
+                  "f|fa|fasta=s"      => \$opt_fasta ) )
 {
     pod2usage( { -message => 'Failed to parse command line',
                  -verbose => 1,
@@ -49,12 +51,9 @@ if (! defined($opt_gfffile) or ! defined($opt_fasta)){
 $config = get_agat_config({config_file_in => $config});
 
 my $log;
-if ($config->{log}) {
-  my ($file) = $0 =~ /([^\/]+)$/;
-  my $log_name = $file . ".agat.log";
-  open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
-  dual_print($log, $header, 0);
-}
+my $log_name = get_log_path($common, $config);
+open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+dual_print($log, $header, 0);
 
 ######################
 # Manage output file #

--- a/bin/agat_sp_fix_features_locations_duplicated.pl
+++ b/bin/agat_sp_fix_features_locations_duplicated.pl
@@ -18,14 +18,16 @@ my $ref = undef;
 my $verbose = undef;
 my $opt_help= 0;
 
+my $common = parse_common_options() || {};
+$config   = $common->{config};
+$outfile  = $common->{output};
+$verbose  = $common->{verbose};
+$opt_help = $common->{help};
+
 my @copyARGV=@ARGV;
 if ( !GetOptions(
-    'c|config=s'               => \$config,
-    "h|help"                 => \$opt_help,
     "f|file|gff3|gff=s"      => \$ref,
-    "v|verbose!"              => \$verbose,
-    "m|model=s"              => \$model_to_test,
-    "output|outfile|out|o=s" => \$outfile))
+    "m|model=s"              => \$model_to_test ))
 
 {
     pod2usage( { -message => 'Failed to parse command line',
@@ -49,6 +51,11 @@ if ( ! (defined($ref)) ){
 
 # --- Manage config ---
 $config = get_agat_config({config_file_in => $config});
+
+my $log;
+my $log_name = get_log_path($common, $config);
+open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+dual_print($log, $header, 0);
 
 ######################
 # Manage output file #

--- a/bin/agat_sp_fix_small_exon_from_extremities.pl
+++ b/bin/agat_sp_fix_small_exon_from_extremities.pl
@@ -21,16 +21,18 @@ my $SIZE_OPT=15;
 my $verbose = undef;
 my $opt_help= 0;
 
+my $common = parse_common_options() || {};
+$config   = $common->{config};
+$outfile  = $common->{output};
+$verbose  = $common->{verbose};
+$opt_help = $common->{help};
+
 my @copyARGV=@ARGV;
 if ( !GetOptions(
-    'c|config=s'               => \$config,
-    "h|help" => \$opt_help,
     "gff=s" => \$gff,
     "fasta|fa|f=s" => \$file_fasta,
     "table|codon|ct=i" => \$codonTableId,
-    "size|s=i" => \$SIZE_OPT,
-    "v!" => \$verbose,
-    "output|outfile|out|o=s" => \$outfile))
+    "size|s=i" => \$SIZE_OPT ))
 
 {
     pod2usage( { -message => 'Failed to parse command line',
@@ -54,6 +56,11 @@ if ( ! (defined($gff)) or !(defined($file_fasta)) ){
 
 # --- Manage config ---
 $config = get_agat_config({config_file_in => $config});
+
+my $log;
+my $log_name = get_log_path($common, $config);
+open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+dual_print($log, $header, 0);
 
 # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>    PARAMS    <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 

--- a/bin/agat_sp_flag_short_introns_ebi.pl
+++ b/bin/agat_sp_flag_short_introns_ebi.pl
@@ -18,13 +18,15 @@ my $verbose=undef;
 my $Xsize=10;
 my $opt_help = 0;
 
+my $common = parse_common_options() || {};
+$config    = $common->{config};
+$opt_output = $common->{output};
+$verbose   = $common->{verbose};
+$opt_help  = $common->{help};
+
 my @copyARGV=@ARGV;
 if ( !GetOptions( 'f|gff|ref|reffile=s' => \$opt_file,
-                  'o|out|output=s'      => \$opt_output,
-                  'v|verbose!'          => \$verbose,
-                  'i|intron_size=i'     => \$Xsize,
-                  'c|config=s'          => \$config,
-                  'h|help!'             => \$opt_help ) )
+                  'i|intron_size=i'     => \$Xsize ) )
 {
     pod2usage( { -message => 'Failed to parse command line',
                  -verbose => 1,
@@ -49,12 +51,9 @@ if ( ! defined($opt_file) ) {
 $config = get_agat_config({config_file_in => $config});
 
 my $log;
-if ($config->{log}) {
-  my ($file) = $0 =~ /([^\/]+)$/;
-  my $log_name = $file . ".agat.log";
-  open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
-  dual_print($log, $header, 0);
-}
+my $log_name = get_log_path($common, $config);
+open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+dual_print($log, $header, 0);
 
 # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>    PARAMS    <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 

--- a/bin/agat_sp_functional_statistics.pl
+++ b/bin/agat_sp_functional_statistics.pl
@@ -16,11 +16,14 @@ my $opt_output = "output_functional_statistics";
 my $opt_genomeSize = undef;
 my $opt_help= 0;
 
+my $common = parse_common_options() || {};
+$config      = $common->{config};
+$opt_output  = $common->{output} // $opt_output;
+my $verbose  = $common->{verbose};
+$opt_help    = $common->{help};
+
 if ( !GetOptions(
-    'c|config=s'               => \$config,
-    "h|help"     => \$opt_help,
     'g|gs=s'     => \$opt_genomeSize,
-    'o|output=s' => \$opt_output,
     "gff|f=s"    => \$gff))
 
 {
@@ -45,6 +48,11 @@ if ( ! (defined($gff)) ){
 
 # --- Manage config ---
 $config = get_agat_config({config_file_in => $config});
+
+my $log;
+my $log_name = get_log_path($common, $config);
+open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+dual_print($log, $header, 0);
 
 # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>    PARAMS    <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 

--- a/bin/agat_sp_keep_longest_isoform.pl
+++ b/bin/agat_sp_keep_longest_isoform.pl
@@ -43,12 +43,9 @@ if ( ! (defined($gff)) ){
 $config = get_agat_config({config_file_in => $config});
 
 my $log;
-if ($config->{log}) {
-  my ($file) = $0 =~ /([^\/]+)$/;
-  my $log_name = $file . ".agat.log";
-  open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
-  dual_print($log, $header, 0);
-}
+my $log_name = get_log_path($common, $config);
+open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+dual_print($log, $header, 0);
 
 # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>    PARAMS    <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 

--- a/bin/agat_sp_list_short_introns.pl
+++ b/bin/agat_sp_list_short_introns.pl
@@ -17,11 +17,15 @@ my $INTRON_LENGTH = 10;
 my $opt_output=undef;
 my $opt_help = 0;
 
+my $common = parse_common_options() || {};
+$config     = $common->{config};
+$opt_output = $common->{output};
+my $verbose = $common->{verbose};
+$opt_help   = $common->{help};
+
 my @copyARGV=@ARGV;
 if ( !GetOptions( 'f|gff|ref|reffile=s' => \$opt_file,
-                  'o|out|output=s'      => \$opt_output,
                   "size|s=i"            => \$INTRON_LENGTH,
-                  'c|config=s'               => \$config,
                   'h|help!'             => \$opt_help ) )
 {
     pod2usage( { -message => 'Failed to parse command line',
@@ -45,6 +49,11 @@ if ( ! defined( $opt_file) ) {
 
 # --- Manage config ---
 $config = get_agat_config({config_file_in => $config});
+
+my $log;
+my $log_name = get_log_path($common, $config);
+open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+dual_print($log, $header, 0);
 
 # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>    PARAMS    <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 

--- a/bin/agat_sp_load_function_from_protein_align.pl
+++ b/bin/agat_sp_load_function_from_protein_align.pl
@@ -42,11 +42,14 @@ my $verbose                = undef;
 my $method_opt             = "replace";
 my $opt_help               = 0;
 
+my $common = parse_common_options() || {};
+$config     = $common->{config};
+$opt_output = $common->{output};
+$verbose    = $common->{verbose};
+$opt_help   = $common->{help};
 
 my @copyARGV=@ARGV;
 if ( !GetOptions(
-    'c|config=s'               => \$config,
-    "h|help"                 => \$opt_help,
     "annotation|a=s"         => \$annotation_gff,
     "pgff=s"                 => \$protein_gff,
     "sp:s"                   => \$sort_method_by_species,
@@ -56,9 +59,8 @@ if ( !GetOptions(
     "fasta|pfasta=s"         => \$protein_fasta,
     "w"                      => \$whole_sequence_opt,
     "value|threshold=i"      => \$valueK,
-    'method|m:s'             => \$method_opt,
-    "verbose|v"              => \$verbose,
-    "output|out|o=s"         => \$opt_output))
+    'method|m:s'             => \$method_opt
+    ))
 
 {
     pod2usage( { -message => 'Failed to parse command line',
@@ -82,6 +84,11 @@ if ( ! ($annotation_gff and $protein_gff and $protein_fasta) ){
 
 # --- Manage config ---
 $config = get_agat_config({config_file_in => $config});
+
+my $log;
+my $log_name = get_log_path($common, $config);
+open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+dual_print($log, $header, 0);
 
 #               +------------------------------------------------------+
 #               |+----------------------------------------------------+|

--- a/bin/agat_sp_manage_attributes.pl
+++ b/bin/agat_sp_manage_attributes.pl
@@ -21,16 +21,19 @@ my $add = undef;
 my $cp = undef;
 my $overwrite = undef;
 
+my $common = parse_common_options() || {};
+$config  = $common->{config};
+$outfile = $common->{output};
+my $verbose = $common->{verbose};
+$opt_help = $common->{help};
+
 if ( !GetOptions(
-    'c|config=s'               => \$config,
-    "h|help"      => \$opt_help,
     "gff|f=s"     => \$gff,
     "add"         => \$add,
-		"overwrite"   => \$overwrite,
+                "overwrite"   => \$overwrite,
     "cp"          => \$cp,
     "p|type|l=s"  => \$primaryTag,
-    "tag|att=s"   => \$attributes,
-    "output|outfile|out|o=s" => \$outfile))
+    "tag|att=s"   => \$attributes))
 
 {
     pod2usage( { -message => 'Failed to parse command line',
@@ -55,6 +58,11 @@ if ( ! $gff or ! $attributes){
 
 # --- Manage config ---
 $config = get_agat_config({config_file_in => $config});
+
+my $log;
+my $log_name = get_log_path($common, $config);
+open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+dual_print($log, $header, 0);
 
 my $gffout = prepare_gffout($config, $outfile);
 

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -41,6 +41,11 @@ my $nbIDstart = 1;
 my $prefixName = undef;
 my %tag_hash;
 my @tag_list;
+my $common = parse_common_options() || {};
+$config     = $common->{config};
+$opt_output = $common->{output};
+$opt_verbose = $common->{verbose};
+$opt_help   = $common->{help};
 # END PARAMETERS - OPTION
 
 # FOR FUNCTIONS BLAST#
@@ -97,11 +102,7 @@ GetOptions(
  'id=s'                     => \$opt_name,
  'idau=s'                   => \$opt_nameU,
  'nb=i'                     => \$nbIDstart,
- 'o|output=s'               => \$opt_output,
- 'a|addgntag'               => \$opt_addGnPresentTag,
- 'v'                        => \$opt_verbose,
- 'c|config=s'               => \$config,
- 'h|help!'                  => \$opt_help
+ 'a|addgntag'               => \$opt_addGnPresentTag
 )
 or pod2usage( {
   -message => 'Failed to parse command line',
@@ -133,6 +134,11 @@ if ( !( defined($opt_reffile) ) ) {
 
 # --- Manage config ---
 $config = get_agat_config({config_file_in => $config});
+
+my $log;
+my $log_name = get_log_path($common, $config);
+open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+dual_print($log, $header, 0);
 
 #################################################
 ####### START Manage files (input output) #######

--- a/bin/agat_sp_prokka_fix_fragmented_gene_annotations.pl
+++ b/bin/agat_sp_prokka_fix_fragmented_gene_annotations.pl
@@ -71,20 +71,23 @@ my $skip_hamap;
 my $verbose = 0;
 my $opt_help= 0;
 
+my $common = parse_common_options() || {};
+$config    = $common->{config};
+$outfolder = $common->{output};
+$verbose   = $common->{verbose};
+$opt_help  = $common->{help};
+
 my @copyARGV=@ARGV;
 if ( !GetOptions(
-    'c|config=s'         => \$config,
-    "h|help"             => \$opt_help,
     "gff=s"              => \$gff,
     "fasta|fa|f=s"       => \$file_fasta,
-	"db=s"               => \$file_db,
-	"frags!"             => \$frags,
-	"pseudo!"            => \$pseudo,
-	"hamap_size=s"       => \$hamap_size,
+        "db=s"               => \$file_db,
+        "frags!"             => \$frags,
+        "pseudo!"            => \$pseudo,
+        "hamap_size=s"       => \$hamap_size,
     "table|codon|ct=i"   => \$codonTable,
-	"skip_hamap!"        => \$skip_hamap,
-    "v=i"                => \$verbose,
-    "output|out|o=s"     => \$outfolder))
+        "skip_hamap!"        => \$skip_hamap,
+        ))
 
 {
     pod2usage( { -message => 'Failed to parse command line',
@@ -111,6 +114,11 @@ if ( ! (defined($gff)) or !(defined($file_fasta)) or !(defined($file_db)) ){
 
 # --- Manage config ---
 $config = get_agat_config({config_file_in => $config});
+
+my $log;
+my $log_name = get_log_path($common, $config);
+open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+dual_print($log, $header, 0);
 
 # Check codon table
 $codonTable = get_proper_codon_table($codonTable);

--- a/bin/agat_sp_separate_by_record_type.pl
+++ b/bin/agat_sp_separate_by_record_type.pl
@@ -14,12 +14,14 @@ my $opt_gfffile;
 my $opt_output;
 my $opt_help = 0;
 
-# OPTION MANAGMENT
-if ( !GetOptions( 'g|gff=s' => \$opt_gfffile,
-                  'o|output=s'      => \$opt_output,
+my $common = parse_common_options() || {};
+$config     = $common->{config};
+$opt_output = $common->{output};
+my $verbose = $common->{verbose};
+$opt_help   = $common->{help};
 
-                  'c|config=s'               => \$config,
-                  'h|help!'         => \$opt_help ) )
+# OPTION MANAGMENT
+if ( !GetOptions( 'g|gff=s' => \$opt_gfffile ) )
 {
     pod2usage( { -message => 'Failed to parse command line',
                  -verbose => 1,
@@ -45,12 +47,9 @@ if (! defined($opt_gfffile) ){
 $config = get_agat_config({config_file_in => $config});
 
 my $log;
-if ($config->{log}) {
-  my ($file) = $0 =~ /([^\/]+)$/;
-  my $log_name = $file . ".agat.log";
-  open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
-  dual_print($log, $header, 0);
-}
+my $log_name = get_log_path($common, $config);
+open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+dual_print($log, $header, 0);
 
 ######################
 # Manage output file #

--- a/bin/agat_sp_statistics.pl
+++ b/bin/agat_sp_statistics.pl
@@ -21,17 +21,19 @@ my $opt_raw = undef;
 my $opt_verbose = 0;
 my $opt_help= 0;
 
+my $common = parse_common_options() || {};
+$config      = $common->{config};
+$opt_output  = $common->{output};
+$opt_verbose = $common->{verbose};
+$opt_help    = $common->{help};
+
 if ( !GetOptions(
-    'c|config=s'               => \$config,
-    "h|help"      => \$opt_help,
-    'o|output=s'  => \$opt_output,
     'percentile=i' => \$opt_percentile,
     'yaml!'        => \$opt_yaml,
     'r|raw!'       => \$opt_raw,
     'd|p!'         => \$opt_plot,
-    'v|verbose'   => \$opt_verbose,
     'g|f|gs=s'    => \$opt_genomeSize,
-    "gff|i=s"     => \$gff))
+    'gff|i=s'     => \$gff))
 
 {
     pod2usage( { -message => "Failed to parse command line",
@@ -55,6 +57,11 @@ if ( ! (defined($gff)) ){
 
 # --- Manage config ---
 $config = get_agat_config({config_file_in => $config});
+
+my $log;
+my $log_name = get_log_path($common, $config);
+open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+dual_print($log, $header, 0);
 
 #### IN / OUT
 my $out = prepare_fileout($opt_output);

--- a/bin/agat_sp_webApollo_compliant.pl
+++ b/bin/agat_sp_webApollo_compliant.pl
@@ -13,11 +13,14 @@ my $opt_gfffile;
 my $opt_output;
 my $opt_help = 0;
 
+my $common = parse_common_options() || {};
+$config     = $common->{config};
+$opt_output = $common->{output};
+my $verbose = $common->{verbose};
+$opt_help   = $common->{help};
+
 # OPTION MANAGMENT
-if ( !GetOptions( 'g|gff=s' => \$opt_gfffile,
-                  'o|output=s'      => \$opt_output,
-                  'c|config=s'               => \$config,
-                  'h|help!'         => \$opt_help ) )
+if ( !GetOptions( 'g|gff=s' => \$opt_gfffile ) )
 {
     pod2usage( { -message => 'Failed to parse command line',
                  -verbose => 1,
@@ -41,6 +44,11 @@ if (! defined($opt_gfffile) ){
 
 # --- Manage config ---
 $config = get_agat_config({config_file_in => $config});
+
+my $log;
+my $log_name = get_log_path($common, $config);
+open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+dual_print($log, $header, 0);
 
 ######################
 # Manage output file #

--- a/bin/agat_sq_add_attributes_from_tsv.pl
+++ b/bin/agat_sq_add_attributes_from_tsv.pl
@@ -53,12 +53,9 @@ if (! $input_gff or ! $input_tsv){
 $config = get_agat_config({config_file_in => $config});
 
 my $log;
-if ($config->{log}) {
-  my ($file) = $0 =~ /([^\/]+)$/;
-  my $log_name = $file . ".agat.log";
-  open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
-  dual_print($log, $header, 0);
-}
+my $log_name = get_log_path($common, $config);
+open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+dual_print($log, $header, 0);
 
 # Manage Output
 my $gffout = prepare_gffout($config, $outputFile);

--- a/bin/agat_sq_add_hash_tag.pl
+++ b/bin/agat_sq_add_hash_tag.pl
@@ -54,12 +54,9 @@ if (( $interval > 2 or $interval < 1) ){
 $config = get_agat_config({config_file_in => $config});
 
 my $log;
-if ($config->{log}) {
-  my ($file) = $0 =~ /([^\/]+)$/;
-  my $log_name = $file . ".agat.log";
-  open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
-  dual_print($log, $header, 0);
-}
+my $log_name = get_log_path($common, $config);
+open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+dual_print($log, $header, 0);
 
 # Manage input gff file
 my $format = $config->{force_gff_input_version};

--- a/bin/agat_sq_list_attributes.pl
+++ b/bin/agat_sq_list_attributes.pl
@@ -53,12 +53,9 @@ if ( ! (defined($gff)) ){
 $config = get_agat_config({config_file_in => $config});
 
 my $log;
-if ($config->{log}) {
-  my ($file) = $0 =~ /([^\/]+)$/;
-  my $log_name = $file . ".agat.log";
-  open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
-  dual_print($log, $header, 0);
-}
+my $log_name = get_log_path($common, $config);
+open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+dual_print($log, $header, 0);
 
 # Manage $primaryTag
 my @ptagList;

--- a/bin/agat_sq_reverse_complement.pl
+++ b/bin/agat_sq_reverse_complement.pl
@@ -51,12 +51,9 @@ if ((!defined($opt_gfffile) or !defined($opt_fastafile) ) ){
 $config = get_agat_config({config_file_in => $config});
 
 my $log;
-if ($config->{log}) {
-  my ($file) = $0 =~ /([^\/]+)$/;
-  my $log_name = $file . ".agat.log";
-  open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
-  dual_print($log, $header, 0);
-}
+my $log_name = get_log_path($common, $config);
+open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+dual_print($log, $header, 0);
 
 # Manage input gff file
 my $format = $config->{force_gff_input_version};

--- a/bin/agat_sq_rfam_analyzer.pl
+++ b/bin/agat_sq_rfam_analyzer.pl
@@ -47,12 +47,9 @@ if (! @inputFile ){
 $config = get_agat_config({config_file_in => $config});
 
 my $log;
-if ($config->{log}) {
-  my ($file) = $0 =~ /([^\/]+)$/;
-  my $log_name = $file . ".agat.log";
-  open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
-  dual_print($log, $header, 0);
-}
+my $log_name = get_log_path($common, $config);
+open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+dual_print($log, $header, 0);
 
 # Manage Output
 my $ostream = prepare_fileout($outputFile);

--- a/bin/agat_sq_stat_basic.pl
+++ b/bin/agat_sq_stat_basic.pl
@@ -51,12 +51,9 @@ if (! @inputFile ){
 $config = get_agat_config({config_file_in => $config});
 
 my $log;
-if ($config->{log}) {
-  my ($file) = $0 =~ /([^\/]+)$/;
-  my $log_name = $file . ".agat.log";
-  open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
-  dual_print($log, $header, 0);
-}
+my $log_name = get_log_path($common, $config);
+open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
+dual_print($log, $header, 0);
 
 # Manage Output
 my $ostream = prepare_fileout($outputFile);

--- a/lib/AGAT/AGAT.pm
+++ b/lib/AGAT/AGAT.pm
@@ -20,7 +20,7 @@ use Getopt::Long;
 our $VERSION     = "v1.5.1";
 our $CONFIG; # This variable will be used to store the config and will be available from everywhere.
 our @ISA         = qw( Exporter );
-our @EXPORT      = qw( get_agat_header print_agat_version get_agat_config handle_levels parse_common_options );
+our @EXPORT      = qw( get_agat_header print_agat_version get_agat_config handle_levels parse_common_options get_log_path );
 sub import {
     AGAT::AGAT->export_to_level(1, @_); # to be able to load the EXPORT functions when direct call; (normal case)
     AGAT::OmniscientI->export_to_level(1, @_);
@@ -156,7 +156,8 @@ sub parse_common_options {
         $parser->getoptionsfromarray(
                 $argv, \%options,
                 'config|c=s',
-                'output|out|o=s',
+                'output|outfile|out|o=s',
+                'log=s',
                 'verbose|v!',
                 'debug|d!',
                 'help|h'
@@ -164,6 +165,16 @@ sub parse_common_options {
           or return;
         $options{argv} = \@original;
         return \%options;
+}
+
+sub get_log_path {
+        my ($common, $config) = @_;
+        $common ||= {};
+        $config ||= {};
+        return $common->{log} || $config->{log_path} || do {
+                my ($file) = $0 =~ /([^\\\/]+)$/;
+                $file . ".agat.log";
+        };
 }
 
 # load configuration file from local file if any either the one shipped with AGAT

--- a/lib/AGAT/Config.pm
+++ b/lib/AGAT/Config.pm
@@ -174,10 +174,14 @@ sub check_config{
 		print "progress_bar parameter missing in the configuration file.\n";
 		$error = 1;
 	}
-	if( !  exists_keys($config,("log") ) ){
-		print "log parameter missing in the configuration file.\n";
-		$error = 1;
-	}
+        if( !  exists_keys($config,("log") ) ){
+                print "log parameter missing in the configuration file.\n";
+                $error = 1;
+        }
+        if( !  exists_keys($config,("log_path") ) ){
+                print "log_path parameter missing in the configuration file.\n";
+                $error = 1;
+        }
 	if( !  exists_keys($config, ("debug") ) ){
 		print "debug parameter missing in the configuration file.\n";
 		$error = 1;

--- a/share/agat_config.yaml
+++ b/share/agat_config.yaml
@@ -31,6 +31,7 @@ progress_bar: true
 # Create a log file while parsing the input file to keep track of modification
 # made by AGAT
 log: true
+log_path: "" # by default: <input>.agat.log
 
 # Extra verbosity for debugging
 debug: false

--- a/t/config/out/agat_config.yaml
+++ b/t/config/out/agat_config.yaml
@@ -20,6 +20,7 @@ locus_tag:
   - test1
   - test2
 log: false
+log_path: ''
 merge_loci: true
 output_format: gtf
 prefix_new_id: nbisTEST

--- a/t/parse_common_options.t
+++ b/t/parse_common_options.t
@@ -6,7 +6,8 @@ use AGAT::AGAT;
 
 {
     my @args = (
-        '--config', 'foo.yaml', '--output', 'bar',
+        '--config', 'foo.yaml', '--outfile', 'bar',
+        '--log', 'baz.log',
         '--verbose', '--debug', '--help', '--extra', 'val'
     );
     local @ARGV = @args;
@@ -14,7 +15,7 @@ use AGAT::AGAT;
     my $orig = delete $opts->{argv};
     is_deeply(
         $opts,
-        { config => 'foo.yaml', output => 'bar', verbose => 1, debug => 1, help => 1 },
+        { config => 'foo.yaml', output => 'bar', log => 'baz.log', verbose => 1, debug => 1, help => 1 },
         'parsed values'
     );
     is_deeply( \@ARGV, [ '--extra', 'val' ], 'remaining args preserved' );


### PR DESCRIPTION
## Summary
- use `parse_common_options` across scripts to standardize option handling
- centralize log setup with `get_log_path($common, $config)`
- accept `--outfile` alias in the common option parser
