### PR TITLE
ci: re-enable coverage job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,5 +90,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEVEL_COVER_OPTIONS: "+ignore,^local/"
-          HARNESS_OPTIONS: "j$(nproc)"
-        run: cover -test -report Coveralls
+        run: |
+          export HARNESS_OPTIONS=j$(nproc)
+          cover -test -report Coveralls

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,8 +55,7 @@ jobs:
   # This workflow contains a first job called "build"
   build_perl530:
     # avoid to run twice push and PR
-    if: false # temporarily
-    #if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
 
     # The type of runner that the job will run on
     runs-on: ubuntu-22.04
@@ -72,7 +71,6 @@ jobs:
         run: sudo apt-get -y install r-base
         
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      # Use of Devel::Cover@1.44 because newer versions take in account all scripts (even those we just do a -h). It drops the coverage ~5%. I would improve testing before unpinning this version.
       - uses: actions/checkout@v2
       - name: Setup Perl
         uses: shogo82148/actions-setup-perl@v1
@@ -80,7 +78,7 @@ jobs:
             perl-version: '5.30'
             install-modules-with: cpanm
             install-modules-args: --notest --force
-            install-modules: File::ShareDir::Install Devel::Cover@1.44 Devel::Cover::Report::Coveralls
+            install-modules: File::ShareDir::Install Devel::Cover Devel::Cover::Report::Coveralls
       - uses: webiny/action-post-run@2.0.1
         id: post-run-command
         if: ${{ failure() }}
@@ -92,4 +90,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEVEL_COVER_OPTIONS: "+ignore,^local/"
+          HARNESS_OPTIONS: "j$(nproc)"
         run: cover -test -report Coveralls

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,6 +71,7 @@ jobs:
         run: sudo apt-get -y install r-base
         
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      # Use of Devel::Cover@1.44 because newer versions take in account all scripts (even those we just do a -h). It drops the coverage ~5%. I would improve testing before unpinning this version.
       - uses: actions/checkout@v2
       - name: Setup Perl
         uses: shogo82148/actions-setup-perl@v1
@@ -78,7 +79,7 @@ jobs:
             perl-version: '5.30'
             install-modules-with: cpanm
             install-modules-args: --notest --force
-            install-modules: File::ShareDir::Install Devel::Cover Devel::Cover::Report::Coveralls
+            install-modules: File::ShareDir::Install Devel::Cover@1.44 Devel::Cover::Report::Coveralls
       - uses: webiny/action-post-run@2.0.1
         id: post-run-command
         if: ${{ failure() }}


### PR DESCRIPTION
## Summary
- re-enable coverage workflow and drop old Devel::Cover pin
- parallelize test run via HARNESS_OPTIONS

## Testing
- `prove -lr t` *(fails: missing fixtures and config)*

------
https://chatgpt.com/codex/tasks/task_e_68a54762d244832ab0fb9afa9d98a5b1