### PR TITLE
Use dual_print and propagate verbosity

### DIFF
--- a/bin/agat_sp_add_attribute_shortest_intron_size.pl
+++ b/bin/agat_sp_add_attribute_shortest_intron_size.pl
@@ -42,7 +42,7 @@ my $string1 = strftime "%m/%d/%Y at %Hh%Mm%Ss", localtime;
 $string1 .= "\n\nusage: $0 @copyARGV\n\n";
 
 print $ostreamReport $string1;
-if($opt_output){print $string1;}
+if($opt_output){ dual_print($log, $string1, $config->{verbose}); }
 
                                                       #######################
                                                       #        MAIN         #
@@ -50,10 +50,10 @@ if($opt_output){print $string1;}
 
 ######################
 ### Parse GFF input #
-print "Reading ".$opt_file,"\n";
+dual_print($log, "Reading $opt_file\n", $config->{verbose});
 my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $opt_file,
                                                                  config => $config });
-print("Parsing Finished\n\n");
+dual_print($log, "Parsing Finished\n\n", $config->{verbose});
 ### END Parse GFF input #
 #########################
 
@@ -113,7 +113,7 @@ foreach my $tag_l1 (keys %{$hash_omniscient->{'level1'}}){
 
 my $toprint = "$nb_cases_l1 $tag flags/attributes added to level1 features and $nb_cases_l2 $tag flags/attributes added to level2 features. The value of the attribute is size of the shortest exon found.\n";
 print $ostreamReport $toprint;
-if($opt_output){print $toprint;}
+if($opt_output){ dual_print($log, $toprint, $config->{verbose}); }
 print_omniscient( {omniscient => $hash_omniscient, output => $gffout} );
       #########################
       ######### END ###########

--- a/bin/agat_sp_add_intergenic_regions.pl
+++ b/bin/agat_sp_add_intergenic_regions.pl
@@ -41,7 +41,7 @@ my $gffout = prepare_gffout($config, $opt_output);
   #########################
 
 if(! exists_keys($omniscient,('level1', "gene") ) ){
-  dual_print($log, "No gene feature found in $opt_file, intergenic regions cannot be determinded!", 1);
+  dual_print($log, "No gene feature found in $opt_file, intergenic regions cannot be determinded!\n", $config->{verbose});
   exit 0;
 }
 
@@ -147,7 +147,7 @@ foreach my $locusID ( sort keys %{$flattened_locations}){ # tag_l1 = gene or rep
 # print result
 print_omniscient( {omniscient => $omniscient, output => $gffout} );
 
-print "$intergenic_added intergenic_region added!\nBye Bye\n";
+dual_print($log, "$intergenic_added intergenic_region added!\nBye Bye\n", $config->{verbose});
       #########################
       ######### END ###########
       #########################

--- a/bin/agat_sp_add_start_and_stop.pl
+++ b/bin/agat_sp_add_start_and_stop.pl
@@ -48,7 +48,7 @@ if ( my $log_name = $config->{log_path} ) {
 # #######################
 my $gffout = prepare_gffout( $config, $config->{output} );
 
-$codon_table_id = get_proper_codon_table($codon_table_id);
+$codon_table_id = get_proper_codon_table($codon_table_id, $log, $opt_verbose);
 
 my $codon_table = Bio::Tools::CodonTable->new( -id => $codon_table_id, -no_iupac => 0 );
 # #####################################

--- a/bin/agat_sp_fix_fusion.pl
+++ b/bin/agat_sp_fix_fusion.pl
@@ -65,7 +65,7 @@ my $gffout2 = prepare_gffout($config, $gffout2_file);
 my $gffout3 = prepare_gffout($config, $gffout3_file);
 my $logout = prepare_fileout($logout_file);
 
-$opt_codonTableID = get_proper_codon_table($opt_codonTableID);
+$opt_codonTableID = get_proper_codon_table($opt_codonTableID, $log, $verbose);
 
 if(!$threshold){
   $threshold=100;

--- a/bin/agat_sp_fix_longest_ORF.pl
+++ b/bin/agat_sp_fix_longest_ORF.pl
@@ -46,12 +46,12 @@ my $verbose      = $config->{verbose};
 my $log;
 if ( my $log_name = $config->{log_path} ) {
     open( $log, '>', $log_name )
-      or die "Can not open $log_name for printing: $!"; 
+      or die "Can not open $log_name for printing: $!";
     dual_print( $log, $header, 0 );
 }
 
 # --- Check codon table
-$codonTable = get_proper_codon_table($codonTable);
+$codonTable = get_proper_codon_table($codonTable, $log, $verbose);
 
 ######################
 # Manage output file #

--- a/bin/agat_sp_fix_small_exon_from_extremities.pl
+++ b/bin/agat_sp_fix_small_exon_from_extremities.pl
@@ -42,7 +42,7 @@ my $gffout = prepare_gffout($config, $outfile);
 # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>    EXTRA     <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
 # --- Check codon table
-$codonTableId = get_proper_codon_table($codonTableId);
+$codonTableId = get_proper_codon_table($codonTableId, $log, $verbose);
 
 # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>     MAIN     <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 

--- a/lib/AGAT/Utilities.pm
+++ b/lib/AGAT/Utilities.pm
@@ -83,10 +83,12 @@ sub get_proper_codon_table {
     "It uses codon table $codon_table_id_bioperl instead.");
   }
 
-  dual_print($log,
-             "Codon table ".$codon_table_id_bioperl.
-             " in use. You can change it using the appropriate parameter.\n",
-             $verbose // 1);
+  dual_print(
+    $log,
+    "Codon table ".$codon_table_id_bioperl.
+      " in use. You can change it using the appropriate parameter.\n",
+    $verbose
+  );
   return $codon_table_id_bioperl;
 }
 


### PR DESCRIPTION
## Summary
- ensure scripts respect verbosity by routing messages through `dual_print`
- propagate log and verbose parameters to `get_proper_codon_table`
- adjust utility to rely on caller-provided verbosity

## Testing
- `prove -l t/agat_sp_add_attribute_shortest_intron_size.t t/agat_sp_add_intergenic_regions.t t/agat_sp_add_start_and_stop.t` *(fails: Can't locate Getopt/Long/Descriptive.pm, List::MoreUtils.pm)*
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_68aa023fc95c832ab17d2967aaca7575