### PR TITLE
Fix uninitialized warning in OmniscientTool

### DIFF
--- a/lib/AGAT/OmniscientTool.pm
+++ b/lib/AGAT/OmniscientTool.pm
@@ -238,7 +238,7 @@ sub rename_ID_existing_in_omniscient {
 
 	my ($hash_omniscient1, $hash_omniscient2, $verbose)=@_;
 
-	if(! $verbose){$verbose=1;}
+       if(! defined $verbose){$verbose=1;}
 
 	my $hash_whole_IDs = get_all_IDs($hash_omniscient1);
 	my $hash2_whole_IDs = get_all_IDs($hash_omniscient2);
@@ -1585,8 +1585,8 @@ sub info_omniscient {
                 if ( $level eq 'level2' or $level eq 'level3' ) {
                         foreach my $tag ( keys %{ $hash_omniscient->{$level} } ) {
                                 foreach my $id ( keys %{ $hash_omniscient->{$level}{$tag} } ) {
-                                        my $nb =
-                                          $# { $hash_omniscient->{$level}{$tag}{$id} } + 1;
+                                       my $nb =
+                                          $#{ $hash_omniscient->{$level}{$tag}{$id} } + 1;
                                         if ( exists_keys( \%resu, ($tag) ) ) {
                                                 $resu{$tag} += $nb;
                                         }


### PR DESCRIPTION
## Summary
- avoid accessing special variable `$#` by correctly dereferencing arrays
- restore rename summary printouts when verbosity is enabled

## Testing
- `prove -Iblib/lib -Iblib/arch -lv t/agat_sp_complement_annotations.t` *(fails: missing Test::TempDir::Tiny module)*
- `make test` *(fails: missing Getopt::Long::Descriptive module)*

------
https://chatgpt.com/codex/tasks/task_e_68aa02afc450832a995db13c83980d5c