### PR TITLE
Respect quiet flag in config expose

### DIFF
--- a/lib/AGAT/AGAT.pm
+++ b/lib/AGAT/AGAT.pm
@@ -399,7 +399,7 @@ sub handle_config {
 
                 # Deal with Expose feature OPTION
                 if($expose){
-                        my $config_file = get_config({type => "original"});
+                        my $config_file = get_config({type => "original", verbose => $verbose});
 			my $config = load_config({ config_file => $config_file});
                         print "Config loaded\n" if $verbose;
 
@@ -554,11 +554,11 @@ sub handle_config {
 
 			 
 			
-			if ($modified_on_the_fly) {
-				expose_config_hash({ config_in => $config, config_file_out => $config_new_name})
-			} else {
-				expose_config_file({config_file_in => $config_file, config_file_out => $config_new_name});
-			}
+                        if ($modified_on_the_fly) {
+                                expose_config_hash({ config_in => $config, config_file_out => $config_new_name})
+                        } else {
+                                expose_config_file({config_file_in => $config_file, config_file_out => $config_new_name, verbose => $verbose});
+                        }
 
 			# inform user
 			my $config_file_used;

--- a/lib/AGAT/Config.pm
+++ b/lib/AGAT/Config.pm
@@ -141,20 +141,21 @@ sub expose_config_hash{
 
 # @Purpose: Write the config hash in a yaml file in the current directory 
 sub expose_config_file{
-	my ($args)=@_;
+        my ($args)=@_;
 
-	my ($path_in, $config_file_out);
-	if( ! defined($args->{config_file_in}) ) { $path_in = undef;} else{ $path_in = $args->{config_file_in};}
-	if( ! defined($args->{config_file_out}) ) { $config_file_out = $config_file;} else{ $config_file_out = $args->{config_file_out};}
+        my ($path_in, $config_file_out, $verbose);
+        if( ! defined($args->{config_file_in}) ) { $path_in = undef;} else{ $path_in = $args->{config_file_in};}
+        if( ! defined($args->{config_file_out}) ) { $config_file_out = $config_file;} else{ $config_file_out = $args->{config_file_out};}
+        if( ! defined($args->{verbose}) ) { $verbose = 1;} else{ $verbose = $args->{verbose};}
 
-	#set run directory
-	if(! $path_in){
-		$path_in = dist_file('AGAT', $config_file);
-		print "Path where $config_file is standing according to dist_file: $path_in\n";
-	}
-	# copy the file locally
-	my $run_dir = cwd;
-	copy($path_in, $run_dir."/".$config_file_out) or die print "Copy failed: $!";
+        #set run directory
+        if(! $path_in){
+                $path_in = dist_file('AGAT', $config_file);
+                dual_print(undef, "Path where $config_file is standing according to dist_file: $path_in\n", $verbose);
+        }
+        # copy the file locally
+        my $run_dir = cwd;
+        copy($path_in, $run_dir."/".$config_file_out) or die print "Copy failed: $!";
 }
 
 # @Purpose: Check config value to be sure everything is set as expected


### PR DESCRIPTION
## Summary
- ensure `agat config --expose` passes verbosity to `get_config` so `--quiet` suppresses messages
- allow `expose_config_file` to honor `--quiet`

## Testing
- `HARNESS_OPTIONS=j4 .agents/with-perl-local.sh make test` *(fails: output /workspace/AGAT/bin/agat_convert_embl2gff.pl; stdout is empty in multiple scripts)*

------
https://chatgpt.com/codex/tasks/task_e_68ab125a7c84832abd955b43fef7090e