### PR TITLE
Guard verbose output with dual_print

### DIFF
--- a/bin/agat_sp_fix_cds_phases.pl
+++ b/bin/agat_sp_fix_cds_phases.pl
@@ -45,7 +45,7 @@ dual_print($log, "Fasta file parsed\n", $opt_verbose);
 
 ###
 # Fix frame
-fil_cds_frame($hash_omniscient, $db, $opt_verbose);
+fil_cds_frame($hash_omniscient, $db, $log, $opt_verbose);
 
 ###
 # Print result

--- a/bin/agat_sp_fix_longest_ORF.pl
+++ b/bin/agat_sp_fix_longest_ORF.pl
@@ -51,7 +51,7 @@ if ( my $log_name = $config->{log_path} ) {
 }
 
 # --- Check codon table
-$codonTable = get_proper_codon_table($codonTable);
+$codonTable = get_proper_codon_table($codonTable, $log, $verbose);
 
 ######################
 # Manage output file #
@@ -216,7 +216,8 @@ foreach my $primary_tag_key_level1 (keys %{$hash_omniscient->{'level1'}}){ # pri
 
 									if( pass_ambiguous_start($longest_ORF_prot_obj, $originalProt_size) ){
 
-                    $ListModel{1}++; print "Model 1: gene=$gene_id_tag_key mRNA=$id_level2\n" if ($verbose);
+                    $ListModel{1}++;
+                    dual_print($log, "Model 1: gene=$gene_id_tag_key mRNA=$id_level2\n", $verbose);
                     dual_print( $log, "original:$cds_prot\nnew:". $longest_ORF_prot_obj->seq."\n", $verbose );
                     modify_gene_model($hash_omniscient, \%omniscient_modified_gene, $gene_feature, $gene_id_tag_key, $level2_feature, $id_level2, \@exons_features, \@cds_feature_list, $cdsExtremStart, $cdsExtremEnd, $realORFstart, $realORFend, 'model1', $gffout);
                     $ORFmodified="yes";
@@ -234,7 +235,8 @@ foreach my $primary_tag_key_level1 (keys %{$hash_omniscient->{'level1'}}){ # pri
                   my $model;
 
                   if( exists($ListModel{2}) ){
-                    $ListModel{2}++; print "Model 2: gene=$gene_id_tag_key mRNA=$id_level2\n" if ($verbose);
+                    $ListModel{2}++;
+                    dual_print($log, "Model 2: gene=$gene_id_tag_key mRNA=$id_level2\n", $verbose);
                     $model=1;
                     if($split_opt){
                       split_gene_model(\@intact_gene_list, $hash_omniscient, \%omniscient_modified_gene, $gene_feature, $gene_id_tag_key, $level2_feature, $id_level2, \@exons_features, \@cds_feature_list, $cdsExtremStart, $cdsExtremEnd, $realORFstart, $realORFend, 'model2', $gffout);
@@ -252,7 +254,8 @@ foreach my $primary_tag_key_level1 (keys %{$hash_omniscient->{'level1'}}){ # pri
   #Model3         ###############
                   # original protein and predicted one are different; the predicted one is longest, they overlap each other.
                   if( exists($ListModel{3}) ){
-                    $ListModel{3}++; print "Model 3: gene=$gene_id_tag_key mRNA=$id_level2\n" if ($verbose);
+                    $ListModel{3}++;
+                    dual_print($log, "Model 3: gene=$gene_id_tag_key mRNA=$id_level2\n", $verbose);
 
                     modify_gene_model($hash_omniscient, \%omniscient_modified_gene, $gene_feature, $gene_id_tag_key, $level2_feature, $id_level2, \@exons_features, \@cds_feature_list, $cdsExtremStart, $cdsExtremEnd, $realORFstart, $realORFend, 'model3', $gffout);
                     $ORFmodified="yes";
@@ -271,7 +274,8 @@ foreach my $primary_tag_key_level1 (keys %{$hash_omniscient->{'level1'}}){ # pri
                 #Model4     ###############
                 # /!\ Here we compare the CDS traduction (traduct in IUPAC) against longest CDS in mRNA IUPAC modified to take in account for stops codon only those that are trustable only (TGA, TAR...).
                 if( exists($ListModel{4}) ){
-                  $ListModel{4}++;  print "Model 4: gene=$gene_id_tag_key mRNA=$id_level2\n" if ($verbose);
+                  $ListModel{4}++;
+                  dual_print($log, "Model 4: gene=$gene_id_tag_key mRNA=$id_level2\n", $verbose);
                   dual_print( $log, "Original: ".$original_prot_obj->seq."\n", $verbose );
                   dual_print( $log, "longestl: ".$longest_ORF_prot_obj->seq."\n", $verbose );
                   #remodelate a shorter gene
@@ -357,9 +361,9 @@ foreach my $primary_tag_key_level1 (keys %{$hash_omniscient->{'level1'}}){ # pri
 
 ###########
 # Fix frame
-fil_cds_frame(\%omniscient_modified_gene, $db, $verbose);
+fil_cds_frame(\%omniscient_modified_gene, $db, $log, $verbose, $codonTable);
 #fil_cds_frame(\%omniscient_pseudogene);
-fil_cds_frame($hash_omniscient, $db, $verbose);
+fil_cds_frame($hash_omniscient, $db, $log, $verbose, $codonTable);
 
 #Clean omniscient_modified_gene of duplicated/identical genes and isoforms
 dual_print( $log, "removing duplicates\n", $verbose );

--- a/bin/agat_sp_fix_small_exon_from_extremities.pl
+++ b/bin/agat_sp_fix_small_exon_from_extremities.pl
@@ -42,7 +42,7 @@ my $gffout = prepare_gffout($config, $outfile);
 # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>    EXTRA     <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
 # --- Check codon table
-$codonTableId = get_proper_codon_table($codonTableId);
+$codonTableId = get_proper_codon_table($codonTableId, $log, $verbose);
 
 # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>     MAIN     <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 

--- a/lib/AGAT/OmniscientTool.pm
+++ b/lib/AGAT/OmniscientTool.pm
@@ -1437,7 +1437,8 @@ sub create_or_append_tag{
 # 2 means that there are two extra bases (the second and third bases of the codon) before the first codon.
 sub fil_cds_frame {
 
-	my ($hash_omniscient, $db, $verbose)=@_;
+        my ($hash_omniscient, $db, $log, $verbose, $codon_table_id)=@_;
+        $codon_table_id //= 0;
 
 	foreach my $primary_tag_key_level2 (keys %{$hash_omniscient->{'level2'}}){ # primary_tag_key_level2 = mrna or mirna or ncrna or trna etc...
 
@@ -1458,7 +1459,7 @@ sub fil_cds_frame {
 						@cds_list=sort {$b->start <=> $a->start}  @{$hash_omniscient->{'level3'}{'cds'}{$level2_ID}};
 					}
 
-					my $phase = _get_cds_start_phase( $db, $hash_omniscient->{'level3'}{'cds'}{$level2_ID} );
+                                        my $phase = _get_cds_start_phase( $db, $hash_omniscient->{'level3'}{'cds'}{$level2_ID}, $codon_table_id );
 
 					# Particular case If no phase found and a phase does not exist in the CDS feature we set it to 0 to start
 					if ( ! defined( $phase ) and  $cds_list[0]->frame eq "." ) {
@@ -1473,10 +1474,10 @@ sub fil_cds_frame {
 						foreach my $cds_feature ( @cds_list) {
 							my $original_phase = $cds_feature->frame;
 
-							if ( ($original_phase eq ".") or ($original_phase != $phase) ){
-								print "Original phase $original_phase replaced by $phase for ".$cds_feature->_tag_value("ID")."\n" if $verbose;
-								$cds_feature->frame($phase);
-							}
+                                                        if ( ($original_phase eq ".") or ($original_phase != $phase) ){
+                                                                dual_print($log, "Original phase $original_phase replaced by $phase for ".$cds_feature->_tag_value("ID")."\n", $verbose);
+                                                                $cds_feature->frame($phase);
+                                                        }
 							my $cds_length=$cds_feature->end-$cds_feature->start +1;
 							$phase=(3-(($cds_length-$phase)%3))%3; #second modulo allows to avoid the frame with 3. Instead we have 0.
 						}


### PR DESCRIPTION
## Summary
- ensure AGAT fix scripts respect `--quiet` by routing messages through `dual_print`
- pass verbose and log handles when determining codon tables
- teach `fil_cds_frame` to log phase corrections without spurious stdout

## Testing
- `bash .agents/with-perl-local.sh make test` *(fails: Can't locate Bio::Tools::GFF.pm and related modules)*

------
https://chatgpt.com/codex/tasks/task_e_68aa0405dac4832a8d22f183f081dec0