### PR TITLE
Refactor scripts for describe_script_options and verbose logging

### DIFF
--- a/bin/agat_convert_mfannot2gff.pl
+++ b/bin/agat_convert_mfannot2gff.pl
@@ -14,6 +14,7 @@ my ( $opt, $usage, $config ) = AGAT::AGAT::describe_script_options(
 );
 
 my $mfannot_file = $opt->mfannot;
+my $opt_verbose  = $config->{verbose};
 
 my $log;
 if ( my $log_name = $config->{log_path} ) {
@@ -67,13 +68,13 @@ sub read_mfannot {
 			}
 		}
         elsif ($_ =~ /^\s*(\d+)\s+([ATCGatcgNn]+)/) {
-			dual_print( $log, "DNA sequence line\n", $config->{verbose} );
+			dual_print( $log, "DNA sequence line\n", $opt_verbose );
             # If line is a numbered sequence line
             my ($pos_begin,$seqline) = ($1, $2);   # Sequence position
             $current_pos = length($seqline) + $pos_begin - 1;
         }
         elsif ( ($_ =~ /^;+\s+G-(\w.*)/) or ($_ =~ /^;; mfannot:\s+(\/group=.*)/) or ($_ =~ /^;; mfannot:$/) or ($_ =~ /^;+\s+(rnl.*)/) or ($_ =~ /^;+\s+(rns.*)/) ){
-			dual_print( $log, "Feature line\n", $config->{verbose} );
+			dual_print( $log, "Feature line\n", $opt_verbose );
 			if ( ($_ =~ /^;+\s+G-(\w.*)/) or ($_ =~ /^;+\s+(rnl.*)/) or ($_ =~ /^;+\s+(rns.*)/) ){
 
 				# If line is a feature boundary, save that information
@@ -88,7 +89,7 @@ sub read_mfannot {
 					if (defined $startend_hash{$current_contig}{$previousIntron}{$type}{"end"}{0}) {
 							my $i = keys %{$startend_hash{$current_contig}{$previousIntron}{$type}{"end"}};
 							$startend_hash{$current_contig}{$previousIntron}{$type}{"end"}{$i} = $current_pos;
-							dual_print( $log, "Feature ". $previousIntron. " already defined. Please manually verify in $mfannot_file\n", $config->{verbose} );
+							dual_print( $log, "Feature ". $previousIntron. " already defined. Please manually verify in $mfannot_file\n", $opt_verbose );
 					}
 					else { 
 						$startend_hash{$current_contig}{$previousIntron}{$type}{"end"}{0} = $current_pos; 
@@ -101,7 +102,7 @@ sub read_mfannot {
 					if (defined $startend_hash{$current_contig}{$previousRns}{$type}{"end"}{0}) {
 							my $i = keys %{$startend_hash{$current_contig}{$previousRns}{$type}{"end"}};
 							$startend_hash{$current_contig}{$previousRns}{$type}{"end"}{$i} = $current_pos;
-							dual_print( $log, "Feature ". $previousRns. " already defined. Please manually verify in $mfannot_file\n", $config->{verbose} );
+							dual_print( $log, "Feature ". $previousRns. " already defined. Please manually verify in $mfannot_file\n", $opt_verbose );
 					}
 					else { $startend_hash{$current_contig}{$previousRns}{$type}{"end"}{0} = $current_pos; }
 					$previousRns = undef;
@@ -112,7 +113,7 @@ sub read_mfannot {
 					if (defined $startend_hash{$current_contig}{$previousRnl}{$type}{"end"}{0}) {
 							my $i = keys %{$startend_hash{$current_contig}{$previousRnl}{$type}{"end"}};
 							$startend_hash{$current_contig}{$previousRnl}{$type}{"end"}{$i} = $current_pos;
-							dual_print( $log, "Feature ". $previousRnl. " already defined. Please manually verify in $mfannot_file\n", $config->{verbose} );
+							dual_print( $log, "Feature ". $previousRnl. " already defined. Please manually verify in $mfannot_file\n", $opt_verbose );
 					}
 					else { $startend_hash{$current_contig}{$previousRnl}{$type}{"end"}{0} = $current_pos; }
 					$previousRnl = undef;
@@ -128,7 +129,7 @@ sub read_mfannot {
 							if (defined $startend_hash{$current_contig}{$previousRnl}{"rRNA"}{"end"}{0}) {
 									my $i = keys %{$startend_hash{$current_contig}{$previousRnl}{"rRNA"}{"end"}};
 									$startend_hash{$current_contig}{$previousRnl}{"rRNA"}{"end"}{$i} = $current_pos;
-									dual_print( $log, "Feature ". $previousRnl. " already defined. Please manually verify in $mfannot_file\n", $config->{verbose} );
+									dual_print( $log, "Feature ". $previousRnl. " already defined. Please manually verify in $mfannot_file\n", $opt_verbose );
 							}
 							else { $startend_hash{$current_contig}{$previousRnl}{"rRNA"}{"end"}{0} = $current_pos; }
 							$previousRnl = undef;
@@ -138,7 +139,7 @@ sub read_mfannot {
 						if (defined $startend_hash{$current_contig}{$current_name}{"rRNA"}{"start"}{0} ) {
 								my $i = keys %{$startend_hash{$current_contig}{$current_name}{"rRNA"}{"start"}};
 								$startend_hash{$current_contig}{$current_name}{"rRNA"}{"start"}{$i} = $current_pos + 1;
-								dual_print( $log, "Feature ". $current_name. " already defined. Please manually verify in $mfannot_file\n", $config->{verbose} );
+								dual_print( $log, "Feature ". $current_name. " already defined. Please manually verify in $mfannot_file\n", $opt_verbose );
 						}
 						else { $startend_hash{$current_contig}{$current_name}{"rRNA"}{"start"}{0} = $current_pos + 1;}
 						$previousRnl=$current_name;
@@ -149,7 +150,7 @@ sub read_mfannot {
 							if (defined $startend_hash{$current_contig}{$previousRns}{"rRNA"}{"end"}{0}) {
 									my $i = keys %{$startend_hash{$current_contig}{$previousRns}{"rRNA"}{"end"}};
 									$startend_hash{$current_contig}{$previousRns}{"rRNA"}{"end"}{$i} = $current_pos;
-									dual_print( $log, "Feature ". $previousRns. " already defined. Please manually verify in $mfannot_file\n", $config->{verbose} );
+									dual_print( $log, "Feature ". $previousRns. " already defined. Please manually verify in $mfannot_file\n", $opt_verbose );
 							}
 							else { $startend_hash{$current_contig}{$previousRns}{"rRNA"}{"end"}{0} = $current_pos; }
 							$previousRns = undef;
@@ -159,7 +160,7 @@ sub read_mfannot {
 						if (defined $startend_hash{$current_contig}{$current_name}{"rRNA"}{"start"}{0} ) {
 								my $i = keys %{$startend_hash{$current_contig}{$current_name}{"rRNA"}{"start"}};
 								$startend_hash{$current_contig}{$current_name}{"rRNA"}{"start"}{$i} = $current_pos + 1;
-								dual_print( $log, "Feature ". $current_name. " already defined. Please manually verify in $mfannot_file\n", $config->{verbose} );
+								dual_print( $log, "Feature ". $current_name. " already defined. Please manually verify in $mfannot_file\n", $opt_verbose );
 						}
 						else { $startend_hash{$current_contig}{$current_name}{"rRNA"}{"start"}{0} = $current_pos + 1;}
 						$previousRns=$current_name;
@@ -192,13 +193,13 @@ sub read_mfannot {
 							if ($previousDirection eq $current_direction and $previousStartEnd eq $current_startend){ #keep the first key and the second value
 								my $i = keys %{$startend_hash{$current_contig}{$current_name}{$type}{"start"}};
 								$startend_hash{$current_contig}{$current_name}{$type}{"start"}{$i-1} = $current_pos;
-								dual_print( $log, "11 - Feature ". $current_name. " already defined. Please manually verify in $mfannot_file\n", $config->{verbose} );
+								dual_print( $log, "11 - Feature ". $current_name. " already defined. Please manually verify in $mfannot_file\n", $opt_verbose );
 								next;
 							}
 
 							my $i = keys %{$startend_hash{$current_contig}{$current_name}{$type}{"start"}};
 							$startend_hash{$current_contig}{$current_name}{$type}{"start"}{$i} = $current_pos;
-							dual_print( $log, "1 - Feature ". $current_name. " already defined. Please manually verify in $mfannot_file\n", $config->{verbose} );
+							dual_print( $log, "1 - Feature ". $current_name. " already defined. Please manually verify in $mfannot_file\n", $opt_verbose );
 						}
 						else { $startend_hash{$current_contig}{$current_name}{$type}{"start"}{0} = $current_pos; }
 					}
@@ -209,13 +210,13 @@ sub read_mfannot {
 							if ($previousDirection eq $current_direction and $previousStartEnd eq $current_startend){ #keep the first key and the second value
 								my $i = keys %{$startend_hash{$current_contig}{$current_name}{$type}{"end"}};
 								$startend_hash{$current_contig}{$current_name}{$type}{"end"}{$i-1} = $current_pos;
-								dual_print( $log, "22 - Feature ". $current_name. " already defined. Please manually verify in $mfannot_file\n", $config->{verbose} );
+								dual_print( $log, "22 - Feature ". $current_name. " already defined. Please manually verify in $mfannot_file\n", $opt_verbose );
 								next;
 							}
 
 							my $i = keys %{$startend_hash{$current_contig}{$current_name}{$type}{"end"}};
 							$startend_hash{$current_contig}{$current_name}{$type}{"end"}{$i} = $current_pos;
-							dual_print( $log, "2 - Feature ". $current_name. " already defined. Please manually verify in $mfannot_file\n", $config->{verbose} );
+							dual_print( $log, "2 - Feature ". $current_name. " already defined. Please manually verify in $mfannot_file\n", $opt_verbose );
 						}
 						else { $startend_hash{$current_contig}{$current_name}{$type}{"end"}{0} = $current_pos; }
 
@@ -225,13 +226,13 @@ sub read_mfannot {
 						if (defined $startend_hash{$current_contig}{$current_name}{$type}{"start"}{0}) {
 
 							if ($previousDirection eq $current_direction and $previousStartEnd eq $current_startend){
-								dual_print( $log, "3 - Feature ". $current_name. " already defined. Please manually verify in $mfannot_file\n", $config->{verbose} );
+								dual_print( $log, "3 - Feature ". $current_name. " already defined. Please manually verify in $mfannot_file\n", $opt_verbose );
 								next;
 							} #keep the first key and the first value
 
 							my $i = keys %{$startend_hash{$current_contig}{$current_name}{$type}{"start"}};
 							$startend_hash{$current_contig}{$current_name}{$type}{"start"}{$i} = $value;
-							dual_print( $log, "3 - Feature ". $current_name. " already defined. Please manually verify in $mfannot_file\n", $config->{verbose} );
+							dual_print( $log, "3 - Feature ". $current_name. " already defined. Please manually verify in $mfannot_file\n", $opt_verbose );
 						}
 						else { $startend_hash{$current_contig}{$current_name}{$type}{"start"}{0} = $value; }
 					}
@@ -240,20 +241,20 @@ sub read_mfannot {
 						if (defined $startend_hash{$current_contig}{$current_name}{$type}{"end"}{0}) {
 
 							if ($previousDirection eq $current_direction and $previousStartEnd eq $current_startend){
-							dual_print( $log, "44 - Feature ". $current_name. " already defined. Please manually verify in $mfannot_file\n", $config->{verbose} );
+							dual_print( $log, "44 - Feature ". $current_name. " already defined. Please manually verify in $mfannot_file\n", $opt_verbose );
 							next;
 							} #keep the first key and the first val
 
 							my $i = keys %{$startend_hash{$current_contig}{$current_name}{$type}{"end"}};
 							$startend_hash{$current_contig}{$current_name}{$type}{"end"}{$i} = $value;
-							dual_print( $log, "4 - Feature ". $current_name. " already defined. Please manually verify in $mfannot_file\n", $config->{verbose} );
+							dual_print( $log, "4 - Feature ". $current_name. " already defined. Please manually verify in $mfannot_file\n", $opt_verbose );
 						}
 						else { $startend_hash{$current_contig}{$current_name}{$type}{"end"}{0} = $value; }
 					}
 				}
 				# --- COMBINATION UNKNOW ---
 				else { 
-                                    warn "Exception to possible combination of feature boundaries and directions: $_ \n" if $config->{verbose};
+                                    warn "Exception to possible combination of feature boundaries and directions: $_ \n" if $opt_verbose;
 				}
 
 				$previousDirection=$current_direction;
@@ -268,7 +269,7 @@ sub read_mfannot {
 					if (defined $startend_hash{$current_contig}{$previousIntron}{$type}{"end"}{0}) {
 							my $i = keys %{$startend_hash{$current_contig}{$previousIntron}{$type}{"end"}};
 							$startend_hash{$current_contig}{$previousIntron}{$type}{"end"}{$i} = $current_pos;
-							dual_print( $log, "Feature ". $previousIntron. " already defined. Please manually verify in $mfannot_file\n", $config->{verbose} );
+							dual_print( $log, "Feature ". $previousIntron. " already defined. Please manually verify in $mfannot_file\n", $opt_verbose );
 					}
 					else { 
 						$startend_hash{$current_contig}{$previousIntron}{$type}{"end"}{0} = $current_pos; 
@@ -280,7 +281,7 @@ sub read_mfannot {
 				if (defined $startend_hash{$current_contig}{$1}{$type}{"start"}{0} ) {
 						my $i = keys %{$startend_hash{$current_contig}{$1}{$type}{"start"}};
 						$startend_hash{$current_contig}{$1}{$type}{"start"}{$i} = $current_pos + 1;
-						dual_print( $log, "Feature ".$1. " already defined. Please manually verify in $mfannot_file\n", $config->{verbose} );
+						dual_print( $log, "Feature ".$1. " already defined. Please manually verify in $mfannot_file\n", $opt_verbose );
 				}
 				else { 
 					$startend_hash{$current_contig}{$1}{$type}{"start"}{0} = $current_pos + 1;
@@ -293,7 +294,7 @@ sub read_mfannot {
 					if (defined $startend_hash{$current_contig}{$previousIntron}{$type}{"end"}{0}) {
 							my $i = keys %{$startend_hash{$current_contig}{$previousIntron}{$type}{"end"}};
 							$startend_hash{$current_contig}{$previousIntron}{$type}{"end"}{$i} = $current_pos;
-							dual_print( $log, "Feature ". $previousIntron. " already defined. Please manually verify in $mfannot_file\n", $config->{verbose} );
+							dual_print( $log, "Feature ". $previousIntron. " already defined. Please manually verify in $mfannot_file\n", $opt_verbose );
 					}
 					else { 
 						$startend_hash{$current_contig}{$previousIntron}{$type}{"end"}{0} = $current_pos; 

--- a/bin/agat_sp_add_start_and_stop.pl
+++ b/bin/agat_sp_add_start_and_stop.pl
@@ -17,11 +17,16 @@ my $stop_id  = 1;
 
 my ( $opt, $usage, $config ) = AGAT::AGAT::describe_script_options(
     $header,
-    [ 'gff|i|g=s',        'Input GTF/GFF file', { required => 1 } ],
-    [ 'fasta|fa|f=s',     'Input FASTA file',   { required => 1 } ],
-    [ 'table|codon|ct=i', 'Codon table id',     { default => 1 } ],
-    [ 'extend|e!',        'Try to extend the sequence' ],
-    [ 'no_iupac|ni|na!',  'Disable IUPAC in codon table' ],
+    [ 'gff|i|g=s',    'Input GTF/GFF file', { required => 1 } ],
+    [ 'fasta|fa|f=s', 'Input FASTA file',   { required => 1 } ],
+    [ 'table|codon|ct=i', 'Codon table id', {
+            default   => 1,
+            callbacks => {
+                positive => sub { shift() > 0 or die 'Codon table id must be positive' },
+            },
+        } ],
+    [ 'extend|e!',       'Try to extend the sequence' ],
+    [ 'no_iupac|ni|na!', 'Disable IUPAC in codon table' ],
 );
 
 my $opt_file       = $opt->gff;
@@ -29,6 +34,7 @@ my $file_fasta     = $opt->fasta;
 my $codon_table_id = $opt->table;
 my $opt_extend     = $opt->extend;
 my $opt_no_iupac   = $opt->no_iupac;
+my $opt_verbose    = $config->{verbose};
 
 my $log;
 if ( my $log_name = $config->{log_path} ) {
@@ -61,14 +67,14 @@ my $codon_table = Bio::Tools::CodonTable->new( -id => $codon_table_id, -no_iupac
 ### Parse GFF input #
 my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $opt_file,
                                                                  config => $config });
-dual_print( $log, "Parsing Finished\n\n", $config->{verbose} );
+dual_print( $log, "Parsing Finished\n\n", $opt_verbose );
 ### END Parse GFF input #
 #########################
 
 ####################
 # index the genome #
 my $db = Bio::DB::Fasta->new($file_fasta);
-dual_print( $log, "Fasta file parsed\n", $config->{verbose} );
+dual_print( $log, "Fasta file parsed\n", $opt_verbose );
 
 my $counter_start_missing = 0;
 my $counter_start_added = 0;
@@ -88,9 +94,9 @@ foreach my $tag_l2 (sort keys %{$hash_omniscient->{'level2'}}){
       if ($feature_l2->strand == -1 or $feature_l2->strand eq "-"){
         $strand="-";
       }
-      dual_print( $log, "feature strand = $strand\n", $config->{verbose} );
+      dual_print( $log, "feature strand = $strand\n", $opt_verbose );
       my $seq_id = $feature_l2->seq_id();
-      dual_print( $log, "sequence length ".$db->length($seq_id)."\n", $config->{verbose} );
+      dual_print( $log, "sequence length ".$db->length($seq_id)."\n", $opt_verbose );
       
       ##############################
       #If it's a mRNA = have CDS. #
@@ -105,20 +111,20 @@ foreach my $tag_l2 (sort keys %{$hash_omniscient->{'level2'}}){
         #-------------------------
         #       START CASE
         #-------------------------
-        dual_print( $log, "---START CODON TEST---\n", $config->{verbose} );
+        dual_print( $log, "---START CODON TEST---\n", $opt_verbose );
         if ( exists ($hash_omniscient->{'level3'}{'start_codon'}{$id_level2} ) ){
-          dual_print( $log, "start_codon already exists for $id_level2\n", $config->{verbose} );
+          dual_print( $log, "start_codon already exists for $id_level2\n", $opt_verbose );
         }
         else{
           # ----- Find the start codon -----
           my $extension=0;
           my $start_codon = undef;
           if ( !$start_codon ){
-            dual_print( $log, " Try find a start codon in the CDS (GFF and GTF case) \n", $config->{verbose} );
+            dual_print( $log, " Try find a start codon in the CDS (GFF and GTF case) \n", $opt_verbose );
             $start_codon = next_codon_is_start(\@cds_feature_list, -3);
           } 
           if ( $opt_extend and !$start_codon ){
-            dual_print( $log, " Try to extend the sequence to find a start codon further...\n", $config->{verbose} );
+            dual_print( $log, " Try to extend the sequence to find a start codon further...\n", $opt_verbose );
             $extension += 3;  
             # check end of seq
             my $out=undef;
@@ -211,9 +217,9 @@ foreach my $tag_l2 (sort keys %{$hash_omniscient->{'level2'}}){
         #-------------------------
         #       STOP CASE
         #-------------------------
-        dual_print( $log, "---STOP CODON TEST---\n", $config->{verbose} );
+        dual_print( $log, "---STOP CODON TEST---\n", $opt_verbose );
         if ( exists ($hash_omniscient->{'level3'}{'stop_codon'}{$id_level2} ) ){
-          dual_print( $log, "stop_codon already exists for $id_level2\n", $config->{verbose} );
+          dual_print( $log, "stop_codon already exists for $id_level2\n", $opt_verbose );
         }
         else{ 
           # ----- Find a stop codon -----
@@ -221,11 +227,11 @@ foreach my $tag_l2 (sort keys %{$hash_omniscient->{'level2'}}){
           my $extension = 0;
           my $terminal_codon = undef;
           if ( !$terminal_codon ){
-            dual_print( $log, " Try find a stop codon in the CDS (GFF case) \n", $config->{verbose} );
+            dual_print( $log, " Try find a stop codon in the CDS (GFF case) \n", $opt_verbose );
             $terminal_codon = next_codon_is_ter(\@cds_feature_list, -3);
           } 
           if ( !$terminal_codon ){
-              dual_print( $log, " Try find a stop codon next codon out of the CDS (GTF case) \n", $config->{verbose} );
+              dual_print( $log, " Try find a stop codon next codon out of the CDS (GTF case) \n", $opt_verbose );
             $terminal_codon = next_codon_is_ter(\@cds_feature_list, 0);
 
             if($strand eq "+"){
@@ -235,7 +241,7 @@ foreach my $tag_l2 (sort keys %{$hash_omniscient->{'level2'}}){
             }
           } # with extend option 
           if ($opt_extend and !$terminal_codon){
-            dual_print( $log, " Try to extend the sequence to find a stop codon further...\n", $config->{verbose} );
+            dual_print( $log, " Try to extend the sequence to find a stop codon further...\n", $opt_verbose );
             $extension += 3;  
             # check end of seq
             my $out=undef;
@@ -340,9 +346,9 @@ if ($opt_extend){
   print_omniscient( {omniscient => $hash_omniscient, output => $gffout} );
 }
 
-dual_print( $log, "$counter_start_added start codon added and $counter_start_missing CDS do not start by a start codon\n", $config->{verbose} );
-dual_print( $log, "$counter_end_added stop codon added and $counter_end_missing CDS do not end by a stop codon \n", $config->{verbose} );
-dual_print( $log, "bye bye\n", $config->{verbose} );
+dual_print( $log, "$counter_start_added start codon added and $counter_start_missing CDS do not start by a start codon\n", $opt_verbose );
+dual_print( $log, "$counter_end_added stop codon added and $counter_end_missing CDS do not end by a stop codon \n", $opt_verbose );
+dual_print( $log, "bye bye\n", $opt_verbose );
 
       #########################
       ######### END ###########
@@ -371,10 +377,10 @@ sub create_cds_object{
     my $seqid=$feature->seq_id();
     $seq .= $db->seq( $seqid, $start, $end );
   }
-  dual_print( $log, "sequence: $seq\n", $config->{verbose} );
+  dual_print( $log, "sequence: $seq\n", $opt_verbose );
   my $debut = $db->seq( $feature_list->[0]->seq_id(), $feature_list->[0]->start-1, $feature_list->[0]->start -3 );
   my $fin = $db->seq( $feature_list->[0]->seq_id(), $feature_list->[-1]->end+1, $feature_list->[-1]->end+ 3 );
-  dual_print( $log, "sequence_extended: $debut$seq$fin\n", $config->{verbose} );
+  dual_print( $log, "sequence_extended: $debut$seq$fin\n", $opt_verbose );
 
   #create the cds object
   my $cds_obj = Bio::Seq->new(-seq => $seq, -alphabet => 'dna' );
@@ -384,8 +390,8 @@ sub create_cds_object{
   if ($feature_list->[0]->strand == -1 or $feature_list->[0]->strand eq "-"){
       $cds_obj = $cds_obj->revcom();
       $strand = "-";
-      dual_print( $log, "feature on minus strand\n", $config->{verbose} );
-      dual_print( $log, "sequence: ".$cds_obj->seq."\n", $config->{verbose} );
+      dual_print( $log, "feature on minus strand\n", $opt_verbose );
+      dual_print( $log, "sequence: ".$cds_obj->seq."\n", $opt_verbose );
   }
   
   return $cds_obj;
@@ -396,7 +402,7 @@ sub next_codon_is_start{
   if(! $more){
     $more=0;
   }
-  dual_print( $log, "next_codon_is_start test: \n", $config->{verbose} );
+  dual_print( $log, "next_codon_is_start test: \n", $opt_verbose );
   my $cds_obj;
   my $seqid=$feature_list->[0]->seq_id();
 
@@ -406,20 +412,20 @@ sub next_codon_is_start{
       my $seq = $db->seq( $seqid,$end+1+$more, $end+3+$more);
       $cds_obj = Bio::Seq->new(-seq => $seq, -alphabet => 'dna' );
       $cds_obj = $cds_obj->revcom();
-      dual_print( $log, "  Minus strand - most right side: ".($end+3+$more)."\n", $config->{verbose} );
+      dual_print( $log, "  Minus strand - most right side: ".($end+3+$more)."\n", $opt_verbose );
   }
   else{ # Plus strand
       my $start=$feature_list->[0]->start();
       my $seq = $db->seq( $seqid, $start-3-$more,  $start-1-$more);
       $cds_obj = Bio::Seq->new(-seq => $seq, -alphabet => 'dna' );
-      dual_print( $log, "  Plus strand - most right side: ".($start-3-$more)."\n", $config->{verbose} );
+      dual_print( $log, "  Plus strand - most right side: ".($start-3-$more)."\n", $opt_verbose );
   }
 
   my $codon = $cds_obj->seq ;
-  dual_print( $log, "  codon tested is = $codon \n", $config->{verbose} );
+  dual_print( $log, "  codon tested is = $codon \n", $opt_verbose );
 
   if ( !is_ambiguous_codon($codon) and $codon_table->is_start_codon( $codon )){
-    dual_print( $log, "  It is considered as a start codon!\n", $config->{verbose} );;
+    dual_print( $log, "  It is considered as a start codon!\n", $opt_verbose );;
     return 1;
   } else{
     return 0;
@@ -432,7 +438,7 @@ sub next_codon_is_ter{
   if(! $more){
     $more=0;
   }
-  dual_print( $log, "next_codon_is_ter test: \n", $config->{verbose} );
+  dual_print( $log, "next_codon_is_ter test: \n", $opt_verbose );
   my $cds_obj;
   my $seqid=$feature_list->[0]->seq_id();
 
@@ -442,20 +448,20 @@ sub next_codon_is_ter{
       my $seq = $db->seq( $seqid,$start-3-$more, $start-1-$more);
       $cds_obj = Bio::Seq->new(-seq => $seq, -alphabet => 'dna' );
       $cds_obj = $cds_obj->revcom();
-      dual_print( $log, "  Minus strand - most right side: ".($start-3-$more)."\n", $config->{verbose} );
+      dual_print( $log, "  Minus strand - most right side: ".($start-3-$more)."\n", $opt_verbose );
   }
   else{ # Plus strand
       my $end=$feature_list->[-1]->end();
       my $seq = $db->seq( $seqid, $end+1+$more,  $end+3+$more);
       $cds_obj = Bio::Seq->new(-seq => $seq, -alphabet => 'dna' );
-      dual_print( $log, "  Plus strand - most right side: ".($end+3+$more)."\n", $config->{verbose} );
+      dual_print( $log, "  Plus strand - most right side: ".($end+3+$more)."\n", $opt_verbose );
   }
   
   my $codon = $cds_obj->seq ;
-  dual_print( $log, "  codon tested is = $codon \n", $config->{verbose} );
+  dual_print( $log, "  codon tested is = $codon \n", $opt_verbose );
 
   if ( !is_ambiguous_codon($codon) and $codon_table->is_ter_codon( $codon )){
-    dual_print( $log, "  It is considered as a stop codon!\n", $config->{verbose} );
+    dual_print( $log, "  It is considered as a stop codon!\n", $opt_verbose );
     return 1;
   } else{
     return 0;
@@ -477,13 +483,13 @@ sub is_out_of_seq_start{
   if($strand eq "+"){
     if( $feature_list->[0]->start() - $more < 1 ){
       $out = 1;
-      dual_print( $log, "is_out_of_seq_start!! Plus strand - Most left out of seq: ".($feature_list->[0]->start() - $more)."\n", $config->{verbose} );
+      dual_print( $log, "is_out_of_seq_start!! Plus strand - Most left out of seq: ".($feature_list->[0]->start() - $more)."\n", $opt_verbose );
     }
   }
   else{
     if( $feature_list->[-1]->end() + $more > $length_seqid ){
       $out = 1;
-      dual_print( $log, "is_out_of_seq_start!! Minus strand - Most right out of seq: ".($feature_list->[-1]->end() + $more)."\n", $config->{verbose} );
+      dual_print( $log, "is_out_of_seq_start!! Minus strand - Most right out of seq: ".($feature_list->[-1]->end() + $more)."\n", $opt_verbose );
     }
   }
   return $out;
@@ -503,13 +509,13 @@ sub is_out_of_seq_stop{
   if($strand eq "+"){
     if( $feature_list->[-1]->end() + $more > $length_seqid ){
       $out = 1;
-      dual_print( $log, "is_out_of_seq_stop!! Plus strand - Most right out of seq: ".($feature_list->[-1]->end() + $more)."\n", $config->{verbose} );
+      dual_print( $log, "is_out_of_seq_stop!! Plus strand - Most right out of seq: ".($feature_list->[-1]->end() + $more)."\n", $opt_verbose );
     }
   }
   else{
     if( $feature_list->[0]->start() - $more < 1 ){
       $out = 1;
-      dual_print( $log, "is_out_of_seq_stop!! Minus strand - Most right out of seq: ".($feature_list->[0]->start() - $more)."\n", $config->{verbose} );
+      dual_print( $log, "is_out_of_seq_stop!! Minus strand - Most right out of seq: ".($feature_list->[0]->start() - $more)."\n", $opt_verbose );
     }
   }
   return $out;
@@ -522,7 +528,7 @@ sub is_ambiguous_codon{
 
   if ($opt_no_iupac){
     if ( $codon !~ /[ATGC]{3}/) {
-      dual_print( $log, "$codon is an ambiguous codon we skip it because the no_iupac option is activated!\n", $config->{verbose} );
+      dual_print( $log, "$codon is an ambiguous codon we skip it because the no_iupac option is activated!\n", $opt_verbose );
       return 1;
     } 
   }

--- a/bin/agat_sp_alignment_output_style.pl
+++ b/bin/agat_sp_alignment_output_style.pl
@@ -12,6 +12,7 @@ my ( $opt, $usage, $config ) = AGAT::AGAT::describe_script_options(
 );
 
 my $opt_gfffile = $opt->gff;
+my $opt_verbose = $config->{verbose};
 
 my $log;
 if ( my $log_name = $config->{log_path} ) {
@@ -34,7 +35,7 @@ my ($hash_omniscient, $hash_mRNAGeneLink) =  slurp_gff3_file_JD({
                                                                input => $opt_gfffile,
                                                                config => $config
                                                                });
-dual_print( $log, "GFF3 file parsed\n", $config->{verbose} );
+dual_print( $log, "GFF3 file parsed\n", $opt_verbose );
 
 ###
 # Print result
@@ -42,7 +43,7 @@ print_omniscient_as_match( {omniscient => $hash_omniscient, output => $gffout} )
 
 my $end_run = time();
 my $run_time = $end_run - $start_run;
-dual_print( $log, "Job done in $run_time seconds\n", $config->{verbose} );
+dual_print( $log, "Job done in $run_time seconds\n", $opt_verbose );
 __END__
 
 =head1 NAME

--- a/bin/agat_sp_clipN_seqExtremities_and_fixCoordinates.pl
+++ b/bin/agat_sp_clipN_seqExtremities_and_fixCoordinates.pl
@@ -21,6 +21,7 @@ my $opt_gfffile    = $opt->gff;
 my $opt_fastafile  = $opt->fasta;
 my $opt_output_fasta = $opt->of;
 my $opt_output_gff   = $opt->og // $config->{output};
+my $opt_verbose     = $config->{verbose};
 
 my $log;
 if ( my $log_name = $config->{log_path} ) {
@@ -45,11 +46,11 @@ my $gffout = prepare_gffout($config, $opt_output_gff);
 #### read gff file and save info in memory
 ######################
 ### Parse GFF input #
-dual_print($log, "Reading file $opt_gfffile\n", $config->{verbose} );
+dual_print($log, "Reading file $opt_gfffile\n", $opt_verbose );
 my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $opt_gfffile,
                                                                  config => $config
                                                               });
-dual_print($log, "Parsing Finished\n", $config->{verbose} );
+dual_print($log, "Parsing Finished\n", $opt_verbose );
 ### END Parse GFF input #
 #########################
 
@@ -140,13 +141,13 @@ foreach my $seq_id (@ids ){
 # print annotation whith shifter location
 print_omniscient( {omniscient => $hash_omniscient, output => $gffout} );
 
-dual_print($log, "We found $cpt_Nleft sequence(s) starting with N\n", $config->{verbose} );
-dual_print($log, "We found $cpt_Nright sequence(s) ending with N\n", $config->{verbose} );
-dual_print($log, "We found $cpt_Nboth sequence(s) having N both extremities\n", $config->{verbose} );
+dual_print($log, "We found $cpt_Nleft sequence(s) starting with N\n", $opt_verbose );
+dual_print($log, "We found $cpt_Nright sequence(s) ending with N\n", $opt_verbose );
+dual_print($log, "We found $cpt_Nboth sequence(s) having N both extremities\n", $opt_verbose );
 
 my $end_run = time();
 my $run_time = $end_run - $start_run;
-dual_print($log, "Job done in $run_time seconds\n", $config->{verbose} );
+dual_print($log, "Job done in $run_time seconds\n", $opt_verbose );
 
 close $log if $log;
 


### PR DESCRIPTION
## Summary
- validate bed conversion options and add verbose-aware warnings
- add codon table validation and unify verbose flag handling
- respect verbosity in alignment, clipping, and mfannot converters

## Testing
- `make test` *(fails: No rule to make target 'test')*
- `perl Makefile.PL` *(fails: Can't locate File::ShareDir::Install.pm)*
- `cpanm File::ShareDir::Install` *(fails: command not found)*
- `prove -lr t` *(fails: Can't locate Test::TempDir::Tiny.pm)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ab780d48832a988ae2fa9798a797