### PR TITLE
ci: restrict coverage to library

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,7 +90,7 @@ jobs:
       - name: test
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DEVEL_COVER_OPTIONS: "+ignore,^local/"
+          DEVEL_COVER_OPTIONS: "+select,^lib/ +ignore,^bin/ +ignore,^local/"
         run: |
           export HARNESS_OPTIONS=j$(nproc)
           cover -test -report Coveralls


### PR DESCRIPTION
## Summary
- confine Devel::Cover to library code while excluding bin and local directories

## Testing
- `python - <<'PY'
import yaml,sys
with open('.github/workflows/main.yml') as f:
    yaml.safe_load(f)
print('YAML OK')
PY`
- `.agents/with-perl-local.sh prove -lr t` *(fails: Can't locate Test/TempDir::Tiny.pm)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f06d3c4c832abc5e035369b8e3e2