### PR TITLE
chore: cache CPAN modules in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,7 @@ jobs:
       #- name: Checkout AGAT
       - uses: actions/checkout@v2
       - name: Setup Perl
+        id: setup-perl
         uses: shogo82148/actions-setup-perl@v1
         with:
             perl-version: '5.36'
@@ -43,6 +44,15 @@ jobs:
         if: ${{ failure() }}
         with:
           run: cat /home/runner/.cpanm/build.log
+      - name: Cache Perl modules
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cpanm
+            ~/perl5
+          key: ${{ runner.os }}-perl-${{ steps.setup-perl.outputs['perl-version'] }}-${{ hashFiles('cpanfile','Makefile.PL') }}
+          restore-keys: |
+            ${{ runner.os }}-perl-${{ steps.setup-perl.outputs['perl-version'] }}-
       - name: install AGAT deps
         run: cpanm --installdeps --notest --force .
       - name: test
@@ -74,6 +84,7 @@ jobs:
       # Use of Devel::Cover@1.44 because newer versions take in account all scripts (even those we just do a -h). It drops the coverage ~5%. I would improve testing before unpinning this version.
       - uses: actions/checkout@v2
       - name: Setup Perl
+        id: setup-perl
         uses: shogo82148/actions-setup-perl@v1
         with:
             perl-version: '5.30'
@@ -85,6 +96,15 @@ jobs:
         if: ${{ failure() }}
         with:
           run: cat /home/runner/.cpanm/build.log
+      - name: Cache Perl modules
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cpanm
+            ~/perl5
+          key: ${{ runner.os }}-perl-${{ steps.setup-perl.outputs['perl-version'] }}-${{ hashFiles('cpanfile','Makefile.PL') }}
+          restore-keys: |
+            ${{ runner.os }}-perl-${{ steps.setup-perl.outputs['perl-version'] }}-
       - name: install AGAT deps
         run: cpanm --installdeps --notest --force .
       - name: test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@
 
 name: CI
 
-# Controls when the action will run. 
+# Controls when the action will run.
 # Triggers the workflow on push or pull request events
 on: [push, pull_request, workflow_dispatch]
 
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
-jobs:  
+jobs:
 
   # This workflow contains a second job called "build2"
   build_perl536:
@@ -21,21 +21,33 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-22.04
 
+    env:
+      PERL_VERSION: '5.36'
+
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: libdb-dev r-base
           version: 1.0
-        
+
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       #- name: Checkout AGAT
       - uses: actions/checkout@v2
+      - name: Cache Perl modules
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cpanm
+            ~/perl5
+          key: ${{ runner.os }}-perl-${{ env.PERL_VERSION }}-${{ hashFiles('cpanfile','Makefile.PL') }}
+          restore-keys: |
+            ${{ runner.os }}-perl-${{ env.PERL_VERSION }}-
       - name: Setup Perl
         id: setup-perl
         uses: shogo82148/actions-setup-perl@v1
         with:
-            perl-version: '5.36'
+            perl-version: ${{ env.PERL_VERSION }}
             install-modules-with: cpanm
             install-modules-args: --notest --force
             install-modules: File::ShareDir::Install
@@ -44,15 +56,6 @@ jobs:
         if: ${{ failure() }}
         with:
           run: cat /home/runner/.cpanm/build.log
-      - name: Cache Perl modules
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cpanm
-            ~/perl5
-          key: ${{ runner.os }}-perl-${{ steps.setup-perl.outputs['perl-version'] }}-${{ hashFiles('cpanfile','Makefile.PL') }}
-          restore-keys: |
-            ${{ runner.os }}-perl-${{ steps.setup-perl.outputs['perl-version'] }}-
       - name: install AGAT deps
         run: cpanm --installdeps --notest --force .
       - name: test
@@ -73,21 +76,33 @@ jobs:
     #container:
     #  image: perl:5.30
 
+    env:
+      PERL_VERSION: '5.30'
+
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: libdb-dev r-base
           version: 1.0
-        
+
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       # Use of Devel::Cover@1.44 because newer versions take in account all scripts (even those we just do a -h). It drops the coverage ~5%. I would improve testing before unpinning this version.
       - uses: actions/checkout@v2
+      - name: Cache Perl modules
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cpanm
+            ~/perl5
+          key: ${{ runner.os }}-perl-${{ env.PERL_VERSION }}-${{ hashFiles('cpanfile','Makefile.PL') }}
+          restore-keys: |
+            ${{ runner.os }}-perl-${{ env.PERL_VERSION }}-
       - name: Setup Perl
         id: setup-perl
         uses: shogo82148/actions-setup-perl@v1
         with:
-            perl-version: '5.30'
+            perl-version: ${{ env.PERL_VERSION }}
             install-modules-with: cpanm
             install-modules-args: --notest --force
             install-modules: File::ShareDir::Install Devel::Cover@1.44 Devel::Cover::Report::Coveralls
@@ -96,15 +111,6 @@ jobs:
         if: ${{ failure() }}
         with:
           run: cat /home/runner/.cpanm/build.log
-      - name: Cache Perl modules
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cpanm
-            ~/perl5
-          key: ${{ runner.os }}-perl-${{ steps.setup-perl.outputs['perl-version'] }}-${{ hashFiles('cpanfile','Makefile.PL') }}
-          restore-keys: |
-            ${{ runner.os }}-perl-${{ steps.setup-perl.outputs['perl-version'] }}-
       - name: install AGAT deps
         run: cpanm --installdeps --notest --force .
       - name: test


### PR DESCRIPTION
## Summary
- cache CPAN installations for Perl 5.36 and 5.30 GitHub Actions jobs to speed up builds

## Testing
- `make test` *(skipped: CI config only)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f064af10832a8ac0b27603410d41