### PR TITLE
Guard verbose-dependent output in AGAT modules

### DIFF
--- a/lib/AGAT/AGAT.pm
+++ b/lib/AGAT/AGAT.pm
@@ -336,14 +336,15 @@ sub handle_main {
 sub handle_levels {
 		my ($general, $config, $args) = @_;
 
-		my $expose = $general->{configs}[-1]{expose};
-		my $help = $general->{configs}[-1]{help};
+                my $expose = $general->{configs}[-1]{expose};
+                my $help = $general->{configs}[-1]{help};
+                my $verbose = $general->{configs}[-1]{verbose};
 
 		# Deal with Expose feature OPTION
-		if($expose){
-			expose_levels();
-			print "Feature_levels YAML file copied in your working directory\n";
-		}
+                if($expose){
+                        expose_levels({ verbose => $verbose });
+                        print "Feature_levels YAML file copied in your working directory\n" if $verbose;
+                }
 
 		# if help was called (or not arg provided) we let AppEaser continue to print help
 		my $nb_args = keys %{$general->{configs}[-1]};
@@ -392,7 +393,7 @@ sub handle_config {
 		if($expose){
 			my $config_file = get_config({type => "original"});
 			my $config = load_config({ config_file => $config_file});
-			print "Config loaded\n";
+                        print "Config loaded\n" if $verbose;
 
 			# set config params on the fly
 			my $modified_on_the_fly = undef;
@@ -536,12 +537,12 @@ sub handle_config {
 			}
 
 			if ($modified_on_the_fly) {
-					print "Config modified\n";
+                                        print "Config modified\n" if $verbose;
 			}
 
 			# check config
 			check_config({ config => $config});
-			print "Config checked\n";
+                        print "Config checked\n" if $verbose;
 
 			 
 			
@@ -556,7 +557,7 @@ sub handle_config {
 			if($config_new_name){
 				$config_file_used = $config_new_name;
 			} else { $config_file_used = "agat_config.yaml"; }
-			print "Config file written in your working directory ($config_file_used)\n";
+                        print "Config file written in your working directory ($config_file_used)\n" if $verbose;
 		}
 
 		# if help was called (or not arg provided) we let AppEaser continue to print help

--- a/lib/AGAT/Levels.pm
+++ b/lib/AGAT/Levels.pm
@@ -126,13 +126,19 @@ sub load_levels{
 
 # @Purpose: copy the yaml level feature file in the current directory 
 sub expose_levels{
-	
+
+	my ($args) = @_;
+	my $verbose = 0;
+	if ( defined $args && ref($args) eq 'HASH' ) {
+		$verbose = $args->{verbose} // 0;
+	}
+
 	my	$path = dist_file('AGAT', $feature_levels_file);
-	print "Path where $feature_levels_file is standing according to dist_file: $path\n";
-	
+	print "Path where $feature_levels_file is standing according to dist_file: $path\n" if $verbose;
+
 	# copy the json files locally
 	my $run_dir = cwd;
-	copy($path, $run_dir) or die print "Copy failed: $!";
+	copy($path, $run_dir) or die "Copy failed: $!";
 }
 
 1;

--- a/lib/AGAT/OmniscientO.pm
+++ b/lib/AGAT/OmniscientO.pm
@@ -756,14 +756,16 @@ sub webapollo_rendering_l3 {
 
 #Transform omniscient data to be embl compliant
 sub embl_compliant {
-		my ($omniscient) = @_  ;
+                my ($omniscient) = @_  ;
+
+        my $verbose = $omniscient->{"config"}{"verbose"};
 
 	#################
 	# == LEVEL 1 == #
 	#################
 	foreach my $primary_tag_key_level1 (keys %{$omniscient->{'level1'}}){ # primary_tag_key_level1 = gene or repeat etc...
 		foreach my $id_tag_key_level1 (keys %{$omniscient->{'level1'}{$primary_tag_key_level1}}){
-			_embl_rendering($omniscient->{'level1'}{$primary_tag_key_level1}{$id_tag_key_level1});
+                        _embl_rendering($omniscient->{'level1'}{$primary_tag_key_level1}{$id_tag_key_level1}, $verbose);
 
 			#################
 			# == LEVEL 2 == #
@@ -772,7 +774,7 @@ sub embl_compliant {
 
 				if ( exists ($omniscient->{'level2'}{$primary_tag_key_level2}{$id_tag_key_level1} ) ){
 					foreach my $feature_level2 ( @{$omniscient->{'level2'}{$primary_tag_key_level2}{$id_tag_key_level1}}) {
-						_embl_rendering($feature_level2);
+                                        _embl_rendering($feature_level2, $verbose);
 
 						#################
 						# == LEVEL 3 == #
@@ -783,7 +785,7 @@ sub embl_compliant {
 
 							if ( exists ($omniscient->{'level3'}{$primary_tag_key_level3}{$level2_ID} ) ){
 								foreach my $feature_level3 ( @{$omniscient->{'level3'}{$primary_tag_key_level3}{$level2_ID}}) {
-									_embl_rendering($feature_level3);
+                                                                        _embl_rendering($feature_level3, $verbose);
 								}
 							}
 						}
@@ -796,7 +798,7 @@ sub embl_compliant {
 
 sub _embl_rendering {
 
-	my ($feature)=@_;
+        my ($feature, $verbose)=@_;
 
 	## check primary tag
 	my $primary_tag = lc($feature->primary_tag);
@@ -820,7 +822,7 @@ sub _embl_rendering {
 			elsif($primary_tag =~ /utr/ and ($primary_tag =~ /5/ or $primary_tag =~ /five/) ){
 				$feature->$primary_tag = "5'UTR";
 			}
-			print "WARNING: this primary tag ".$primary_tag." is not recognized among those expected to be EMBL compliant. Please check it or create an exception rule.\n";
+                        print "WARNING: this primary tag ".$primary_tag." is not recognized among those expected to be EMBL compliant. Please check it or create an exception rule.\n" if $verbose;
 		}
 	}
 }

--- a/lib/AGAT/OmniscientToGTF.pm
+++ b/lib/AGAT/OmniscientToGTF.pm
@@ -326,7 +326,7 @@ sub _convert_feature_type{
 												}
 											}
 											else{
-												print "Warning: stop codon longer than 3 nucleotides for $level2_ID\n";
+                                                                                               print "Warning: stop codon longer than 3 nucleotides for $level2_ID\n" if $verbose;
 											}
 										}
 									}
@@ -354,7 +354,7 @@ sub _convert_feature_type{
 												}
 											}
 											else{
-												print "Warning: stop codon longer than 3 nucleotides for $level2_ID\n";
+                                                                                               print "Warning: stop codon longer than 3 nucleotides for $level2_ID\n" if $verbose;
 											}
 										}
 									}


### PR DESCRIPTION
## Summary
- wrap stop codon warnings in OmniscientToGTF with verbose checks
- add optional verbose to expose_levels and propagate in AGAT
- gate config and levels messages on verbose and extend EMBL compliance warnings

## Testing
- `make test` *(fails: output differences in multiple agat_sp scripts)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ecf452e8832a9ecdb3be3a5e68f2