### PR TITLE
Refactor option parsing and verbose logging in multiple scripts

### DIFF
--- a/bin/agat_sp_separate_by_record_type.pl
+++ b/bin/agat_sp_separate_by_record_type.pl
@@ -3,64 +3,37 @@
 use strict;
 use warnings;
 use Pod::Usage;
-use Getopt::Long;
 use AGAT::AGAT;
 use Sort::Naturally;
 
 my $header = get_agat_header();
-my $config;
 my $start_run = time();
-my $opt_gfffile;
-my $opt_output;
-my $opt_help = 0;
+my ( $opt, $usage, $config ) = AGAT::AGAT::describe_script_options(
+    $header,
+    [ 'gff|g=s', 'Input reference gff file', { required => 1, callbacks => { file => sub { -e $_[0] or die "gff file $_[0] not found" } } } ],
+);
 
-my $common = parse_common_options() || {};
-$config     = $common->{config};
-$opt_output = $common->{output};
-my $verbose = $common->{verbose};
-$opt_help   = $common->{help};
-
-# OPTION MANAGMENT
-if ( !GetOptions( 'g|gff=s' => \$opt_gfffile ) )
-{
-    pod2usage( { -message => 'Failed to parse command line',
-                 -verbose => 1,
-                 -exitval => 1 } );
-}
-
-# Print Help and exit
-if ($opt_help) {
-    pod2usage( { -verbose => 99,
-                 -exitval => 0,
-                 -message => "$header\n" } );
-}
-
-if (! defined($opt_gfffile) ){
-    pod2usage( {
-           -message => "$header\nAt least 1 parameter is mandatory:\nInput reference gff file (-g).\n\n".
-           "Ouptut is optional. Look at the help documentation to know more.\n",
-           -verbose => 0,
-           -exitval => 1 } );
-}
-
-# --- Manage config ---
-$config = get_agat_config({config_file_in => $config});
+my $opt_gfffile = $opt->gff;
+my $opt_output  = $config->{output};
+my $verbose     = $config->{verbose};
 
 my $log;
-my $log_name = get_log_path($common, $config);
-open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
-dual_print($log, $header, 0);
+if ( my $log_name = $config->{log_path} ) {
+    open( $log, '>', $log_name ) or die "Can not open $log_name for printing: $!";
+    dual_print( $log, $header, 0 );
+}
 
 ######################
 # Manage output file #
 
 if (! $opt_output) {
-  dual_print($log, "Default output name: split_result\n");
+  dual_print($log, "Default output name: split_result\n", $verbose);
   $opt_output="split_result";
 }
 
 if (-d $opt_output){
-  dual_print($log, "The output directory choosen already exists. Please give me another Name.\n", 1);exit();
+  warn "The output directory choosen already exists. Please give me another Name.\n" if $verbose;
+  exit();
 }
 mkdir $opt_output;
 
@@ -73,7 +46,7 @@ mkdir $opt_output;
 my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $opt_gfffile,
                                                                  config => $config
                                                               });
-dual_print($log, "GFF3 file parsed\n");
+dual_print($log, "GFF3 file parsed\n", $verbose);
 
 
 my $topfeatures = get_feature_type_by_agat_value($hash_omniscient, 'level1', 'topfeature');
@@ -184,7 +157,7 @@ foreach my $key (keys %handlers){
 
 my $end_run = time();
 my $run_time = $end_run - $start_run;
-dual_print($log, "Job done in $run_time seconds\n");
+dual_print($log, "Job done in $run_time seconds\n", $verbose);
 
 close $log if $log;
 __END__

--- a/bin/agat_sp_webApollo_compliant.pl
+++ b/bin/agat_sp_webApollo_compliant.pl
@@ -3,52 +3,24 @@
 use strict;
 use warnings;
 use Pod::Usage;
-use Getopt::Long;
 use AGAT::AGAT;
 
 my $header = get_agat_header();
-my $config;
 my $start_run = time();
-my $opt_gfffile;
-my $opt_output;
-my $opt_help = 0;
+my ( $opt, $usage, $config ) = AGAT::AGAT::describe_script_options(
+    $header,
+    [ 'gff|g=s', 'Input reference gff file', { required => 1, callbacks => { file => sub { -e $_[0] or die "gff file $_[0] not found" } } } ],
+);
 
-my $common = parse_common_options() || {};
-$config     = $common->{config};
-$opt_output = $common->{output};
-my $verbose = $common->{verbose};
-$opt_help   = $common->{help};
-
-# OPTION MANAGMENT
-if ( !GetOptions( 'g|gff=s' => \$opt_gfffile ) )
-{
-    pod2usage( { -message => 'Failed to parse command line',
-                 -verbose => 1,
-                 -exitval => 1 } );
-}
-
-# Print Help and exit
-if ($opt_help) {
-    pod2usage( { -verbose => 99,
-                 -exitval => 0,
-                 -message => "$header\n" } );
-}
-
-if (! defined($opt_gfffile) ){
-    pod2usage( {
-           -message => "\nAt least 1 parameter is mandatory:\nInput reference gff file (-g).\n\n".
-           "Ouptut is optional. Look at the help documentation to know more.\n",
-           -verbose => 0,
-           -exitval => 1 } );
-}
-
-# --- Manage config ---
-$config = get_agat_config({config_file_in => $config});
+my $opt_gfffile = $opt->gff;
+my $opt_output  = $config->{output};
+my $verbose     = $config->{verbose};
 
 my $log;
-my $log_name = get_log_path($common, $config);
-open($log, '>', $log_name) or die "Can not open $log_name for printing: $!";
-dual_print($log, $header, 0);
+if ( my $log_name = $config->{log_path} ) {
+    open( $log, '>', $log_name ) or die "Can not open $log_name for printing: $!";
+    dual_print( $log, $header, 0 );
+}
 
 ######################
 # Manage output file #
@@ -62,7 +34,7 @@ my $gffout = prepare_gffout($config, $opt_output);
 my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $opt_gfffile,
                                                                  config => $config
                                                               });
-print ("GFF3 file parsed\n");
+dual_print( $log, "GFF3 file parsed\n", $verbose );
 
 ########
 # Transform thing needed for webapollo.
@@ -74,7 +46,7 @@ print_omniscient( {omniscient => $hash_omniscient, output => $gffout} );
 
 my $end_run = time();
 my $run_time = $end_run - $start_run;
-print "Job done in $run_time seconds\n";
+dual_print( $log, "Job done in $run_time seconds\n", $verbose );
 __END__
 
 =head1 NAME


### PR DESCRIPTION
## Summary
- migrate several scripts to `AGAT::AGAT::describe_script_options`
- route script messages through `dual_print` and `warn` respecting `verbose`

## Testing
- `perl -Ilib -c bin/agat_sp_sensitivity_specificity.pl` *(fails: Bio::Tools::GFF not found)*
- `prove -lr t/smoke` *(fails: Cannot detect source of 't/smoke')*
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_68a9abf94e6c832a9d0626ac18e401f1