### PR TITLE
Add quiet option to agat config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@
 ## Tests
 - Full suite: `make test`
 - Coverage (optional): `cover -test` (uploader: Coveralls/Codecov if configured)
-- Config management: `agat config --expose 2>&1 1>/dev/null` (redirecting to suppress messages). By default, it creates `agat_config.yaml` in the workdir. Use `--output <local_config_path>` to rename and `--config <local_config_path>` when invoking scripts.
+- Config management: `agat config --quiet --expose` (creates `agat_config.yaml` in the workdir). Use `--output <local_config_path>` to rename and `--config <local_config_path>` when invoking scripts.
 
 ### Default parser config
 If not overriden by --expose invokation with custom parameters, tests use these `share/agat_config.yaml` defaults:

--- a/bin/agat
+++ b/bin/agat
@@ -161,14 +161,19 @@ force_gff_input_version, gtf_output_version, gff_output_version and output_forma
 							getopt      => 'log!',
 							help        => 'To create a log file while parsing the input file to keep track of modification made by AGAT. [Default activated]',
 					 },
-					 {
-							getopt      => 'debug!',
-							help        => 'Extra verbosity for debugging. [Default deactivated]',
-					 },
-					 {
-							getopt      => 'tabix!',
-							help        => 'To sort the output in tabix format. [Default deactivated]',
-					 },
+                                         {
+                                                        getopt      => 'debug!',
+                                                        help        => 'Extra verbosity for debugging. [Default deactivated]',
+                                         },
+                                        {
+                                                        getopt      => 'quiet|q!',
+                                                        help        => 'Disable verbose output, progress bar, and debug.',
+                                                        shortbool   => 1,
+                                        },
+                                        {
+                                                        getopt      => 'tabix!',
+                                                        help        => 'To sort the output in tabix format. [Default deactivated]',
+                                        },
 					 {
 							getopt      => 'merge_loci!',
 							help        => 'To merge loci that overlap at CDS level in a single locus. [Default deactivated]',

--- a/docs/agat_how_does_it_work.md
+++ b/docs/agat_how_does_it_work.md
@@ -72,7 +72,7 @@ Example of gene_id/transcript_id relationship used by the GTF format:
   **2. ELSE Parsing approach 2: by a common attribute/tag** 
 
   a common attribute (or common tag) is an attribute value shared by feature that must be grouped together. AGAT uses default attributes (`gene_id` and `locus_tag`) displayed in the log but can be set by the user modifying the AGAT configuration file `agat_config.yaml`.  
-  You can modify the `agat_config.yaml` either running `agat config --expose` to access it (it will be copied in the current directory) and then modifying it manually; or running `agat config --expose --locus_tag attribute_name` that will copy the `agat_config.yaml` locally with the modification of the `locus_tag` parameter accordingly.
+  You can modify the `agat_config.yaml` either running `agat config --expose` to access it (it will be copied in the current directory) and then modifying it manually; or running `agat config --expose --locus_tag attribute_name` that will copy the `agat_config.yaml` locally with the modification of the `locus_tag` parameter accordingly. Add `--quiet` (or `-q`) to suppress verbose messages, the progress bar, and debug output.
 
 Example of relationship made using a common tag (here locus_tag):
 

--- a/lib/AGAT/AGAT.pm
+++ b/lib/AGAT/AGAT.pm
@@ -365,10 +365,11 @@ sub handle_config {
 		my $progress_bar = $general->{configs}[-1]{progress_bar};
 		my $config_new_name = $general->{configs}[-1]{output};
 		my $log = $general->{configs}[-1]{log};
-		my $debug = $general->{configs}[-1]{debug};
-		my $tabix = $general->{configs}[-1]{tabix};
-		my $merge_loci = $general->{configs}[-1]{merge_loci};
-		my $throw_fasta = $general->{configs}[-1]{throw_fasta};
+                my $debug = $general->{configs}[-1]{debug};
+                my $quiet = $general->{configs}[-1]{quiet};
+                my $tabix = $general->{configs}[-1]{tabix};
+                my $merge_loci = $general->{configs}[-1]{merge_loci};
+                my $throw_fasta = $general->{configs}[-1]{throw_fasta};
 		my $force_gff_input_version = $general->{configs}[-1]{force_gff_input_version};
 		my $output_format = $general->{configs}[-1]{output_format};
 		my $gff_output_version = $general->{configs}[-1]{gff_output_version};
@@ -387,12 +388,18 @@ sub handle_config {
 		my $check_utrs = $general->{configs}[-1]{check_utrs};
 		my $check_all_level2_locations = $general->{configs}[-1]{check_all_level2_locations};
 		my $check_all_level1_locations = $general->{configs}[-1]{check_all_level1_locations};
-		my $check_identical_isoforms = $general->{configs}[-1]{check_identical_isoforms};
-		my $prefix_new_id = $general->{configs}[-1]{prefix_new_id};
+                my $check_identical_isoforms = $general->{configs}[-1]{check_identical_isoforms};
+                my $prefix_new_id = $general->{configs}[-1]{prefix_new_id};
 
-		# Deal with Expose feature OPTION
-		if($expose){
-			my $config_file = get_config({type => "original"});
+                if ($quiet) {
+                        $verbose = 0;
+                        $progress_bar = 0;
+                        $debug = 0;
+                }
+
+                # Deal with Expose feature OPTION
+                if($expose){
+                        my $config_file = get_config({type => "original"});
 			my $config = load_config({ config_file => $config_file});
                         print "Config loaded\n" if $verbose;
 


### PR DESCRIPTION
## Summary
- allow `agat config` to accept `--quiet`/`-q`
- ensure quiet mode disables verbose output, progress bar, and debug
- document quiet usage in configuration docs and guidelines

## Testing
- `.agents/with-perl-local.sh make test` *(fails: t/agat_convert_embl2gff.t 1/4 subtests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ff54b5b4832a98d9882e961c135e