### PR TITLE
Handle quiet mode and remove verbose warnings

### DIFF
--- a/bin/agat_convert_bed2gff.pl
+++ b/bin/agat_convert_bed2gff.pl
@@ -27,7 +27,7 @@ my ( $opt, $usage, $config ) = AGAT::AGAT::describe_script_options(
 my $bed          = $opt->bed;
 my $source_tag   = $opt->source;
 my $primary_tag  = $opt->primary_tag;
-my $inflating_off = $opt->inflate_off;
+my $inflating_off = $opt->inflate_off // 0;
 my $inflate_type = $opt->inflate_type;
 my $opt_verbose  = $config->{verbose};
 

--- a/bin/agat_convert_mfannot2gff.pl
+++ b/bin/agat_convert_mfannot2gff.pl
@@ -14,15 +14,13 @@ my ( $opt, $usage, $config ) = AGAT::AGAT::describe_script_options(
 );
 
 my $mfannot_file = $opt->mfannot;
-my $opt_verbose  = $config->{verbose};
-
 my $log;
 if ( my $log_name = $config->{log_path} ) {
     open( $log, '>', $log_name )
       or die "Can not open $log_name for printing: $!";
     dual_print( $log, $header, 0 );
 }
-my $opt_verbose = $config->{verbose};
+my $opt_verbose  = $config->{verbose};
 
 ## Manage output file
 my $gffout = prepare_gffout( $config, $config->{output} );

--- a/bin/agat_sp_kraken_assess_liftover.pl
+++ b/bin/agat_sp_kraken_assess_liftover.pl
@@ -20,6 +20,7 @@ my $outfile = undef;
 my $gff = undef;
 my $valueK = undef;
 my $verbose = undef;
+my $quiet   = 0;
 my $kraken_tag = "Kraken_mapped";
 my $kraken_tag_alt = 'kraken_mapped';
 my $opt_plot;
@@ -32,6 +33,7 @@ if ( !GetOptions(
     'threshold|t=i'            => \$valueK,
     'p|plot!'                  => \$opt_plot,
     'verbose|v!'               => \$verbose,
+    'quiet|q'                  => \$quiet,
     'outfile|output|out|o=s'   => \$outfile ) )
 {
     pod2usage( { -message => 'Failed to parse command line',
@@ -56,7 +58,13 @@ if ( ! (defined($gff)) ){
 # --- Manage config ---
 $config = get_agat_config({config_file_in => $config});
 
-my $opt_verbose = $verbose;
+if ($quiet) {
+    $verbose = 0;
+    $config->{verbose}      = 0;
+    $config->{progress_bar} = 0;
+}
+
+my $opt_verbose = defined $verbose ? $verbose : $config->{verbose};
 my $opt_output  = $outfile;
 my $log;
 if ( my $log_name = $config->{log_path} ) {
@@ -793,6 +801,10 @@ Gene mapping percentage over which a gene must be reported. By default the value
 =item B<--verbose> or B<-v>
 
 Verbose information.
+
+=item B<--quiet> or B<-q>
+
+Run quietly. Implies B<--verbose> 0 and disables the progress bar.
 
 =item  B<--p> or B<--plot>
 

--- a/docs/tools/agat_sp_kraken_assess_liftover.md
+++ b/docs/tools/agat_sp_kraken_assess_liftover.md
@@ -36,6 +36,10 @@ agat_sp_kraken_assess_lift_coverage --help
 
     Verbose information.
 
+- **--quiet** or **-q**
+
+    Run quietly. Sets verbosity to 0 and disables the progress bar.
+
 - **-o** , **--output** , **--out** or **--outfile**
 
     Output GFF file.  If no output file is specified, the output will be


### PR DESCRIPTION
## Summary
- avoid redeclaring `$opt_verbose` in `agat_convert_mfannot2gff.pl`
- default `inflate_off` flag to 0 in `agat_convert_bed2gff.pl`
- add `--quiet` option to `agat_sp_kraken_assess_liftover.pl` and document it

## Testing
- `make test` *(fails: Can't locate Getopt::Long::Descriptive.pm)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e4ac3d3c832aa625d7686abac2c7