### PR TITLE
Add grouped test targets and split CI steps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,8 @@ jobs:
 
     # The type of runner that the job will run on
     runs-on: ubuntu-22.04
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -45,12 +47,26 @@ jobs:
           run: cat /home/runner/.cpanm/build.log
       - name: install AGAT deps
         run: cpanm --installdeps --notest --force .
-      - name: test
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          perl Makefile.PL
-          HARNESS_OPTIONS=j$(nproc) make test
+      - name: generate Makefile
+        run: perl Makefile.PL
+      - name: test_config
+        run: HARNESS_OPTIONS=j$(nproc) make test_config
+      - name: test_agat_convert
+        run: HARNESS_OPTIONS=j$(nproc) make test_agat_convert
+      - name: test_agat_add
+        run: HARNESS_OPTIONS=j$(nproc) make test_agat_add
+      - name: test_agat_sp_extract
+        run: HARNESS_OPTIONS=j$(nproc) make test_agat_sp_extract
+      - name: test_agat_sp_filter
+        run: HARNESS_OPTIONS=j$(nproc) make test_agat_sp_filter
+      - name: test_agat_sp_fix
+        run: HARNESS_OPTIONS=j$(nproc) make test_agat_sp_fix
+      - name: test_agat_sp_manage
+        run: HARNESS_OPTIONS=j$(nproc) make test_agat_sp_manage
+      - name: test_agat_other
+        run: HARNESS_OPTIONS=j$(nproc) make test_agat_other
+      - name: test_gff
+        run: HARNESS_OPTIONS=j$(nproc) make test_gff
 
   # Run tests with coverage on Perl 5.30
   test_coverage:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
             perl-version: '5.36'
             install-modules-with: cpanm
             install-modules-args: --notest --force
-            install-modules: File::ShareDir::Install
+            install-modules: File::ShareDir::Install Getopt::Long::Descriptive
       - uses: webiny/action-post-run@2.0.1
         id: post-run-command
         if: ${{ failure() }}
@@ -55,14 +55,14 @@ jobs:
         run: HARNESS_OPTIONS=j$(nproc) make test_agat_convert
       - name: test_agat_add
         run: HARNESS_OPTIONS=j$(nproc) make test_agat_add
-      - name: test_agat_extract
-        run: HARNESS_OPTIONS=j$(nproc) make test_agat_extract
-      - name: test_agat_filter
-        run: HARNESS_OPTIONS=j$(nproc) make test_agat_filter
-      - name: test_agat_fix
-        run: HARNESS_OPTIONS=j$(nproc) make test_agat_fix
-      - name: test_agat_manage
-        run: HARNESS_OPTIONS=j$(nproc) make test_agat_manage
+      - name: test_agat_sp_extract
+        run: HARNESS_OPTIONS=j$(nproc) make test_agat_sp_extract
+      - name: test_agat_sp_filter
+        run: HARNESS_OPTIONS=j$(nproc) make test_agat_sp_filter
+      - name: test_agat_sp_fix
+        run: HARNESS_OPTIONS=j$(nproc) make test_agat_sp_fix
+      - name: test_agat_sp_manage
+        run: HARNESS_OPTIONS=j$(nproc) make test_agat_sp_manage
       - name: test_agat_other
         run: HARNESS_OPTIONS=j$(nproc) make test_agat_other
       - name: test_gff
@@ -96,7 +96,7 @@ jobs:
             perl-version: '5.30'
             install-modules-with: cpanm
             install-modules-args: --notest --force
-            install-modules: File::ShareDir::Install Devel::Cover@1.44 Devel::Cover::Report::Coveralls
+            install-modules: File::ShareDir::Install Getopt::Long::Descriptive Devel::Cover@1.44 Devel::Cover::Report::Coveralls
       - uses: webiny/action-post-run@2.0.1
         id: post-run-command
         if: ${{ failure() }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,24 +45,24 @@ jobs:
         if: ${{ failure() }}
         with:
           run: cat /home/runner/.cpanm/build.log
-      - name: install AGAT deps
-        run: cpanm --installdeps --notest --force .
       - name: generate Makefile
         run: perl Makefile.PL
+      - name: install AGAT deps
+        run: cpanm --installdeps --notest --force .
       - name: test_config
         run: HARNESS_OPTIONS=j$(nproc) make test_config
       - name: test_agat_convert
         run: HARNESS_OPTIONS=j$(nproc) make test_agat_convert
       - name: test_agat_add
         run: HARNESS_OPTIONS=j$(nproc) make test_agat_add
-      - name: test_agat_sp_extract
-        run: HARNESS_OPTIONS=j$(nproc) make test_agat_sp_extract
-      - name: test_agat_sp_filter
-        run: HARNESS_OPTIONS=j$(nproc) make test_agat_sp_filter
-      - name: test_agat_sp_fix
-        run: HARNESS_OPTIONS=j$(nproc) make test_agat_sp_fix
-      - name: test_agat_sp_manage
-        run: HARNESS_OPTIONS=j$(nproc) make test_agat_sp_manage
+      - name: test_agat_extract
+        run: HARNESS_OPTIONS=j$(nproc) make test_agat_extract
+      - name: test_agat_filter
+        run: HARNESS_OPTIONS=j$(nproc) make test_agat_filter
+      - name: test_agat_fix
+        run: HARNESS_OPTIONS=j$(nproc) make test_agat_fix
+      - name: test_agat_manage
+        run: HARNESS_OPTIONS=j$(nproc) make test_agat_manage
       - name: test_agat_other
         run: HARNESS_OPTIONS=j$(nproc) make test_agat_other
       - name: test_gff
@@ -102,6 +102,8 @@ jobs:
         if: ${{ failure() }}
         with:
           run: cat /home/runner/.cpanm/build.log
+      - name: generate Makefile
+        run: perl Makefile.PL
       - name: install AGAT deps
         run: cpanm --installdeps --notest --force .
       - name: test

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -134,4 +134,35 @@ WriteMakefile(%WriteMakefileArgs);
 
 #Mandatory otherwise the data files from the share folder will not be copied.
 package MY;
-use File::ShareDir::Install 'postamble';
+use File::ShareDir::Install;
+
+sub postamble {
+  File::ShareDir::Install::postamble() . <<'POSTAMBLE';
+test_agat_convert :
+	$(MAKE) test TEST_FILES="$(wildcard t/agat_convert*.t)"
+
+test_agat_add :
+	$(MAKE) test TEST_FILES="$(wildcard t/agat_s[pq]_add_*.t)"
+
+test_agat_sp_extract :
+	$(MAKE) test TEST_FILES="$(wildcard t/agat_sp_extract_*.t)"
+
+test_agat_sp_filter :
+	$(MAKE) test TEST_FILES="$(wildcard t/agat_sp_filter_*.t)"
+
+test_agat_sp_fix :
+	$(MAKE) test TEST_FILES="$(wildcard t/agat_sp_fix_*.t)"
+
+test_agat_sp_manage :
+	$(MAKE) test TEST_FILES="$(wildcard t/agat_sp_manage_*.t)"
+
+test_agat_other :
+	$(MAKE) test TEST_FILES="$(filter-out $(wildcard t/agat_s[pq]_add_*.t) $(wildcard t/agat_sp_extract_*.t) $(wildcard t/agat_sp_filter_*.t) $(wildcard t/agat_sp_fix_*.t) $(wildcard t/agat_sp_manage_*.t), $(wildcard t/agat_s*_*.t))"
+
+test_gff :
+	$(MAKE) test TEST_FILES="$(wildcard t/gff/*.t)"
+
+test_config :
+	$(MAKE) test TEST_FILES="$(filter-out $(wildcard t/agat*.t), $(wildcard t/*.t))"
+POSTAMBLE
+}

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -137,27 +137,27 @@ package MY;
 use File::ShareDir::Install;
 
 sub postamble {
-  File::ShareDir::Install::postamble() . <<'POSTAMBLE';
+  File::ShareDir::Install::postamble(@_) . <<'POSTAMBLE';
 test_agat_convert :
 	$(MAKE) test TEST_FILES="$(wildcard t/agat_convert*.t)"
 
 test_agat_add :
 	$(MAKE) test TEST_FILES="$(wildcard t/agat_s[pq]_add_*.t)"
 
-test_agat_sp_extract :
-	$(MAKE) test TEST_FILES="$(wildcard t/agat_sp_extract_*.t)"
+test_agat_extract :
+	$(MAKE) test TEST_FILES="$(wildcard t/agat_s[pq]_extract_*.t)"
 
-test_agat_sp_filter :
-	$(MAKE) test TEST_FILES="$(wildcard t/agat_sp_filter_*.t)"
+test_agat_filter :
+	$(MAKE) test TEST_FILES="$(wildcard t/agat_s[pq]_filter_*.t)"
 
-test_agat_sp_fix :
-	$(MAKE) test TEST_FILES="$(wildcard t/agat_sp_fix_*.t)"
+test_agat_fix :
+	$(MAKE) test TEST_FILES="$(wildcard t/agat_s[pq]_fix_*.t)"
 
-test_agat_sp_manage :
-	$(MAKE) test TEST_FILES="$(wildcard t/agat_sp_manage_*.t)"
+test_agat_manage :
+	$(MAKE) test TEST_FILES="$(wildcard t/agat_s[pq]_manage_*.t)"
 
 test_agat_other :
-	$(MAKE) test TEST_FILES="$(filter-out $(wildcard t/agat_s[pq]_add_*.t) $(wildcard t/agat_sp_extract_*.t) $(wildcard t/agat_sp_filter_*.t) $(wildcard t/agat_sp_fix_*.t) $(wildcard t/agat_sp_manage_*.t), $(wildcard t/agat_s*_*.t))"
+	$(MAKE) test TEST_FILES="$(filter-out $(wildcard t/agat_s[pq]_add_*.t) $(wildcard t/agat_s[pq]_extract_*.t) $(wildcard t/agat_s[pq]_filter_*.t) $(wildcard t/agat_s[pq]_fix_*.t) $(wildcard t/agat_s[pq]_manage_*.t), $(wildcard t/agat_s*_*.t))"
 
 test_gff :
 	$(MAKE) test TEST_FILES="$(wildcard t/gff/*.t)"

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -144,16 +144,16 @@ test_agat_convert :
 test_agat_add :
 	$(MAKE) test TEST_FILES="$(wildcard t/agat_s[pq]_add_*.t)"
 
-test_agat_extract :
+test_agat_sp_extract :
 	$(MAKE) test TEST_FILES="$(wildcard t/agat_s[pq]_extract_*.t)"
 
-test_agat_filter :
+test_agat_sp_filter :
 	$(MAKE) test TEST_FILES="$(wildcard t/agat_s[pq]_filter_*.t)"
 
-test_agat_fix :
+test_agat_sp_fix :
 	$(MAKE) test TEST_FILES="$(wildcard t/agat_s[pq]_fix_*.t)"
 
-test_agat_manage :
+test_agat_sp_manage :
 	$(MAKE) test TEST_FILES="$(wildcard t/agat_s[pq]_manage_*.t)"
 
 test_agat_other :


### PR DESCRIPTION
## Summary
- group tests in Makefile.PL for convert, add, sp_* categories, gff, and config suites
- run `test_config` first and other test groups separately in CI

## Testing
- `bash .agents/with-perl-local.sh perl Makefile.PL` *(fails: Missing prerequisite modules)*
- `bash .agents/with-perl-local.sh make test` *(fails: No rule to make target `test`)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ec2b2ac4832aa5b2deb404968d2f