### PR TITLE
Silence test script output and verify

### DIFF
--- a/t/agat_convert_bed2gff.t
+++ b/t/agat_convert_bed2gff.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -25,7 +25,7 @@ my $result = "$output_folder/agat_convert_bed2gff_1.gff";
 {
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
-    system(" $script --bed $input_folder/test.bed -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --bed $input_folder/test.bed -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/agat_convert_embl2gff.t
+++ b/t/agat_convert_embl2gff.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -25,7 +25,7 @@ my $result = "$output_folder/agat_convert_embl2gff_1.gff";
 {
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
-    system(" $script --embl $input_folder/agat_convert_embl2gff_1.embl -o $outtmp --emblmygff3 2>&1 1>/dev/null");
+    check_quiet_run(" $script --embl $input_folder/agat_convert_embl2gff_1.embl -o $outtmp --emblmygff3");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/agat_convert_genscan2gff.t
+++ b/t/agat_convert_genscan2gff.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -25,7 +25,7 @@ my $result = "$output_folder/agat_convert_genscan2gff_1.gff";
 {
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
-    system(" $script --genscan $input_folder/test.genscan -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --genscan $input_folder/test.genscan -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/agat_convert_mfannot2gff.t
+++ b/t/agat_convert_mfannot2gff.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_convert_mfannot2gff_1.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --mfannot $input_folder/test.mfannot -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --mfannot $input_folder/test.mfannot -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 
@@ -37,7 +37,7 @@ $result = "$output_folder/agat_convert_mfannot2gff_2.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --mfannot $input_folder/test.mfannot2 -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --mfannot $input_folder/test.mfannot2 -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/agat_convert_minimap2_bam2gff.t
+++ b/t/agat_convert_minimap2_bam2gff.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -25,7 +25,7 @@ my $result = "$output_folder/agat_convert_minimap2_bam2gff_1.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script -i $input_folder/test_minimap2.sam -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script -i $input_folder/test_minimap2.sam -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/agat_convert_sp_gff2bed.t
+++ b/t/agat_convert_sp_gff2bed.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_convert_sp_gff2bed_1.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/1.gff -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/agat_convert_sp_gff2gtf.t
+++ b/t/agat_convert_sp_gff2gtf.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -27,7 +27,7 @@ my $result = "$convert_sp_gff2gtf_folder/agat_convert_sp_gff2gtf_1.gtf";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/1.gff --gtf_version 3 -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/1.gff --gtf_version 3 -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 
@@ -37,7 +37,7 @@ $result = "$convert_sp_gff2gtf_folder/agat_convert_sp_gff2gtf_2.gtf";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $convert_sp_gff2gtf_folder/stop_start_an_exon.gff --gtf_version 3 -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $convert_sp_gff2gtf_folder/stop_start_an_exon.gff --gtf_version 3 -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 
@@ -47,7 +47,7 @@ $result = "$convert_sp_gff2gtf_folder/agat_convert_sp_gff2gtf_3.gtf";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $convert_sp_gff2gtf_folder/stop_split_over_two_exons.gff --gtf_version 3 -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $convert_sp_gff2gtf_folder/stop_split_over_two_exons.gff --gtf_version 3 -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 
@@ -57,7 +57,7 @@ $result = "$convert_sp_gff2gtf_folder/result_issue_245.gtf";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $convert_sp_gff2gtf_folder/issue_245.gff --gtf_version 3 -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $convert_sp_gff2gtf_folder/issue_245.gff --gtf_version 3 -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/agat_convert_sp_gff2zff.t
+++ b/t/agat_convert_sp_gff2zff.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_convert_sp_gff2zff_1.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/1.gff --fasta $input_folder/1.fa -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/1.gff --fasta $input_folder/1.fa -o $outtmp");
     check_diff( "$outprefix.ann", $result, "output $script" );
 }
 

--- a/t/agat_sp_add_attribute_shortest_exon_size.t
+++ b/t/agat_sp_add_attribute_shortest_exon_size.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_sp_add_attribute_shortest_exon_size.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/1.gff -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/agat_sp_add_attribute_shortest_intron_size.t
+++ b/t/agat_sp_add_attribute_shortest_intron_size.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_sp_add_attribute_shortest_intron_size.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/1.gff -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/agat_sp_add_intergenic_regions.t
+++ b/t/agat_sp_add_intergenic_regions.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_sp_add_intergenic_regions_1.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/1.gff -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/agat_sp_add_introns.t
+++ b/t/agat_sp_add_introns.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_sp_add_introns_1.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/1.gff -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/agat_sp_add_splice_sites.t
+++ b/t/agat_sp_add_splice_sites.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_sp_add_splice_sites_1.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/0.gff -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/0.gff -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/agat_sp_add_start_and_stop.t
+++ b/t/agat_sp_add_start_and_stop.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_sp_add_start_and_stop_1.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/agat_sp_add_start_and_stop.gff --fasta $input_folder/1.fa --ni -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/agat_sp_add_start_and_stop.gff --fasta $input_folder/1.fa --ni -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 
@@ -37,7 +37,7 @@ $result = "$output_folder/agat_sp_add_start_and_stop_2.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/agat_sp_add_start_and_stop.gff --fasta $input_folder/1.fa -e --ni -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/agat_sp_add_start_and_stop.gff --fasta $input_folder/1.fa -e --ni -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/agat_sp_compare_two_annotations.t
+++ b/t/agat_sp_compare_two_annotations.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -24,7 +24,7 @@ my $result = "$output_folder/agat_sp_compare_two_annotations_1.txt";
 {
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
-    system(" $script --gff1 $input_folder/1.gff  --gff2 $input_folder/1.gff -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff1 $input_folder/1.gff  --gff2 $input_folder/1.gff -o $outtmp");
     check_diff( "$outtmp/report.txt", $result, "output $script", "-I '^usage:'" );
 }
 
@@ -34,7 +34,7 @@ $result = "$output_folder/agat_sp_compare_two_annotations_2.txt";
 {
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
-    system(" $script --gff1 $input_folder/agat_sp_compare_two_annotations/file1.gff  --gff2 $input_folder/agat_sp_compare_two_annotations/file2.gff -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff1 $input_folder/agat_sp_compare_two_annotations/file1.gff  --gff2 $input_folder/agat_sp_compare_two_annotations/file2.gff -o $outtmp");
     check_diff( "$outtmp/report.txt", $result, "output $script", "-I '^usage:'" );
 }
 
@@ -44,7 +44,7 @@ $result = "$output_folder/agat_sp_compare_two_annotations_3.txt";
 {
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
-    system(" $script --gff1 $input_folder/agat_sp_compare_two_annotations/file2.gff  --gff2 $input_folder/agat_sp_compare_two_annotations/file1.gff -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff1 $input_folder/agat_sp_compare_two_annotations/file2.gff  --gff2 $input_folder/agat_sp_compare_two_annotations/file1.gff -o $outtmp");
     check_diff( "$outtmp/report.txt", $result, "output $script", "-I '^usage:'" );
 }
 

--- a/t/agat_sp_complement_annotations.t
+++ b/t/agat_sp_complement_annotations.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -25,12 +25,12 @@ my $result = "$output_folder/agat_sp_complement_annotations_1.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(
+    check_quiet_run(
         " $script --ref "
           . catfile( $Bin, 'gff', 'gff_syntax', 'in', '25_test.gff' )
           . "  --add "
           . catfile( $Bin, 'gff', 'gff_syntax', 'in', '9_test.gff' )
-          . " -o $outtmp 2>&1 1>/dev/null"
+          . " -o $outtmp"
     );
     check_diff( $outtmp, $result, "output $script" );
 }
@@ -41,7 +41,7 @@ $result = "$output_folder/agat_sp_complement_annotations_2.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --ref $input_folder/agat_sp_complement_annotations/agat_sp_complement_annotations_ref.gff  --add $input_folder/agat_sp_complement_annotations/agat_sp_complement_annotations_add.gff -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --ref $input_folder/agat_sp_complement_annotations/agat_sp_complement_annotations_ref.gff  --add $input_folder/agat_sp_complement_annotations/agat_sp_complement_annotations_add.gff -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/agat_sp_ensembl_output_style.t
+++ b/t/agat_sp_ensembl_output_style.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_sp_ensembl_output_style_1.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system("$script --gff $input_folder/0.gff -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run("$script --gff $input_folder/0.gff -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/agat_sp_extract_attributes.t
+++ b/t/agat_sp_extract_attributes.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_sp_extract_attributes_1.txt";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/1.gff --att protein_id -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/1.gff --att protein_id -o $outtmp");
     check_diff( "${outprefix}_protein_id.gff", $result, "output $script" );
 }
 

--- a/t/agat_sp_extract_sequences.t
+++ b/t/agat_sp_extract_sequences.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$input_folder/agat_sp_extract_sequences/agat_sp_extract_sequences_
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/1.gff --fasta $input_folder/1.fa -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/1.gff --fasta $input_folder/1.fa -o $outtmp");
     check_diff( $outtmp, $result, "output $script test1" );
 }
 
@@ -37,7 +37,7 @@ $result = "$input_folder/agat_sp_extract_sequences/agat_sp_extract_sequences_spl
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/1.gff --fasta $input_folder/1.fa --split -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/1.gff --fasta $input_folder/1.fa --split -o $outtmp");
     check_diff( $outtmp, $result, "output $script test2" );
 }
 
@@ -48,7 +48,7 @@ $result = "$input_folder/agat_sp_extract_sequences/agat_sp_extract_sequences_mer
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/1.gff --fasta $input_folder/1.fa -t exon --merge -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/1.gff --fasta $input_folder/1.fa -t exon --merge -o $outtmp");
     check_diff( $outtmp, $result, "output $script test3" );
 }
 
@@ -59,7 +59,7 @@ $result = "$input_folder/agat_sp_extract_sequences/agat_sp_extract_sequences_ful
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/1.gff --fasta $input_folder/1.fa --full -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/1.gff --fasta $input_folder/1.fa --full -o $outtmp");
     check_diff( $outtmp, $result, "output $script test4" );
 }
 
@@ -70,7 +70,7 @@ $result = "$input_folder/agat_sp_extract_sequences/agat_sp_extract_sequences_att
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/1.gff --fasta $input_folder/1.fa --keep_attributes -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/1.gff --fasta $input_folder/1.fa --keep_attributes -o $outtmp");
     check_diff( $outtmp, $result, "output $script test5" );
 }
 
@@ -81,7 +81,7 @@ $result = "$input_folder/agat_sp_extract_sequences/agat_sp_extract_sequences_par
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/1.gff --fasta $input_folder/1.fa --keep_parent_attributes -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/1.gff --fasta $input_folder/1.fa --keep_parent_attributes -o $outtmp");
     check_diff( $outtmp, $result, "output $script test6" );
 }
 

--- a/t/agat_sp_filter_by_ORF_size.t
+++ b/t/agat_sp_filter_by_ORF_size.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -25,7 +25,7 @@ my $result = "$output_folder/agat_sp_filter_by_ORF_size_sup100.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/1.gff -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp");
     check_diff( "${outprefix}_sup100.gff", $result, "output $script" );
 }
 

--- a/t/agat_sp_filter_by_locus_distance.t
+++ b/t/agat_sp_filter_by_locus_distance.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -25,7 +25,7 @@ my $result = "$output_folder/agat_sp_filter_by_locus_distance_1.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/1.gff -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/agat_sp_filter_feature_by_attribute_presence.t
+++ b/t/agat_sp_filter_feature_by_attribute_presence.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -25,7 +25,7 @@ my $result = "$output_folder/agat_sp_filter_feature_by_attribute_presence_1.gff"
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/1.gff -o $outtmp -a protein_id 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp -a protein_id");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/agat_sp_filter_feature_by_attribute_value.t
+++ b/t/agat_sp_filter_feature_by_attribute_value.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_sp_filter_feature_by_attribute_value_1.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/1.gff -o $outtmp --value Os01t0100100-01 -p level3 -a protein_id 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp --value Os01t0100100-01 -p level3 -a protein_id");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/agat_sp_filter_feature_from_keep_list.t
+++ b/t/agat_sp_filter_feature_from_keep_list.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_sp_filter_feature_from_keep_list_1.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/1.gff -o $outtmp --kl $input_folder/keep_list.txt 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp --kl $input_folder/keep_list.txt");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/agat_sp_filter_feature_from_kill_list.t
+++ b/t/agat_sp_filter_feature_from_kill_list.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_sp_filter_feature_from_kill_list_1.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/1.gff -o $outtmp --kl $input_folder/kill_list.txt 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp --kl $input_folder/kill_list.txt");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/agat_sp_filter_gene_by_intron_numbers.t
+++ b/t/agat_sp_filter_gene_by_intron_numbers.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_sp_filter_gene_by_intron_numbers_1.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/1.gff -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/agat_sp_filter_gene_by_length.t
+++ b/t/agat_sp_filter_gene_by_length.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_sp_filter_gene_by_length_1.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/1.gff --size 1000 --test \"<\" -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/1.gff --size 1000 --test \"<\" -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/agat_sp_filter_incomplete_gene_coding_models.t
+++ b/t/agat_sp_filter_incomplete_gene_coding_models.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -27,7 +27,7 @@ my $result2 = "$output_folder/agat_sp_filter_incomplete_gene_coding_models_incom
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/1.gff --fasta $input_folder/1.fa -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/1.gff --fasta $input_folder/1.fa -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
     check_diff( $outprefix . "_incomplete.gff", $result2, "output $script" );
 }

--- a/t/agat_sp_filter_record_by_coordinates.t
+++ b/t/agat_sp_filter_record_by_coordinates.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_sp_filter_record_by_coordinates_1.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/1.gff --tsv $input_folder/coordinates.tsv -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/1.gff --tsv $input_folder/coordinates.tsv -o $outtmp");
     check_diff( "$outtmp/remaining.gff3", $result, "output $script" );
 }
 

--- a/t/agat_sp_fix_cds_phases.t
+++ b/t/agat_sp_fix_cds_phases.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_sp_fix_cds_phases_1.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/1.gff --fasta $input_folder/1.fa -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/1.gff --fasta $input_folder/1.fa -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/agat_sp_fix_features_locations_duplicated.t
+++ b/t/agat_sp_fix_features_locations_duplicated.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -27,7 +27,7 @@ my $result = "$output_folder/agat_sp_fix_features_locations_duplicated_1.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/agat_sp_fix_features_locations_duplicated/test.gff -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/agat_sp_fix_features_locations_duplicated/test.gff -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/agat_sp_fix_fusion.t
+++ b/t/agat_sp_fix_fusion.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_sp_fix_fusion_1.txt";
     my $dir = setup_tempdir();
     my $outtmp    = catfile( $dir, 'tmp.gff' );
     my $outprefix = catfile( $dir, 'tmp' );
-    system(" $script --gff $input_folder/1.gff --fasta $input_folder/1.fa -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/1.gff --fasta $input_folder/1.fa -o $outtmp");
     check_diff( "$outprefix-report.txt", $result, "output $script", "-b -I '^Job done in' -I '^usage:'" );
 }
 

--- a/t/agat_sp_fix_longest_ORF.t
+++ b/t/agat_sp_fix_longest_ORF.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_sp_fix_longest_ORF_1.txt";
     my $dir = setup_tempdir();
     my $outtmp    = catfile( $dir, 'tmp.gff' );
     my $outprefix = catfile( $dir, 'tmp' );
-    system(" $script --gff $input_folder/1.gff --fasta $input_folder/1.fa -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/1.gff --fasta $input_folder/1.fa -o $outtmp");
     check_diff( "$outprefix-report.txt", $result, "output $script", "-b -I '^Job done in' -I '^usage:'" );
 }
 

--- a/t/agat_sp_fix_overlaping_genes.t
+++ b/t/agat_sp_fix_overlaping_genes.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_sp_fix_overlaping_genes_1.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/genes_overlap.gff -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/genes_overlap.gff -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 
@@ -37,7 +37,7 @@ $result = "$output_folder/agat_sp_fix_overlaping_genes_2.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/genes_overlap.gff -o $outtmp --merge 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/genes_overlap.gff -o $outtmp --merge");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/agat_sp_flag_premature_stop_codons.t
+++ b/t/agat_sp_flag_premature_stop_codons.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_sp_flag_premature_stop_codons_1.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/prokka_fragmented_genes.gff --fasta $input_folder/prokka_cav_10DC88.fa -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/prokka_fragmented_genes.gff --fasta $input_folder/prokka_cav_10DC88.fa -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/agat_sp_flag_short_introns.t
+++ b/t/agat_sp_flag_short_introns.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_sp_flag_short_introns_1.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/agat_sp_flag_short_introns.gff -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/agat_sp_flag_short_introns.gff -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/agat_sp_flag_short_introns_ebi.t
+++ b/t/agat_sp_flag_short_introns_ebi.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_sp_flag_short_introns_ebi_1.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/agat_sp_flag_short_introns_ebi.gff -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/agat_sp_flag_short_introns_ebi.gff -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/agat_sp_functional_statistics.t
+++ b/t/agat_sp_functional_statistics.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_sp_functional_statistics_1.txt";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/function.gff -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/function.gff -o $outtmp");
     check_diff( "$outtmp/gene\@mrna/table_per_feature_type.txt", "$output_folder/agat_sp_functional_statistics/table_gene_mrna.txt", "output $script" );
     check_diff( "$outtmp/repeat_region/table_per_feature_type.txt", "$output_folder/agat_sp_functional_statistics/table_repeat.txt", "output $script" );
 }

--- a/t/agat_sp_keep_longest_isoform.t
+++ b/t/agat_sp_keep_longest_isoform.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_sp_keep_longest_isoform_1.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/1.gff -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 
@@ -36,7 +36,7 @@ $result = "$output_folder/agat_sp_keep_longest_isoform_2.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/agat_sp_keep_longest_isoform_2.gff -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/agat_sp_keep_longest_isoform_2.gff -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/agat_sp_kraken_assess_liftover.t
+++ b/t/agat_sp_kraken_assess_liftover.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_sp_kraken_assess_liftover_1.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gtf $input_folder/test_kraken.gtf -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gtf $input_folder/test_kraken.gtf -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/agat_sp_list_short_introns.t
+++ b/t/agat_sp_list_short_introns.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_sp_list_short_introns_1.txt";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/1.gff -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/agat_sp_manage_IDs.t
+++ b/t/agat_sp_manage_IDs.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -24,7 +24,7 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sp_manage_IDs.pl");
 {
     my $dir = setup_tempdir();
     my $outtmp = catfile( $dir, 'tmp.gff' );
-    ok( system(" $script --gff $input_folder/1.gff --ensembl -o $outtmp 2>&1 1>/dev/null") == 0,
+    ok( check_quiet_run(" $script --gff $input_folder/1.gff --ensembl -o $outtmp") == 0,
         "output $script" );
 }
 

--- a/t/agat_sp_manage_UTRs.t
+++ b/t/agat_sp_manage_UTRs.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_sp_manage_UTRs_1.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/1.gff -b -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/1.gff -b -o $outtmp");
     check_diff( "$outprefix/1_bothSides_under5.gff", $result, "output $script" );
 }
 

--- a/t/agat_sp_manage_attributes.t
+++ b/t/agat_sp_manage_attributes.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_sp_manage_attributes_1.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/1.gff --att protein_id -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/1.gff --att protein_id -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/agat_sp_manage_functional_annotation.t
+++ b/t/agat_sp_manage_functional_annotation.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_sp_manage_functional_annotation_1.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/agat_sp_manage_functional_annotation/02413F.gff --db $input_folder/agat_sp_manage_functional_annotation/uniprot_sprot_test.fasta -b $input_folder/agat_sp_manage_functional_annotation/02413F_blast.out -i $input_folder/agat_sp_manage_functional_annotation/02413F_interpro.tsv --clean_name -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/agat_sp_manage_functional_annotation/02413F.gff --db $input_folder/agat_sp_manage_functional_annotation/uniprot_sprot_test.fasta -b $input_folder/agat_sp_manage_functional_annotation/02413F_blast.out -i $input_folder/agat_sp_manage_functional_annotation/02413F_interpro.tsv --clean_name -o $outtmp");
     check_diff( "$outtmp/02413F.gff", $result, "output $script" );
 }
 

--- a/t/agat_sp_manage_introns.t
+++ b/t/agat_sp_manage_introns.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_sp_manage_introns_1.txt";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/1.gff -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp");
     check_diff( "$outtmp/report.txt", $result, "output $script", "-b -I '^usage:'" );
 }
 

--- a/t/agat_sp_merge_annotations.t
+++ b/t/agat_sp_merge_annotations.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_sp_merge_annotations_1.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/agat_sp_merge_annotations/file1.gff  --gff $input_folder/agat_sp_merge_annotations/file2.gff -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/agat_sp_merge_annotations/file1.gff  --gff $input_folder/agat_sp_merge_annotations/file2.gff -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 
@@ -36,7 +36,7 @@ $result = "$output_folder/agat_sp_merge_annotations_2.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/agat_sp_merge_annotations/fileA.gff  --gff $input_folder/agat_sp_merge_annotations/fileB.gff -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/agat_sp_merge_annotations/fileA.gff  --gff $input_folder/agat_sp_merge_annotations/fileB.gff -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 
@@ -46,7 +46,7 @@ $result = "$output_folder/agat_sp_merge_annotations_3.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/agat_sp_merge_annotations/test457_A.gff  --gff $input_folder/agat_sp_merge_annotations/test457_B.gff -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/agat_sp_merge_annotations/test457_A.gff  --gff $input_folder/agat_sp_merge_annotations/test457_B.gff -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/agat_sp_move_attributes_within_records.t
+++ b/t/agat_sp_move_attributes_within_records.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_sp_move_attributes_within_records.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/agat_sp_move_attributes_within_records.gff --fp exon,CDS --fc mRNA -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/agat_sp_move_attributes_within_records.gff --fp exon,CDS --fc mRNA -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/agat_sp_prokka_fix_fragmented_gene_annotations.t
+++ b/t/agat_sp_prokka_fix_fragmented_gene_annotations.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -27,7 +27,7 @@ my $result2 = "$output_folder/agat_sp_prokka_fix_fragmented_gene_annotations_1.f
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/prokka_cav_10DC88.gff --fasta $input_folder/prokka_cav_10DC88.fa --db $input_folder/prokka_bacteria_sprot.fa --skip_hamap --frags -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/prokka_cav_10DC88.gff --fasta $input_folder/prokka_cav_10DC88.fa --db $input_folder/prokka_bacteria_sprot.fa --skip_hamap --frags -o $outtmp");
     check_diff( "$outtmp/prokka_cav_10DC88.gff", $result, "output $script" );
     check_diff( "$outtmp/prokka_cav_10DC88.fa", $result2, "output $script" );
 }

--- a/t/agat_sp_sensitivity_specificity.t
+++ b/t/agat_sp_sensitivity_specificity.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -25,7 +25,7 @@ my $result = "$output_folder/agat_sp_sensitivity_specificity_1.txt";
 {
     my $dir = setup_tempdir();
     my $outtmp   = catfile( $dir, 'tmp.gff' );
-    system(" $script --gff1 $input_folder/1.gff --gff2 $input_folder/1.gff -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff1 $input_folder/1.gff --gff2 $input_folder/1.gff -o $outtmp");
     check_diff( $outtmp, $result, "output $script", "-I '^usage:'" );
 }
 
@@ -35,7 +35,7 @@ $result = "$output_folder/agat_sp_sensitivity_specificity_2.txt";
 {
     my $dir = setup_tempdir();
     my $outtmp   = catfile( $dir, 'tmp.gff' );
-    system(" $script --gff1 $input_folder/agat_sp_sensitivity_specificity/ref0.gff3 --gff2 $input_folder/agat_sp_sensitivity_specificity/query0.gff3 -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff1 $input_folder/agat_sp_sensitivity_specificity/ref0.gff3 --gff2 $input_folder/agat_sp_sensitivity_specificity/query0.gff3 -o $outtmp");
     check_diff( $outtmp, $result, "output $script", "-I '^usage:'" );
 }
 
@@ -45,7 +45,7 @@ $result = "$output_folder/agat_sp_sensitivity_specificity_3.txt";
 {
     my $dir = setup_tempdir();
     my $outtmp   = catfile( $dir, 'tmp.gff' );
-    system(" $script --gff1 $input_folder/agat_sp_sensitivity_specificity/ref1.gff3 --gff2 $input_folder/agat_sp_sensitivity_specificity/query1.gff3 -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff1 $input_folder/agat_sp_sensitivity_specificity/ref1.gff3 --gff2 $input_folder/agat_sp_sensitivity_specificity/query1.gff3 -o $outtmp");
     check_diff( $outtmp, $result, "output $script", "-I '^usage:'" );
 }
 
@@ -55,7 +55,7 @@ $result = "$output_folder/agat_sp_sensitivity_specificity_4.txt";
 {
     my $dir = setup_tempdir();
     my $outtmp   = catfile( $dir, 'tmp.gff' );
-    system(" $script --gff1 $input_folder/agat_sp_sensitivity_specificity/ref2.gff3 --gff2 $input_folder/agat_sp_sensitivity_specificity/query2.gff3 -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff1 $input_folder/agat_sp_sensitivity_specificity/ref2.gff3 --gff2 $input_folder/agat_sp_sensitivity_specificity/query2.gff3 -o $outtmp");
     check_diff( $outtmp, $result, "output $script", "-I '^usage:'" );
 }
 
@@ -65,7 +65,7 @@ $result = "$output_folder/agat_sp_sensitivity_specificity_5.txt";
 {
     my $dir = setup_tempdir();
     my $outtmp   = catfile( $dir, 'tmp.gff' );
-    system(" $script --gff1 $input_folder/agat_sp_sensitivity_specificity/ref3.gff3 --gff2 $input_folder/agat_sp_sensitivity_specificity/query3.gff3 -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff1 $input_folder/agat_sp_sensitivity_specificity/ref3.gff3 --gff2 $input_folder/agat_sp_sensitivity_specificity/query3.gff3 -o $outtmp");
     check_diff( $outtmp, $result, "output $script", "-I '^usage:'" );
 }
 

--- a/t/agat_sp_split_by_level2_feature.t
+++ b/t/agat_sp_split_by_level2_feature.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_sp_separate_by_record_type_1.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/1.gff -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp");
     check_diff( "$outtmp/trna.gff", $result, "output $script" );
 }
 

--- a/t/agat_sp_statistics.t
+++ b/t/agat_sp_statistics.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_sp_statistics_1.txt";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/1.gff -o $outtmp -r 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp -r");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/agat_sp_to_tabulated.t
+++ b/t/agat_sp_to_tabulated.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_convert_sp_gff2tsv_1.tsv";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/1.gff -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/agat_sp_webApollo_compliant.t
+++ b/t/agat_sp_webApollo_compliant.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_sp_webApollo_compliant_1.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/1.gff -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/agat_sq_add_attributes_from_tsv.t
+++ b/t/agat_sq_add_attributes_from_tsv.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_sq_add_attributes_from_tsv_1.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/agat_sq_add_attributes_from_tsv.gff --tsv $input_folder/agat_sq_add_attributes_from_tsv.tsv -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/agat_sq_add_attributes_from_tsv.gff --tsv $input_folder/agat_sq_add_attributes_from_tsv.tsv -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/agat_sq_add_hash_tag.t
+++ b/t/agat_sq_add_hash_tag.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_sq_add_hash_tag_1.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/1.gff -i 2 -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/1.gff -i 2 -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/agat_sq_add_locus_tag.t
+++ b/t/agat_sq_add_locus_tag.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_sq_add_locus_tag_1.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/1.gff -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/agat_sq_list_attributes.t
+++ b/t/agat_sq_list_attributes.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_sq_list_attributes_1.txt";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/1.gff -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp");
     check_diff( $outtmp, $result, "output $script", "-b -I '^Job done in'" );
 }
 

--- a/t/agat_sq_manage_IDs.t
+++ b/t/agat_sq_manage_IDs.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_sq_manage_IDs_1.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/1.gff -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/agat_sq_remove_redundant_entries.t
+++ b/t/agat_sq_remove_redundant_entries.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_sq_remove_redundant_entries_1.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/1.gff -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/agat_sq_rename_seqid.t
+++ b/t/agat_sq_rename_seqid.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_sq_rename_seqid_1.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/agat_sq_rename_seqid/rename_seqid.gff --tsv $input_folder/agat_sq_rename_seqid/rename_table.tsv -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/agat_sq_rename_seqid/rename_seqid.gff --tsv $input_folder/agat_sq_rename_seqid/rename_table.tsv -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/agat_sq_reverse_complement.t
+++ b/t/agat_sq_reverse_complement.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_sq_reverse_complement_1.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/1.gff --fasta  $input_folder/1.fa -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/1.gff --fasta  $input_folder/1.fa -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/agat_sq_stat_basic.t
+++ b/t/agat_sq_stat_basic.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -26,7 +26,7 @@ my $result = "$output_folder/agat_sq_stat_basic_1.gff";
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $outprefix = catfile($dir, 'tmp');
-    system(" $script --gff $input_folder/1.gff -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp");
     check_diff( $outtmp, $result, "output $script" );
 }
 

--- a/t/config.t
+++ b/t/config.t
@@ -7,7 +7,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catdir catfile);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 
 =head1 DESCRIPTION
 
@@ -75,10 +75,10 @@ $script = $script_prefix . catfile($root, 'bin', 'agat');
     my $new_config_name = catfile( $dir, 'agat_config_renamed.yml' );
     system("$script config -e --output $new_config_name --locus_tag Name");
     my $tmp = catfile( $dir, 'tmp.gff' );
-    system(
+    check_quiet_run(
         catfile( $root, 'bin', 'agat_convert_sp_gxf2gxf.pl' ) .
           " --gff " . catfile( $Bin, 'gff', 'gff_syntax', 'in', '28_test.gff' ) .
-          " -c $new_config_name -o $tmp  2>&1 1>/dev/null"
+          " -c $new_config_name -o $tmp"
     );
     check_diff(
         $tmp,

--- a/t/gff/gff_other_issue329.t
+++ b/t/gff/gff_other_issue329.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use File::Spec::Functions qw(catdir catfile);
 use Cwd qw(abs_path);
 use lib catdir($Bin, '..', 'lib');
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 
 my $script_prefix = script_prefix();
 my $root = abs_path(catdir($Bin, '..', '..'));
@@ -19,7 +19,7 @@ my $output_folder = catdir($Bin, 'gff_other', 'out');
     my $dir = setup_tempdir();
     my $pathtmp = catfile($dir, 'tmp.gff');
     my $correct_output = catfile($output_folder, 'issue329.gff');
-    system("$script --gff " . catfile($input_folder, 'issue329.gff') . " -o $pathtmp 2>&1 1>/dev/null");
+    check_quiet_run("$script --gff " . catfile($input_folder, 'issue329.gff') . " -o $pathtmp");
     check_diff($pathtmp, $correct_output, 'issue329 check');
 }
 

--- a/t/gff/gff_other_issue368.t
+++ b/t/gff/gff_other_issue368.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use File::Spec::Functions qw(catdir catfile);
 use Cwd qw(abs_path);
 use lib catdir($Bin, '..', 'lib');
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 
 my $script_prefix = script_prefix();
 my $root = abs_path(catdir($Bin, '..', '..'));
@@ -19,7 +19,7 @@ my $output_folder = catdir($Bin, 'gff_other', 'out');
     my $dir = setup_tempdir();
     my $pathtmp = catfile($dir, 'tmp.gff');
     my $correct_output = catfile($output_folder, 'issue368.gff');
-    system("$script --gff " . catfile($input_folder, 'issue368.gff') . " -o $pathtmp 2>&1 1>/dev/null");
+    check_quiet_run("$script --gff " . catfile($input_folder, 'issue368.gff') . " -o $pathtmp");
     check_diff($pathtmp, $correct_output, 'issue368 check');
 }
 

--- a/t/gff/gff_other_issue389.t
+++ b/t/gff/gff_other_issue389.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use File::Spec::Functions qw(catdir catfile);
 use Cwd qw(abs_path);
 use lib catdir($Bin, '..', 'lib');
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 
 my $script_prefix = script_prefix();
 my $root = abs_path(catdir($Bin, '..', '..'));
@@ -19,7 +19,7 @@ my $output_folder = catdir($Bin, 'gff_other', 'out');
     my $dir = setup_tempdir();
     my $pathtmp = catfile($dir, 'tmp.gff');
     my $correct_output = catfile($output_folder, 'issue389.gff');
-    system("$script --gff " . catfile($input_folder, 'issue389.gff') . " -o $pathtmp 2>&1 1>/dev/null");
+    check_quiet_run("$script --gff " . catfile($input_folder, 'issue389.gff') . " -o $pathtmp");
     check_diff($pathtmp, $correct_output, 'issue389 check');
 }
 

--- a/t/gff/gff_other_issue441.t
+++ b/t/gff/gff_other_issue441.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use File::Spec::Functions qw(catdir catfile);
 use Cwd qw(abs_path);
 use lib catdir($Bin, '..', 'lib');
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 
 my $script_prefix = script_prefix();
 my $root = abs_path(catdir($Bin, '..', '..'));
@@ -20,8 +20,8 @@ my $output_folder = catdir($Bin, 'gff_other', 'out');
     my $dir = setup_tempdir();
     my $pathtmp = catfile($dir, 'tmp.gff');
     my $correct_output = catfile($output_folder, 'issue441.gtf');
-    system("$script_agat config --expose --output_format gtf 2>&1 1>/dev/null");
-    system("$script --g " . catfile($input_folder, 'issue441.gtf') . " -o $pathtmp  2>&1 1>/dev/null");
+    check_quiet_run("$script_agat config --expose --output_format gtf");
+    check_quiet_run("$script --g " . catfile($input_folder, 'issue441.gtf') . " -o $pathtmp");
     check_diff($pathtmp, $correct_output, 'issue441 check');
 }
 

--- a/t/gff/gff_other_issue448.t
+++ b/t/gff/gff_other_issue448.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use File::Spec::Functions qw(catdir catfile);
 use Cwd qw(abs_path);
 use lib catdir($Bin, '..', 'lib');
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 
 my $script_prefix = script_prefix();
 my $root = abs_path(catdir($Bin, '..', '..'));
@@ -20,15 +20,15 @@ my $output_folder = catdir($Bin, 'gff_other', 'out');
     my $dir = setup_tempdir();
     my $pathtmp = catfile($dir, 'tmp.gff');
     my $correct_output = catfile($output_folder, 'issue448.gtf');
-    system("$script_agat config --expose --output_format gtf 2>&1 1>/dev/null");
-    system("$script --g " . catfile($input_folder, 'issue448.gtf') . " -o $pathtmp  2>&1 1>/dev/null");
+    check_quiet_run("$script_agat config --expose --output_format gtf");
+    check_quiet_run("$script --g " . catfile($input_folder, 'issue448.gtf') . " -o $pathtmp");
     check_diff($pathtmp, $correct_output, 'issue448 check');
 }
 {
     my $dir = setup_tempdir();
     my $pathtmp = catfile($dir, 'tmp.gff');
     my $correct_output = catfile($output_folder, 'issue448.gff');
-    system("$script --g " . catfile($input_folder, 'issue448.gtf') . " -o $pathtmp  2>&1 1>/dev/null");
+    check_quiet_run("$script --g " . catfile($input_folder, 'issue448.gtf') . " -o $pathtmp");
     check_diff($pathtmp, $correct_output, 'issue448 check');
 }
 

--- a/t/gff/gff_other_issue457.t
+++ b/t/gff/gff_other_issue457.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use File::Spec::Functions qw(catdir catfile);
 use Cwd qw(abs_path);
 use lib catdir($Bin, '..', 'lib');
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 
 my $script_prefix = script_prefix();
 my $root = abs_path(catdir($Bin, '..', '..'));
@@ -20,8 +20,8 @@ my $output_folder = catdir($Bin, 'gff_other', 'out');
     my $dir = setup_tempdir();
     my $pathtmp = catfile($dir, 'tmp.gff');
     my $correct_output = catfile($output_folder, 'issue457.gtf');
-    system("$script_agat config --expose --deflate_attribute 2>&1 1>/dev/null");
-    system("$script --gff " . catfile($input_folder, 'issue457.gff') . " -o $pathtmp  2>&1 1>/dev/null");
+    check_quiet_run("$script_agat config --expose --deflate_attribute");
+    check_quiet_run("$script --gff " . catfile($input_folder, 'issue457.gff') . " -o $pathtmp");
     check_diff($pathtmp, $correct_output, 'issue457 check');
 }
 

--- a/t/gff/gff_other_tabix.t
+++ b/t/gff/gff_other_tabix.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use File::Spec::Functions qw(catdir catfile);
 use Cwd qw(abs_path);
 use lib catdir($Bin, '..', 'lib');
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 
 my $script_prefix = script_prefix();
 my $root = abs_path(catdir($Bin, '..', '..'));
@@ -20,8 +20,8 @@ my $output_folder = catdir($Bin, 'gff_other', 'out');
     my $dir = setup_tempdir();
     my $pathtmp = catfile($dir, 'tmp.gff');
     my $correct_output = catfile($output_folder, '1_agat_tabix.gff');
-    system("$script_agat config --expose --tabix 2>&1 1>/dev/null");
-    system("$script --gff " . catfile($Bin, '..', 'scripts_output', 'in', '1.gff') . " -o $pathtmp 2>&1 1>/dev/null");
+    check_quiet_run("$script_agat config --expose --tabix");
+    check_quiet_run("$script --gff " . catfile($Bin, '..', 'scripts_output', 'in', '1.gff') . " -o $pathtmp");
     check_diff($pathtmp, $correct_output, 'tabix check');
 }
 

--- a/t/gff/gff_other_zip_and_fasta.t
+++ b/t/gff/gff_other_zip_and_fasta.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use File::Spec::Functions qw(catdir catfile);
 use Cwd qw(abs_path);
 use lib catdir($Bin, '..', 'lib');
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 
 my $script_prefix = script_prefix();
 my $root = abs_path(catdir($Bin, '..', '..'));
@@ -19,7 +19,7 @@ my $output_folder = catdir($Bin, 'gff_other', 'out');
     my $dir = setup_tempdir();
     my $pathtmp = catfile($dir, 'tmp.gff');
     my $correct_output = catfile($output_folder, 'zip_and_fasta_correct_output.gff');
-    system("$script --gff " . catfile($input_folder, 'zip_and_fasta.gff.gz') . " -o $pathtmp  2>&1 1>/dev/null");
+    check_quiet_run("$script --gff " . catfile($input_folder, 'zip_and_fasta.gff.gz') . " -o $pathtmp");
     check_diff($pathtmp, $correct_output, 'zip_and_fasta check');
 }
 

--- a/t/gff/level_missing_testA.t
+++ b/t/gff/level_missing_testA.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use File::Spec::Functions qw(catdir catfile);
 use Cwd qw(abs_path);
 use lib catdir($Bin, '..', 'lib');
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 
 my $script_prefix = script_prefix();
 my $root = abs_path(catdir($Bin, '..', '..'));
@@ -20,31 +20,31 @@ my $output_folder = catdir($Bin, 'level_missing', 'out');
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $result = catfile($output_folder, 'testA_output.gff');
-    system("$script --gff " . catfile($input_folder, 'testA.gff') . " -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run("$script --gff " . catfile($input_folder, 'testA.gff') . " -o $outtmp");
     check_diff($outtmp, $result, 'output testA');
 }
 {
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $result = catfile($output_folder, 'testA_output2.gff');
-    system("$script_agat config --expose --locus_tag common_tag 2>&1 1>/dev/null");
-    system("$script --gff " . catfile($input_folder, 'testA.gff') . " -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run("$script_agat config --expose --locus_tag common_tag");
+    check_quiet_run("$script --gff " . catfile($input_folder, 'testA.gff') . " -o $outtmp");
     check_diff($outtmp, $result, 'output testA2');
 }
 {
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $result = catfile($output_folder, 'testA_output3.gff');
-    system("$script_agat config --expose --locus_tag gene_info 2>&1 1>/dev/null");
-    system("$script --gff " . catfile($input_folder, 'testA.gff') . " -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run("$script_agat config --expose --locus_tag gene_info");
+    check_quiet_run("$script --gff " . catfile($input_folder, 'testA.gff') . " -o $outtmp");
     check_diff($outtmp, $result, 'output testA3');
 }
 {
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $result = catfile($output_folder, 'testA_output4.gff');
-    system("$script_agat config --expose --locus_tag transcript_id 2>&1 1>/dev/null");
-    system("$script --gff " . catfile($input_folder, 'testA.gff') . " -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run("$script_agat config --expose --locus_tag transcript_id");
+    check_quiet_run("$script --gff " . catfile($input_folder, 'testA.gff') . " -o $outtmp");
     check_diff($outtmp, $result, 'output testA4');
 }
 

--- a/t/gff/level_missing_testB.t
+++ b/t/gff/level_missing_testB.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use File::Spec::Functions qw(catdir catfile);
 use Cwd qw(abs_path);
 use lib catdir($Bin, '..', 'lib');
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 
 my $script_prefix = script_prefix();
 my $root = abs_path(catdir($Bin, '..', '..'));
@@ -20,15 +20,15 @@ my $output_folder = catdir($Bin, 'level_missing', 'out');
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $result = catfile($output_folder, 'testB_output.gff');
-    system("$script --gff " . catfile($input_folder, 'testB.gff') . " -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run("$script --gff " . catfile($input_folder, 'testB.gff') . " -o $outtmp");
     check_diff($outtmp, $result, 'output testB');
 }
 {
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $result = catfile($output_folder, 'testB_output2.gff');
-    system("$script_agat config --expose --locus_tag locus_id 2>&1 1>/dev/null");
-    system("$script --gff " . catfile($input_folder, 'testB.gff') . " -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run("$script_agat config --expose --locus_tag locus_id");
+    check_quiet_run("$script --gff " . catfile($input_folder, 'testB.gff') . " -o $outtmp");
     check_diff($outtmp, $result, 'output testB2');
 }
 

--- a/t/gff/level_missing_testC.t
+++ b/t/gff/level_missing_testC.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use File::Spec::Functions qw(catdir catfile);
 use Cwd qw(abs_path);
 use lib catdir($Bin, '..', 'lib');
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 
 my $script_prefix = script_prefix();
 my $root = abs_path(catdir($Bin, '..', '..'));
@@ -20,15 +20,15 @@ my $output_folder = catdir($Bin, 'level_missing', 'out');
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $result = catfile($output_folder, 'testC_output.gff');
-    system("$script --gff " . catfile($input_folder, 'testC.gff') . " -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run("$script --gff " . catfile($input_folder, 'testC.gff') . " -o $outtmp");
     check_diff($outtmp, $result, 'output testC');
 }
 {
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $result = catfile($output_folder, 'testC_output2.gff');
-    system("$script_agat config --expose --locus_tag locus_id 2>&1 1>/dev/null");
-    system("$script --gff " . catfile($input_folder, 'testC.gff') . " -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run("$script_agat config --expose --locus_tag locus_id");
+    check_quiet_run("$script --gff " . catfile($input_folder, 'testC.gff') . " -o $outtmp");
     check_diff($outtmp, $result, 'output testC2');
 }
 

--- a/t/gff/level_missing_testD.t
+++ b/t/gff/level_missing_testD.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use File::Spec::Functions qw(catdir catfile);
 use Cwd qw(abs_path);
 use lib catdir($Bin, '..', 'lib');
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 
 my $script_prefix = script_prefix();
 my $root = abs_path(catdir($Bin, '..', '..'));
@@ -20,15 +20,15 @@ my $output_folder = catdir($Bin, 'level_missing', 'out');
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $result = catfile($output_folder, 'testD_output.gff');
-    system("$script --gff " . catfile($input_folder, 'testD.gff') . " -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run("$script --gff " . catfile($input_folder, 'testD.gff') . " -o $outtmp");
     check_diff($outtmp, $result, 'output testD');
 }
 {
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $result = catfile($output_folder, 'testD_output2.gff');
-    system("$script_agat config --expose --locus_tag ID 2>&1 1>/dev/null");
-    system("$script --gff " . catfile($input_folder, 'testD.gff') . " -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run("$script_agat config --expose --locus_tag ID");
+    check_quiet_run("$script --gff " . catfile($input_folder, 'testD.gff') . " -o $outtmp");
     check_diff($outtmp, $result, 'output testD2');
 }
 

--- a/t/gff/level_missing_testE.t
+++ b/t/gff/level_missing_testE.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use File::Spec::Functions qw(catdir catfile);
 use Cwd qw(abs_path);
 use lib catdir($Bin, '..', 'lib');
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 
 my $script_prefix = script_prefix();
 my $root = abs_path(catdir($Bin, '..', '..'));
@@ -19,7 +19,7 @@ my $output_folder = catdir($Bin, 'level_missing', 'out');
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $result = catfile($output_folder, 'testE_output.gff');
-    system("$script --gff " . catfile($input_folder, 'testE.gff') . " -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run("$script --gff " . catfile($input_folder, 'testE.gff') . " -o $outtmp");
     check_diff($outtmp, $result, 'output testE');
 }
 

--- a/t/gff/level_missing_testF.t
+++ b/t/gff/level_missing_testF.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use File::Spec::Functions qw(catdir catfile);
 use Cwd qw(abs_path);
 use lib catdir($Bin, '..', 'lib');
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 
 my $script_prefix = script_prefix();
 my $root = abs_path(catdir($Bin, '..', '..'));
@@ -19,7 +19,7 @@ my $output_folder = catdir($Bin, 'level_missing', 'out');
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $result = catfile($output_folder, 'testF_output.gff');
-    system("$script --gff " . catfile($input_folder, 'testF.gff') . " -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run("$script --gff " . catfile($input_folder, 'testF.gff') . " -o $outtmp");
     check_diff($outtmp, $result, 'output testF');
 }
 

--- a/t/gff/level_missing_testG.t
+++ b/t/gff/level_missing_testG.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use File::Spec::Functions qw(catdir catfile);
 use Cwd qw(abs_path);
 use lib catdir($Bin, '..', 'lib');
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
 
 my $script_prefix = script_prefix();
 my $root = abs_path(catdir($Bin, '..', '..'));
@@ -19,7 +19,7 @@ my $output_folder = catdir($Bin, 'level_missing', 'out');
     my $dir = setup_tempdir();
     my $outtmp = catfile($dir, 'tmp.gff');
     my $result = catfile($output_folder, 'testG_output.gff');
-    system("$script --gff " . catfile($input_folder, 'testG.gff') . " -o $outtmp 2>&1 1>/dev/null");
+    check_quiet_run("$script --gff " . catfile($input_folder, 'testG.gff') . " -o $outtmp");
     check_diff($outtmp, $result, 'output testG');
 }
 

--- a/t/lib/AGAT/TestUtilities.pm
+++ b/t/lib/AGAT/TestUtilities.pm
@@ -8,7 +8,7 @@ use File::Copy qw(copy);
 use File::Spec;
 use Test::More;
 
-our @EXPORT = qw(setup_tempdir check_diff script_prefix);
+our @EXPORT = qw(setup_tempdir check_diff script_prefix check_quiet_run);
 my @DIRS;    # keep temp dirs alive until program end
 
 sub setup_tempdir {
@@ -34,6 +34,16 @@ sub script_prefix {
         $ENV{HARNESS_PERL_SWITCHES}
           && $ENV{HARNESS_PERL_SWITCHES} =~ m/Devel::Cover/
       ) ? 'perl -MDevel::Cover ' : '';
+}
+
+sub check_quiet_run {
+    my ($cmd) = @_;
+    my $stdout = File::Spec->catfile( $CWD, 'stdout.txt' );
+    my $stderr = File::Spec->catfile( $CWD, 'stderr.txt' );
+    my $exit = system("$cmd --quiet 1>$stdout 2>$stderr");
+    ok( -z $stdout, 'stdout is empty' );
+    ok( -z $stderr, 'stderr is empty' );
+    return $exit;
 }
 
 BEGIN {


### PR DESCRIPTION
## Summary
- add `check_quiet_run` helper to run scripts quietly and assert no stdout/stderr
- update tests in `t/` and `t/gff/` to use `check_quiet_run`

## Testing
- `.agents/with-perl-local.sh prove -lr t` *(fails: stdout/stderr not empty)*

------
https://chatgpt.com/codex/tasks/task_e_68a87e70ead8832a94c568cf65e7e9d1