### PR TITLE
cache apt install using awalsh128/cache-apt-pkgs-action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,16 +23,13 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - name: Cache apt packages
-        uses: actions/cache@v3
+      - name: Read apt packages
+        id: apt-packages
+        run: echo "list=$(tr '\n' ' ' < .github/workflows_config/apt-packages.txt)" >> "$GITHUB_OUTPUT"
+      - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          path: /var/cache/apt/archives
-          key: ${{ runner.os }}-apt-${{ hashFiles('.github/workflows_config/apt-packages.txt') }}
-          restore-keys: ${{ runner.os }}-apt-
-      - name: Install system packages
-        run: |
-          sudo apt-get update
-          sudo xargs -a .github/workflows_config/apt-packages.txt apt-get install -y
+          packages: ${{ steps.apt-packages.outputs.list }}
+          version: 1.0
         
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       #- name: Checkout AGAT
@@ -72,16 +69,13 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - name: Cache apt packages
-        uses: actions/cache@v3
+      - name: Read apt packages
+        id: apt-packages
+        run: echo "list=$(tr '\n' ' ' < .github/workflows_config/apt-packages.txt)" >> "$GITHUB_OUTPUT"
+      - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          path: /var/cache/apt/archives
-          key: ${{ runner.os }}-apt-${{ hashFiles('.github/workflows_config/apt-packages.txt') }}
-          restore-keys: ${{ runner.os }}-apt-
-      - name: Install system packages
-        run: |
-          sudo apt-get update
-          sudo xargs -a .github/workflows_config/apt-packages.txt apt-get install -y
+          packages: ${{ steps.apt-packages.outputs.list }}
+          version: 1.0
         
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       # Use of Devel::Cover@1.44 because newer versions take in account all scripts (even those we just do a -h). It drops the coverage ~5%. I would improve testing before unpinning this version.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,12 +23,9 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - name: Read apt packages
-        id: apt-packages
-        run: echo "list=$(tr '\n' ' ' < .github/workflows_config/apt-packages.txt)" >> "$GITHUB_OUTPUT"
       - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: ${{ steps.apt-packages.outputs.list }}
+          packages: libdb-dev r-base
           version: 1.0
         
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -69,12 +66,9 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - name: Read apt packages
-        id: apt-packages
-        run: echo "list=$(tr '\n' ' ' < .github/workflows_config/apt-packages.txt)" >> "$GITHUB_OUTPUT"
       - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: ${{ steps.apt-packages.outputs.list }}
+          packages: libdb-dev r-base
           version: 1.0
         
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,10 +23,16 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - name: Install libdb-dev
-        run: sudo apt-get -y install libdb-dev
-      - name: Install R
-        run: sudo apt-get -y install r-base
+      - name: Cache apt packages
+        uses: actions/cache@v3
+        with:
+          path: /var/cache/apt/archives
+          key: ${{ runner.os }}-apt-${{ hashFiles('.github/workflows_config/apt-packages.txt') }}
+          restore-keys: ${{ runner.os }}-apt-
+      - name: Install system packages
+        run: |
+          sudo apt-get update
+          sudo xargs -a .github/workflows_config/apt-packages.txt apt-get install -y
         
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       #- name: Checkout AGAT
@@ -66,10 +72,16 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - name: Install libdb-dev
-        run: sudo apt-get -y install libdb-dev
-      - name: Install R
-        run: sudo apt-get -y install r-base
+      - name: Cache apt packages
+        uses: actions/cache@v3
+        with:
+          path: /var/cache/apt/archives
+          key: ${{ runner.os }}-apt-${{ hashFiles('.github/workflows_config/apt-packages.txt') }}
+          restore-keys: ${{ runner.os }}-apt-
+      - name: Install system packages
+        run: |
+          sudo apt-get update
+          sudo xargs -a .github/workflows_config/apt-packages.txt apt-get install -y
         
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       # Use of Devel::Cover@1.44 because newer versions take in account all scripts (even those we just do a -h). It drops the coverage ~5%. I would improve testing before unpinning this version.

--- a/.github/workflows_config/apt-packages.txt
+++ b/.github/workflows_config/apt-packages.txt
@@ -1,2 +1,0 @@
-libdb-dev
-r-base

--- a/.github/workflows_config/apt-packages.txt
+++ b/.github/workflows_config/apt-packages.txt
@@ -1,0 +1,2 @@
+libdb-dev
+r-base


### PR DESCRIPTION
## Summary
- use awalsh128/cache-apt-pkgs-action for cached apt-install of libdb and r-base