### PR TITLE
Handle verbose output in intron and UTR managers

### DIFF
--- a/bin/agat_sp_manage_UTRs.pl
+++ b/bin/agat_sp_manage_UTRs.pl
@@ -34,6 +34,13 @@ my $opt_plot    = $opt->{plot};
 my $opt_output  = $opt->out;
 $config         = $cfg;
 
+my $opt_verbose = $config->{verbose};
+my $log;
+if ( my $log_name = $config->{log_path} ) {
+  open( $log, '>', $log_name ) or die "Can not open $log_name for printing: $!";
+}
+dual_print( $log, $header, $opt_verbose );
+
 my $opt_utr3 = ($mode && $mode eq 'three') ? 1 : 0;
 my $opt_utr5 = ($mode && $mode eq 'five') ? 1 : 0;
 my $opt_bst  = ($mode && $mode eq 'both') ? 1 : 0;
@@ -51,7 +58,10 @@ if (defined($opt_output) ) {
   my ($name,$path,$ext) = fileparse($opt_output,qr/\.[^.]*/);
   $opt_output = $path.$name;
   if (-d $opt_output){
-    print "The output directory choosen already exists. Please geve me another Name.\n";exit();
+    my $msg = "The output directory choosen already exists. Please geve me another Name.\n";
+    dual_print($log, $msg, 0);
+    warn $msg if $opt_verbose;
+    exit();
   }
   else{
     mkdir $opt_output;
@@ -74,7 +84,7 @@ if($opt_utr3 or $opt_utr5 or $opt_bst){
 }
 
 print $ostreamReport $string1;
-if($opt_output){print $string1;}
+dual_print($log, $string1, $opt_output ? $opt_verbose : 0);
 
 # Check if dependencies for plot are available
 if($opt_plot){
@@ -145,7 +155,7 @@ my $ostreamUTRdiscarded = prepare_gffout($config, $ostreamUTRdiscarded_file);
 my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $opt_reffile,
                                                                  config => $config
                                                               });
-print("Parsing Finished\n\n");
+dual_print($log, "Parsing Finished\n\n", $opt_verbose);
 ### END Parse GFF input #
 #########################
 
@@ -339,9 +349,7 @@ if($opt_utr3 or $opt_utr5 or $opt_bst){
 
   #Print Info OUtput
   print $ostreamReport $stringPrint;
-  if($opt_output){
-    print $stringPrint;
-  }
+  dual_print($log, $stringPrint, $opt_output ? $opt_verbose : 0);
 }
 
 ############################

--- a/bin/agat_sp_manage_introns.pl
+++ b/bin/agat_sp_manage_introns.pl
@@ -118,9 +118,12 @@ foreach my $file (@opt_files){
 
   #print statistics
         dual_print($log, "Compute statistics\n", $opt_verbose);
-	print_omniscient_statistics ({ input => $hash_omniscient,
-																 output => $ostreamReport
-															 });
+	print_omniscient_statistics({
+            input   => $hash_omniscient,
+            output  => $ostreamReport,
+            log     => $log,
+            verbose => $opt_output ? $opt_verbose : 0,
+        });
 
   ######################
   ### Parse GFF input #
@@ -235,7 +238,7 @@ foreach  my $tag (sort keys %introns){
   my $stringPrint =  "Introns in feature $tag: Removing $Xpercent percent of the highest values ($nbValueToRemove values) gives you $resu bp as the longest intron in $tag.\n";
 
   print $ostreamReport $stringPrint;
-  if($opt_output){print $stringPrint;}
+  dual_print($log, $stringPrint, $opt_output ? $opt_verbose : 0);
 
 
   # Part 4

--- a/lib/AGAT/OmniscientStat.pm
+++ b/lib/AGAT/OmniscientStat.pm
@@ -52,7 +52,7 @@ sub print_omniscient_statistics{
 	if(ref($args) ne 'HASH'){ print "Hash Arguments expected for print_omniscient_statistics. Please check the call.\n";exit;	}
 
 	# Declare all variables and fill them
-	my ($omniscient, $genome_size, $output, $yaml, $raw,  $verbose, $distri, $isoform, $percentile);
+        my ($omniscient, $genome_size, $output, $yaml, $raw,  $verbose, $distri, $isoform, $percentile, $log);
 
 	# omniscient
 	if( defined($args->{input})) {$omniscient = $args->{input};}
@@ -80,7 +80,7 @@ sub print_omniscient_statistics{
 		  		$genome_size += length($string);
 		  	}
 			}
-			printf("$width%d%s", "Total sequence length (bp)", $genome_size,"\n");
+                        dual_print($log, sprintf("$width%d%s", "Total sequence length (bp)", $genome_size, "\n"), $verbose);
 		}
 	}
 
@@ -101,8 +101,9 @@ sub print_omniscient_statistics{
 	if( ! defined($args->{verbose}) ) {$verbose = 0;}
 		else{ $verbose = $args->{verbose}; }
 	# Path to the folder where to put distribution plot
-	if( ! defined($args->{distri}) ) {$distri = 0;}
-		else{ $distri = $args->{distri}; }
+        if( ! defined($args->{distri}) ) {$distri = 0;}
+                else{ $distri = $args->{distri}; }
+        if( defined($args->{log}) ) { $log = $args->{log}; }
 	# Should we deal with isoform (remove them and re-compute the statistics) 1=yes
 	if( ! defined($args->{isoform}) ) {$isoform = 0;}
 		else{ $isoform = $args->{isoform}; }


### PR DESCRIPTION
## Summary
- guard `agat_sp_manage_introns.pl` output with `dual_print`
- add logging and dual_print to `agat_sp_manage_UTRs.pl`
- use `dual_print` in `AGAT::OmniscientStat` for genome size message

## Testing
- `make test` *(fails: Can't locate File/chdir.pm in @INC)*

------
https://chatgpt.com/codex/tasks/task_e_68aa037eac4c832ab4e6e46cc3d70139