### PR TITLE
Use dual_print in Prokka gene fixer

### DIFF
--- a/bin/agat_sp_prokka_fix_fragmented_gene_annotations.pl
+++ b/bin/agat_sp_prokka_fix_fragmented_gene_annotations.pl
@@ -440,17 +440,17 @@ sub check_protein_size_congruency{
 	$total_putative_gene_fixed_before += @$listGeneToMerge;
 	$total_putative_gene_fixed_after ++;
 
-	print "\nBased on their names and the fact they are conitguous, those ".@$listGeneToMerge." genes might be merged: @$listGeneNameToMerge \n";
+        dual_print($log, "\nBased on their names and the fact they are conitguous, those ".@$listGeneToMerge." genes might be merged: @$listGeneNameToMerge \n", $verbose);
   retrieve_expected_protein_length($obj_case);
 
 	my $expected_protein_length = $obj_case->{expected_length};
 	if ($expected_protein_length){
-	 	print "Average of the expected length = $expected_protein_length \n" ;
+                dual_print($log, "Average of the expected length = $expected_protein_length \n", $verbose);
 
 	 	#add 10 percent to expected protein $seq_lengt
 	 	my $expected_protein_length_plus10 = int (($expected_protein_length * 110) / 100);
 		$obj_case->{expected_length_10} = $expected_protein_length_plus10;
-	 	print "Average of the expected length + 20 % = $expected_protein_length_plus10 \n";
+                dual_print($log, "Average of the expected length + 20 % = $expected_protein_length_plus10 \n", $verbose);
 
 		# need to get the oervlap to remove from the calculated length
 		my $aa_overlap = get_overlap($obj_case);
@@ -462,10 +462,10 @@ sub check_protein_size_congruency{
 	 	}
 		$total_current_size -= $aa_overlap; # remove all overlap parts
 		$obj_case->{current_aa_length_together} = $total_current_size;
-	 	print "current length adding all genes together (and removing overlaping part): $total_current_size\n";
+                dual_print($log, "current length adding all genes together (and removing overlaping part): $total_current_size\n", $verbose);
 
 	 	if ($total_current_size < $expected_protein_length_plus10){
-	 		print "$total_current_size < $expected_protein_length_plus10 => Let's merge them. (The length of the appended proteins is shorter than the size of the protein use for the inference)\n\n";
+                        dual_print($log, "$total_current_size < $expected_protein_length_plus10 => Let's merge them. (The length of the appended proteins is shorter than the size of the protein use for the inference)\n\n", $verbose);
 			$congruent_size++;
 			$size_congruency = 1;
 		}
@@ -474,7 +474,7 @@ sub check_protein_size_congruency{
 		}
 	}
 	else{
-		print "No expected size found - skip the case\n";
+                dual_print($log, "No expected size found - skip the case\n", $verbose);
 	}
  return $size_congruency;
 }
@@ -499,10 +499,10 @@ sub merge_case{
 		$gff_shift{$gene_feature1->seq_id}{$value_insert_position}=$value_insert_size; #keep track of shifts
 		my $sequence = $seqObj->seq();
 
-		print "add N x $value_insert_size at position $value_insert_position\n" if ($verbose);
-		print "piece of sequence before: ".substr($sequence, $value_insert_before + $value_insert_position - 10, 20)."\n" if ($verbose);
-		substr($sequence, $value_insert_before + $value_insert_position-1, 1) = "N" x ($value_insert_size+1);
-		print "piece of sequence after: ".substr($sequence, $value_insert_before + $value_insert_position - 10, 20)."\n" if ($verbose);
+                dual_print($log, "add N x $value_insert_size at position $value_insert_position\n", $verbose);
+                dual_print($log, "piece of sequence before: ".substr($sequence, $value_insert_before + $value_insert_position - 10, 20)."\n", $verbose);
+                substr($sequence, $value_insert_before + $value_insert_position-1, 1) = "N" x ($value_insert_size+1);
+                dual_print($log, "piece of sequence after: ".substr($sequence, $value_insert_before + $value_insert_position - 10, 20)."\n", $verbose);
 		$seqObj->seq($sequence);
 
 		# Should I add Pseudo attribure?
@@ -561,17 +561,17 @@ sub check_long_orf_if_can_be_merged{
 		my $gene_feature1 = shift @listGene;
 		my $gene_feature2 = $listGene[0];
 		my $intergenic = 1;
-		print $gene_feature1->gff_string()."\n" if ($verbose);
-		print $gene_feature2->gff_string()."\n" if ($verbose);
-		if($gene_feature1->end > $gene_feature2->start){
-			print "No intergenic region!\n";
-			$intergenic=undef;
+                dual_print($log, $gene_feature1->gff_string()."\n", $verbose);
+                dual_print($log, $gene_feature2->gff_string()."\n", $verbose);
+                if($gene_feature1->end > $gene_feature2->start){
+                        dual_print($log, "No intergenic region!\n", $verbose);
+                        $intergenic=undef;
 
-		}
-		else{
-			my $intergenic_region = [$gene_feature1->end,$gene_feature2->start];
-			print "intergenic_region = @$intergenic_region\n";
-		}
+                }
+                else{
+                        my $intergenic_region = [$gene_feature1->end,$gene_feature2->start];
+                        dual_print($log, "intergenic_region = @$intergenic_region\n", $verbose);
+                }
 
 		my $ID_correct = $all_db_fasta_IDs{lc($gene_feature1->seq_id)};
 
@@ -605,9 +605,9 @@ sub check_long_orf_if_can_be_merged{
 				# --- this overlaping part will be used as intergenec region to shift frame
 
 				my $overlap_part = $gene_feature1->end - $gene_feature2->start + 1;
-				print "overlap_part $overlap_part\n" if ($verbose);
-				my $to_shrink = 3 + ( 3 - ($overlap_part % 3) );
-				print "to_shrink (last codon plus offset needed to be in frame:) $to_shrink\n" if ($verbose);
+                                dual_print($log, "overlap_part $overlap_part\n", $verbose);
+                                my $to_shrink = 3 + ( 3 - ($overlap_part % 3) );
+                                dual_print($log, "to_shrink (last codon plus offset needed to be in frame:) $to_shrink\n", $verbose);
 				my $subseq1 = $db_fasta->seq($ID_correct, $gene_feature1->start, ($gene_feature2->start - $to_shrink - 1 ));
 				$subseq1_cds_obj = Bio::Seq->new(-seq => $subseq1, -alphabet => 'dna' );
 				$subseq1_cds_obj = $subseq1_cds_obj->revcom();
@@ -658,9 +658,9 @@ sub check_long_orf_if_can_be_merged{
 			}
 			else{
 				my $overlap_part = $gene_feature1->end - $gene_feature2->start + 1;
-				print "overlap_part $overlap_part\n" if ($verbose);
-				my $to_shrink = 3 + (  3 - ( $overlap_part % 3 ) ) ;
-				print "to_shrink (last codon plus offset needed to be in frame:) $to_shrink\n" if ($verbose);
+                                dual_print($log, "overlap_part $overlap_part\n", $verbose);
+                                my $to_shrink = 3 + (  3 - ( $overlap_part % 3 ) ) ;
+                                dual_print($log, "to_shrink (last codon plus offset needed to be in frame:) $to_shrink\n", $verbose);
 				my $subseq2 = $db_fasta->seq($ID_correct, $gene_feature1->end + $to_shrink + 1, $gene_feature2->end );
 				$subseq2_cds_obj = Bio::Seq->new(-seq => $subseq2, -alphabet => 'dna' );
 			}
@@ -673,11 +673,11 @@ sub check_long_orf_if_can_be_merged{
 		if ($gene_feature1->strand == -1 or $gene_feature1->strand eq "-"){
 			my $found = 0;
 			my $prot_second=$subseq1_prot_obj;
-			print "Minus strand swithching seq1 and seq2\n" if ($verbose);
-			print "full seq1: ".$subseq2_prot_obj_full->seq."\n" if ($verbose);
-			print "subseq1: ".$subseq2_prot_obj->seq."\n" if ($verbose);
-			print "full seq2: ".$subseq1_prot_obj_full->seq."\n" if ($verbose);
-			print "subseq2: ".$subseq1_prot_obj->seq."\n" if ($verbose);
+                        dual_print($log, "Minus strand swithching seq1 and seq2\n", $verbose);
+                        dual_print($log, "full seq1: ".$subseq2_prot_obj_full->seq."\n", $verbose);
+                        dual_print($log, "subseq1: ".$subseq2_prot_obj->seq."\n", $verbose);
+                        dual_print($log, "full seq2: ".$subseq1_prot_obj_full->seq."\n", $verbose);
+                        dual_print($log, "subseq2: ".$subseq1_prot_obj->seq."\n", $verbose);
 
 			#getting part1 for merging
 			if( exists $all_db_fasta_IDs{lc($gene_feature1->seq_id)}){
@@ -688,9 +688,9 @@ sub check_long_orf_if_can_be_merged{
 				my $cds_obj1 = Bio::Seq->new(-seq => $seq1, -alphabet => 'dna' );
 				$cds_obj1 = $cds_obj1->revcom();
 				my $prot_obj1 = $cds_obj1->translate(-codontable_id => $codonTable) ;
-				print "Test frame 1 : ".$prot_obj1->seq."\n" if ($verbose);;
-				if (index($prot_obj1->seq, $prot_second->seq) != -1) {
-					print "frame 1 contains protein2\nIs the codon stop from the first gene real? Does the codon code for a stop codon? Is there a substition? Is it a pseudogene?\n";
+                                dual_print($log, "Test frame 1 : ".$prot_obj1->seq."\n", $verbose);
+                                if (index($prot_obj1->seq, $prot_second->seq) != -1) {
+                                        dual_print($log, "frame 1 contains protein2\nIs the codon stop from the first gene real? Does the codon code for a stop codon? Is there a substition? Is it a pseudogene?\n", $verbose);
 					$found++;
 					$case_frame1++;
 					$merged++ if ($pseudo);
@@ -702,9 +702,9 @@ sub check_long_orf_if_can_be_merged{
 				my $cds_obj2 = Bio::Seq->new(-seq => $seq2, -alphabet => 'dna' );
 				$cds_obj2 = $cds_obj2->revcom();
 				my $prot_obj2 = $cds_obj2->translate(-codontable_id => $codonTable) ;
-				print "Test frame 2 : ".$prot_obj2->seq."\n" if ($verbose);
-				if (index($prot_obj2->seq, $prot_second->seq) != -1) {
-					print "frame 2 contains protein2\n";
+                                dual_print($log, "Test frame 2 : ".$prot_obj2->seq."\n", $verbose);
+                                if (index($prot_obj2->seq, $prot_second->seq) != -1) {
+                                        dual_print($log, "frame 2 contains protein2\n", $verbose);
 					push @{$obj_case->{insert_size}}, 1;
 					push @{$obj_case->{total_insert_before}}, $total_insert_before ;
 					$total_insert_before += 1;
@@ -720,9 +720,9 @@ sub check_long_orf_if_can_be_merged{
 				my $cds_obj3 = Bio::Seq->new(-seq => $seq3, -alphabet => 'dna' );
 				$cds_obj3 = $cds_obj3->revcom();
 				my $prot_obj3 = $cds_obj3->translate(-codontable_id => $codonTable) ;
-				print "Test frame 3 : ".$prot_obj3->seq."\n" if ($verbose);
-				if (index($prot_obj3->seq, $prot_second->seq) != -1) {
-					print "frame 3 contains protein2\n";
+                                dual_print($log, "Test frame 3 : ".$prot_obj3->seq."\n", $verbose);
+                                if (index($prot_obj3->seq, $prot_second->seq) != -1) {
+                                        dual_print($log, "frame 3 contains protein2\n", $verbose);
 					push @{$obj_case->{insert_size}}, 2;
 					push @{$obj_case->{total_insert_before}}, $total_insert_before;
 					$total_insert_before += 2;
@@ -734,7 +734,7 @@ sub check_long_orf_if_can_be_merged{
 				}
 			}
 			else{
-				print "ERROR ".$gene_feature1->seq_id." not found among the db!";
+                                dual_print($log, "ERROR ".$gene_feature1->seq_id." not found among the db!\n", $verbose);
 			}
 			if (! $found){
                                 my $msg = "subseq2 not found in any frame. There is a problem when preparing subseq2\n";
@@ -742,17 +742,17 @@ sub check_long_orf_if_can_be_merged{
                                 warn $msg if $verbose;
 			}
 			elsif($found>1){
-				print "interesting, subseq2 found in $found frames\n";
+                                dual_print($log, "interesting, subseq2 found in $found frames\n", $verbose);
 			}
 		}
 		# ---- strand + ----
 		else{
 			my $found = 0;
 			my $prot_second=$subseq2_prot_obj;
-			print "full seq1: ".$subseq1_prot_obj_full->seq."\n" if ($verbose);;
-			print "subseq1: ".$subseq1_prot_obj->seq."\n" if ($verbose);
-			print "full seq2: ".$subseq2_prot_obj_full->seq."\n" if ($verbose);
-			print "subseq2: ".$subseq2_prot_obj->seq."\n" if ($verbose);
+                        dual_print($log, "full seq1: ".$subseq1_prot_obj_full->seq."\n", $verbose);
+                        dual_print($log, "subseq1: ".$subseq1_prot_obj->seq."\n", $verbose);
+                        dual_print($log, "full seq2: ".$subseq2_prot_obj_full->seq."\n", $verbose);
+                        dual_print($log, "subseq2: ".$subseq2_prot_obj->seq."\n", $verbose);
 
 			#getting part1 for merging
 			if( exists $all_db_fasta_IDs{lc($gene_feature1->seq_id)}){
@@ -762,9 +762,9 @@ sub check_long_orf_if_can_be_merged{
 				my $seq1 = $seq."N".$db_fasta->seq($ID_correct, $gene_feature1->end + 1, $gene_feature2->end);
 				my $cds_obj1 = Bio::Seq->new(-seq => $seq1, -alphabet => 'dna' );
 				my $prot_obj1 = $cds_obj1->translate(-codontable_id => $codonTable) ;
-				print "Test frame 1 : ".$prot_obj1->seq."\n" if ($verbose);
-				if (index($prot_obj1->seq, $prot_second->seq) != -1) {
-					print "frame 1 contains protein2\nIs the codon stop from the first gene real? Does the codon code for a stop codon? Is there a substition? Is it a pseudogene?\n";
+                                dual_print($log, "Test frame 1 : ".$prot_obj1->seq."\n", $verbose);
+                                if (index($prot_obj1->seq, $prot_second->seq) != -1) {
+                                        dual_print($log, "frame 1 contains protein2\nIs the codon stop from the first gene real? Does the codon code for a stop codon? Is there a substition? Is it a pseudogene?\n", $verbose);
 					$found++;
 					$case_frame1++;
 					$merged++ if ($pseudo);
@@ -775,9 +775,9 @@ sub check_long_orf_if_can_be_merged{
 				my $seq2 = $seq."NN".$db_fasta->seq($ID_correct, $gene_feature1->end + 1, $gene_feature2->end);
 				my $cds_obj2 = Bio::Seq->new(-seq => $seq2, -alphabet => 'dna' );
 				my $prot_obj2 = $cds_obj2->translate(-codontable_id => $codonTable) ;
-				print "frame 2 : ".$prot_obj2->seq."\n" if ($verbose);
-				if (index($prot_obj2->seq, $prot_second->seq) != -1) {
-					print "frame 2 contains protein2\n";
+                                dual_print($log, "frame 2 : ".$prot_obj2->seq."\n", $verbose);
+                                if (index($prot_obj2->seq, $prot_second->seq) != -1) {
+                                        dual_print($log, "frame 2 contains protein2\n", $verbose);
 					push @{$obj_case->{insert_size}}, 1;
 					push @{$obj_case->{total_insert_before}}, $total_insert_before;
 					$total_insert_before += 1;
@@ -792,9 +792,9 @@ sub check_long_orf_if_can_be_merged{
 				my $seq3 = $seq."NNN".$db_fasta->seq($ID_correct, $gene_feature1->end + 1, $gene_feature2->end);
 				my $cds_obj3 = Bio::Seq->new(-seq => $seq3, -alphabet => 'dna' );
 				my $prot_obj3 = $cds_obj3->translate(-codontable_id => $codonTable) ;
-				print "frame 3 : ".$prot_obj3->seq."\n" if ($verbose);
-				if (index($prot_obj3->seq, $prot_second->seq) != -1) {
-					print "frame 3 contains protein2\n";
+                                dual_print($log, "frame 3 : ".$prot_obj3->seq."\n", $verbose);
+                                if (index($prot_obj3->seq, $prot_second->seq) != -1) {
+                                        dual_print($log, "frame 3 contains protein2\n", $verbose);
 					push @{$obj_case->{insert_size}}, 2;
 					push @{$obj_case->{total_insert_before}}, $total_insert_before;
 					$total_insert_before += 2;
@@ -810,11 +810,11 @@ sub check_long_orf_if_can_be_merged{
                                 warn $msg if $verbose;
 				}
 				elsif($found>1){
-					print "interesting, subseq2 found in $found frames\n";
+                                        dual_print($log, "interesting, subseq2 found in $found frames\n", $verbose);
 				}
 			}
 			else{
-				print "ERROR ".$gene_feature1->seq_id." not found among the db!";
+                                dual_print($log, "ERROR ".$gene_feature1->seq_id." not found among the db!\n", $verbose);
 			}
 		}
 	}
@@ -835,11 +835,11 @@ sub get_overlap {
 
 		if($gene_feature1->end > $gene_feature2->start){
 			my $overlap_region = $gene_feature1->end - $gene_feature2->start + 1;
-			print "overlap_region nt = $overlap_region\n" if ($verbose);
+                        dual_print($log, "overlap_region nt = $overlap_region\n", $verbose);
 			$overlap += ($overlap_region * 2); # overlap touch both gene
 		}
 		else{
-			print "No overlap_region region!\n" if ($verbose);
+                        dual_print($log, "No overlap_region region!\n", $verbose);
 			$overlap+=0;
 		}
 	}
@@ -862,7 +862,7 @@ sub retrieve_expected_protein_length{
 		$obj_sub_gene->{current_dna_length} = $gene_feature->end - $gene_feature->start + 1;
 		$obj_sub_gene->{current_aa_length} = $gene_size;
 
-		print $gene_feature->_tag_value('Name')." has a AA size of: $gene_size\n";
+                dual_print($log, $gene_feature->_tag_value('Name')." has a AA size of: $gene_size\n", $verbose);
 
 		if ($gene_feature->has_tag("inference")){
 			my @inference_atts = $gene_feature->get_tag_values("inference");
@@ -891,22 +891,22 @@ sub retrieve_expected_protein_length{
 		my $prot_name = $obj_sub_gene->{inference_value};
 
 		if (lc($obj_sub_gene->{inference_db}) eq "uniprotkb"){
-			print "Inference made with Uniprot, looking for protein size: $prot_name\n";
+                        dual_print($log, "Inference made with Uniprot, looking for protein size: $prot_name\n", $verbose);
 			if( exists $all_db_db_IDs{lc($prot_name)}){
 				my $protID_correct = $all_db_db_IDs{lc($prot_name)};
 				$obj_sub_gene->{inference_aa_length} = $db_db->length( $protID_correct );
 				$obj_sub_gene->{inference_aa_seq} = $db_db->seq($protID_correct);
 			}
 			else{
-				print "ERROR $prot_name not found among the db!";
+                                dual_print($log, "ERROR $prot_name not found among the db!\n", $verbose);
 			}
 		}
 		elsif (lc($obj_sub_gene->{inference_db}) eq "hamap"){
-			print "Inference made with HAMAP, looking for protein size using internet: $prot_name\n";
+                        dual_print($log, "Inference made with HAMAP, looking for protein size using internet: $prot_name\n", $verbose);
 			fetcher_HAMAP($obj_sub_gene) if (! $skip_hamap);
 		}
 		else{
-			print "Inference made with ".$obj_sub_gene->{inference_db}.", not yet implemented\n";
+                        dual_print($log, "Inference made with ".$obj_sub_gene->{inference_db}.", not yet implemented\n", $verbose);
 		}
 
 		#I have a length, let's check if we can merge the case
@@ -914,7 +914,7 @@ sub retrieve_expected_protein_length{
 			push @{$obj_case->{list_aa_size}}, $obj_sub_gene->{inference_aa_length};
 			$total_size += $obj_sub_gene->{inference_aa_length};
 			$nb_prot++;
-			print "AA length found ".$obj_sub_gene->{inference_aa_length}." \n";
+                        dual_print($log, "AA length found ".$obj_sub_gene->{inference_aa_length}." \n", $verbose);
 		}
 	}
 	$obj_case->{expected_length} = int($total_size/$nb_prot) if $nb_prot;
@@ -936,7 +936,7 @@ sub fetcher_HAMAP {
 				my $string = $response->decoded_content;
 				#print $string."\n";
 				if ( $string =~ /.*<td>(.*)amino acids<\/td>.*/){
-					print "size range: $1\n";
+                                        dual_print($log, "size range: $1\n", $verbose);
 					my @data = split /-/, $1 ;
 
 					if($hamap_size eq "low"){
@@ -955,12 +955,13 @@ sub fetcher_HAMAP {
 
 				}
 				else{
-					print "No size found for $id\n";
+                                        dual_print($log, "No size found for $id\n", $verbose);
 				}
 			$obj_sub_gene->{inference_aa_length} = $size;
 		}
 		else {
-			print $response->status_line && die;
+                        dual_print($log, $response->status_line."\n", $verbose);
+                        die;
 		}
 }
 


### PR DESCRIPTION
## Summary
- replace remaining print statements in `agat_sp_prokka_fix_fragmented_gene_annotations.pl` with `dual_print` to honor verbose and log settings

## Testing
- `.agents/with-perl-local.sh prove -lr t/smoke` *(fails: Cannot detect source of 't/smoke')*
- `.agents/with-perl-local.sh make test` *(fails: output mismatch for `agat_convert_embl2gff.pl` and non-empty stdout)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f5ca3390832a80725cc143c11aac