### PR TITLE
Use dual_print for info_omniscient logging

### DIFF
--- a/bin/agat_sp_complement_annotations.pl
+++ b/bin/agat_sp_complement_annotations.pl
@@ -48,7 +48,7 @@ my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $ref,
                                                                  config => $config
                                                               });
 dual_print( $log, "$ref GFF3 file parsed\n", $verbose );
-info_omniscient($hash_omniscient);
+info_omniscient($hash_omniscient, $log, $verbose);
 
 #Add the features of the other file in the first omniscient. It takes care of name to not have duplicates
 foreach my $next_file (@opt_files){
@@ -56,7 +56,7 @@ foreach my $next_file (@opt_files){
 	                                                                   config => $config
                                                                 });
   dual_print( $log, "$next_file GFF3 file parsed\n", $verbose );
-  info_omniscient($hash_omniscient2);
+  info_omniscient($hash_omniscient2, $log, $verbose);
 
   ################################
   # First rename ID to be sure to not add feature with ID already used
@@ -113,7 +113,7 @@ foreach my $next_file (@opt_files){
   }
   else{
     dual_print( $log, "\nNow the data contains:\n", $verbose );
-    info_omniscient($hash_omniscient);
+    info_omniscient($hash_omniscient, $log, $verbose);
   }
 }
 

--- a/bin/agat_sp_merge_annotations.pl
+++ b/bin/agat_sp_merge_annotations.pl
@@ -56,7 +56,7 @@ my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $file1
                                                                  config => $config
                                                               });
 dual_print($log, "$file1 GFF3 file parsed\n", $opt_verbose);
-info_omniscient($hash_omniscient);
+info_omniscient($hash_omniscient, $log, $opt_verbose);
 
 #Add the features of the other file in the first omniscient. It takes care of name to not have duplicates
 foreach my $next_file (@opt_files){
@@ -64,12 +64,12 @@ foreach my $next_file (@opt_files){
 	                                                                   config => $config
                                                                   });
   dual_print($log, "$next_file GFF3 file parsed\n", $opt_verbose);
-  info_omniscient($hash_omniscient2);
+  info_omniscient($hash_omniscient2, $log, $opt_verbose);
 
   #merge annotation is taking care of Uniq name. Does not look if mRNA are identic or so one, it will be handle later.
   merge_omniscients($hash_omniscient, $hash_omniscient2);
   dual_print($log, "\nTotal raw data of files together:\n", $opt_verbose);
-  info_omniscient($hash_omniscient);
+  info_omniscient($hash_omniscient, $log, $opt_verbose);
 }
 
 # Now all the feature are in the same omniscient
@@ -79,7 +79,7 @@ merge_overlap_loci(undef, $hash_omniscient, $hash_mRNAGeneLink, undef);
 
 
 dual_print($log, "\nfinal result:\n", $opt_verbose);
-info_omniscient($hash_omniscient);
+info_omniscient($hash_omniscient, $log, $opt_verbose);
 
 ########
 # Print results

--- a/lib/AGAT/OmniscientTool.pm
+++ b/lib/AGAT/OmniscientTool.pm
@@ -1572,33 +1572,34 @@ sub _get_cds_start_phase {
 
 sub info_omniscient {
 
-	my ($hash_omniscient)=@_;
+        my ( $hash_omniscient, $log, $verbose ) = @_;
 
-	my %resu;
+        my %resu;
 
-	foreach my $tag (keys %{$hash_omniscient->{'level1'}}){
-    	my $nb=keys %{$hash_omniscient->{'level1'}{$tag}};
-    	$resu{$tag}=$nb;
-	}
+        foreach my $tag ( keys %{ $hash_omniscient->{'level1'} } ) {
+                my $nb = keys %{ $hash_omniscient->{'level1'}{$tag} };
+                $resu{$tag} = $nb;
+        }
 
-	foreach my $level (keys %{$hash_omniscient}){
-  		if ($level eq 'level2' or $level eq 'level3'){
-    			foreach my $tag (keys %{$hash_omniscient->{$level}}){
-      				foreach my $id (keys %{$hash_omniscient->{$level}{$tag}}){
-        				my $nb=$#{$hash_omniscient->{$level}{$tag}{$id}}+1;
-						if(exists_keys(\%resu,($tag))){
-						        $resu{$tag} += $nb;
-						}
-						else{
-							$resu{$tag}=$nb;
-						}
-     				}
-    			}
-  		}
-	}
-	foreach my $tag (keys %resu){
-		print "There is $resu{$tag} $tag\n";
-	}
+        foreach my $level ( keys %{$hash_omniscient} ) {
+                if ( $level eq 'level2' or $level eq 'level3' ) {
+                        foreach my $tag ( keys %{ $hash_omniscient->{$level} } ) {
+                                foreach my $id ( keys %{ $hash_omniscient->{$level}{$tag} } ) {
+                                        my $nb =
+                                          $# { $hash_omniscient->{$level}{$tag}{$id} } + 1;
+                                        if ( exists_keys( \%resu, ($tag) ) ) {
+                                                $resu{$tag} += $nb;
+                                        }
+                                        else {
+                                                $resu{$tag} = $nb;
+                                        }
+                                }
+                        }
+                }
+        }
+        foreach my $tag ( keys %resu ) {
+                dual_print( $log, "There is $resu{$tag} $tag\n", $verbose );
+        }
 }
 
 # omniscient is a hash containing a whole gXf file in memory sorted in a specific way (3 levels)


### PR DESCRIPTION
## Summary
- replace bare print in `info_omniscient` with `dual_print` and add log/verbose parameters
- update `agat_sp_merge_annotations.pl` and `agat_sp_complement_annotations.pl` to pass logging parameters

## Testing
- `prove -lr t/smoke` *(failed: Cannot detect source of 't/smoke')*
- `perlcritic --gentle lib bin` *(command not found)*
- `make test` *(failed: test suite reported many failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e1a199f8832aad58e472aff3459a