### PR TITLE
centralize AppEaser option resolution

### DIFF
--- a/bin/agat_sp_add_introns.pl
+++ b/bin/agat_sp_add_introns.pl
@@ -10,40 +10,32 @@ use Pod::Usage;
 use Clone 'clone';
 use AGAT::AGAT;
 
-my $header = get_agat_header();
-my $config;
+my $header  = get_agat_header();
+my $config  = resolve_common_options();
 my $intronID = 1;
 my $opt_file;
-my $opt_output=undef;
-my $opt_help = 0;
+my $opt_output = $config->{output};
+my $opt_help   = $config->{help};
 
-my @copyARGV=@ARGV;
-if ( !GetOptions( 'f|gff|ref|reffile=s' => \$opt_file,
-                  'o|out|output=s' => \$opt_output,
-                  'c|config=s'               => \$config,
-                  'h|help!'         => \$opt_help ) )
-{
-    pod2usage( { -message => 'Failed to parse command line',
-                 -verbose => 1,
-                 -exitval => 1 } );
+if ( !GetOptions('f|gff|ref|reffile=s' => \$opt_file) ) {
+    pod2usage({ -message => 'Failed to parse command line',
+                -verbose => 1,
+                -exitval => 1 });
 }
 
 # Print Help and exit
 if ($opt_help) {
-    pod2usage( { -verbose => 99,
-                 -exitval => 0,
-                 -message => "$header\n" } );
+    pod2usage({ -verbose => 99,
+                -exitval => 0,
+                -message => "$header\n" });
 }
 
-if ( ! defined( $opt_file) ) {
-    pod2usage( {
+if ( !defined $opt_file ) {
+    pod2usage({
            -message => "$header\nMust specify at least 1 parameters:\nReference data gff3 file (--gff)\n",
            -verbose => 0,
-           -exitval => 1 } );
+           -exitval => 1 });
 }
-
-# --- Manage config ---
-$config = get_agat_config({config_file_in => $config});
 
 # #######################
 # # START Manage Option #
@@ -67,7 +59,7 @@ my $gffout = prepare_gffout($config, $opt_output);
   ### Parse GFF input #
   my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $opt_file,
                                                                    config => $config });
-  print("Parsing Finished\n\n");
+  print("Parsing Finished\n\n") if $config->{verbose};
   ### END Parse GFF input #
   #########################
 
@@ -153,7 +145,7 @@ my $intron_added=0;
 
 print_omniscient( {omniscient => $hash_omniscient, output => $gffout} );
 
-print "$intron_added introns added\nBye Bye\n";
+print "$intron_added introns added\nBye Bye\n" if $config->{verbose};
       #########################
       ######### END ###########
       #########################
@@ -183,7 +175,7 @@ The script aims to add intron features to gtf/gff file without intron features.
 
 =head1 SYNOPSIS
 
-    agat_sp_add_introns.pl --gff infile --out outFile
+    agat_sp_add_introns.pl --gff infile --out outFile --verbose 0
     agat_sp_add_introns.pl --help
 
 =head1 OPTIONS
@@ -203,6 +195,10 @@ Output GFF3 file.
 String - Input agat config file. By default AGAT takes as input agat_config.yaml file from the working directory if any, 
 otherwise it takes the orignal agat_config.yaml shipped with AGAT. To get the agat_config.yaml locally type: "agat config --expose".
 The --config option gives you the possibility to use your own AGAT config file (located elsewhere or named differently).
+
+=item B<-v> or B<--verbose>
+
+Integer - Verbosity level (0-4). Command line overrides the config file. [Default 1]
 
 =item B<--help> or B<-h>
 

--- a/lib/AGAT/AGAT.pm
+++ b/lib/AGAT/AGAT.pm
@@ -159,7 +159,7 @@ sub parse_common_options {
                 'config|c=s',
                 'output|outfile|out|o=s',
                 'log=s',
-                'verbose|v!',
+                'verbose|v=i',
                 'debug|d!',
                 'help|h'
         )
@@ -188,7 +188,7 @@ sub resolve_common_options {
         my $config_file = delete $cli->{config};
         my $config = get_agat_config({ config_file_in => $config_file });
         for my $k (qw(verbose log debug)) {
-                $config{"//=${k}"} = delete $config->{$k} if exists $config->{$k};
+                $config->{"//=${k}"} = delete $config->{$k} if exists $config->{$k};
         }
         return AGAT::AppEaser::hash_merge($config, $cli);
 }

--- a/t/parse_common_options.t
+++ b/t/parse_common_options.t
@@ -8,7 +8,7 @@ use AGAT::AGAT;
     my @args = (
         '--config', 'foo.yaml', '--outfile', 'bar',
         '--log', 'baz.log',
-        '--verbose', '--debug', '--help', '--extra', 'val'
+        '--verbose', '1', '--debug', '--help', '--extra', 'val'
     );
     local @ARGV = @args;
     my $opts = parse_common_options();

--- a/t/resolve_common_options.t
+++ b/t/resolve_common_options.t
@@ -1,0 +1,36 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+use File::Temp qw(tempdir);
+use File::Copy qw(copy);
+use File::Spec;
+use AGAT::AGAT;
+
+# Use a temporary config file to test layering
+my $tmpdir = tempdir(CLEANUP => 1);
+my $config_path = File::Spec->catfile($tmpdir, 'agat_config.yaml');
+copy('share/agat_config.yaml', $config_path);
+
+# Ensure config file sets verbose to 2
+open my $fh, '<', $config_path or die $!;
+my @lines = <$fh>;
+close $fh;
+for (@lines) { s/^verbose: .*/verbose: 2/; }
+open $fh, '>', $config_path or die $!;
+print {$fh} @lines;
+close $fh;
+
+{
+    local @ARGV = ('--config', $config_path);
+    my $cfg = resolve_common_options();
+    is($cfg->{verbose}, 2, 'config file value used');
+}
+
+{
+    local @ARGV = ('--config', $config_path, '--verbose', '0');
+    my $cfg = resolve_common_options();
+    is($cfg->{verbose}, 0, 'command line overrides config');
+}
+
+done_testing;


### PR DESCRIPTION
## Summary
- expose new `resolve_common_options` to merge CLI flags with config defaults via AppEaser
- use `resolve_common_options` in `agat_sp_add_introns.pl` so scripts retrieve layered settings in one call
- add regression test covering command-line precedence over config
