### PR TITLE
Respect verbosity in manage scripts

### DIFF
--- a/bin/agat_sp_manage_UTRs.pl
+++ b/bin/agat_sp_manage_UTRs.pl
@@ -33,6 +33,13 @@ my $mode        = $opt->mode;
 my $opt_plot    = $opt->{plot};
 my $opt_output  = $opt->out;
 $config         = $cfg;
+my $opt_verbose = $config->{verbose};
+
+my $log;
+if ( my $log_name = $config->{log_path} ) {
+  open( $log, '>', $log_name ) or die "Can not open $log_name for printing: $!";
+}
+dual_print( $log, $header, $opt_verbose );
 
 my $opt_utr3 = ($mode && $mode eq 'three') ? 1 : 0;
 my $opt_utr5 = ($mode && $mode eq 'five') ? 1 : 0;
@@ -51,7 +58,10 @@ if (defined($opt_output) ) {
   my ($name,$path,$ext) = fileparse($opt_output,qr/\.[^.]*/);
   $opt_output = $path.$name;
   if (-d $opt_output){
-    print "The output directory choosen already exists. Please geve me another Name.\n";exit();
+    my $msg = "The output directory choosen already exists. Please geve me another Name.\n";
+    dual_print($log, $msg, 0);
+    warn $msg if $opt_verbose;
+    exit();
   }
   else{
     mkdir $opt_output;
@@ -74,7 +84,7 @@ if($opt_utr3 or $opt_utr5 or $opt_bst){
 }
 
 print $ostreamReport $string1;
-if($opt_output){print $string1;}
+dual_print($log, $string1, $opt_output ? $opt_verbose : 0);
 
 # Check if dependencies for plot are available
 if($opt_plot){
@@ -145,7 +155,7 @@ my $ostreamUTRdiscarded = prepare_gffout($config, $ostreamUTRdiscarded_file);
 my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $opt_reffile,
                                                                  config => $config
                                                               });
-print("Parsing Finished\n\n");
+dual_print($log, "Parsing Finished\n\n", $opt_verbose);
 ### END Parse GFF input #
 #########################
 
@@ -339,9 +349,7 @@ if($opt_utr3 or $opt_utr5 or $opt_bst){
 
   #Print Info OUtput
   print $ostreamReport $stringPrint;
-  if($opt_output){
-    print $stringPrint;
-  }
+  dual_print($log, $stringPrint, $opt_output ? $opt_verbose : 0);
 }
 
 ############################

--- a/bin/agat_sp_manage_introns.pl
+++ b/bin/agat_sp_manage_introns.pl
@@ -235,7 +235,7 @@ foreach  my $tag (sort keys %introns){
   my $stringPrint =  "Introns in feature $tag: Removing $Xpercent percent of the highest values ($nbValueToRemove values) gives you $resu bp as the longest intron in $tag.\n";
 
   print $ostreamReport $stringPrint;
-  if($opt_output){print $stringPrint;}
+  dual_print($log, $stringPrint, $opt_output ? $opt_verbose : 0);
 
 
   # Part 4

--- a/lib/AGAT/OmniscientI.pm
+++ b/lib/AGAT/OmniscientI.pm
@@ -4,6 +4,7 @@ package AGAT::OmniscientI;
 
 use strict;
 use warnings;
+use Carp;
 use Try::Tiny;
 use File::Basename;
 use File::ShareDir ':ALL';
@@ -113,7 +114,7 @@ sub slurp_gff3_file_JD {
 	my ($args) = @_	;
 
 	# +----------------- Check we receive a hash as ref ------------------+
-	if(ref($args) ne 'HASH'){ print "Hash Arguments expected for slurp_gff3_file_JD. Please check the call.\n"; exit;	}
+        if(ref($args) ne 'HASH'){ croak "Hash Arguments expected for slurp_gff3_file_JD. Please check the call.\n"; }
 
 	# +-----------------  Declare all variables and fill them ------------------+
 	my ( $file, $gff_in_format, $locus_tag, $verbose, $merge_loci,
@@ -121,12 +122,11 @@ sub slurp_gff3_file_JD {
 
 	# +----------------- first check config ------------------+
 	if( defined($args->{config} ) ){
-		$config = $args->{config};
-		$omniscient{"config"}=$config;
-	} else {
-		print "Configuration missing!\n";
-		exit 1;
-	}
+                $config = $args->{config};
+                $omniscient{"config"}=$config;
+        } else {
+                croak "Configuration missing!\n";
+        }
 
 	# +----------------- input param  ------------------+
 	if( defined($args->{input})) {$file = $args->{input};}

--- a/lib/AGAT/OmniscientO.pm
+++ b/lib/AGAT/OmniscientO.pm
@@ -12,6 +12,7 @@ use AGAT::OmniscientI;
 use AGAT::Utilities;
 use AGAT::OmniscientToGTF;
 use Exporter;
+use Carp;
 
 our @ISA = qw(Exporter);
 our @EXPORT = qw(print_ref_list_feature print_omniscient print_omniscient_as_match
@@ -52,17 +53,18 @@ sub prepare_gffout{
 	}
 	
 	my $gffout;
-	if ($outfile) {
-		# check existence
-	  if(-f $outfile){
-			print "File $outfile already exist.\n";
-			exit;
-		}
-		else {
-			open(my $fh, '>', $outfile) or die "Could not open file '$outfile' $!";
-			$gffout = AGAT::BioperlGFF->new(-fh => $fh, -type => $config->{output_format}, -version => $version);
-		}
-	}
+        if ($outfile) {
+                # check existence
+          if(-f $outfile){
+                        my $msg = "File $outfile already exist.\n";
+                        warn $msg if $AGAT::AGAT::CONFIG->{verbose};
+                        exit;
+                }
+                else {
+                        open(my $fh, '>', $outfile) or die "Could not open file '$outfile' $!";
+                        $gffout = AGAT::BioperlGFF->new(-fh => $fh, -type => $config->{output_format}, -version => $version);
+                }
+        }
 	else{
 		$gffout = AGAT::BioperlGFF->new(-fh => \*STDOUT, -type => $config->{output_format}, -version => $version);
 	}
@@ -74,16 +76,17 @@ sub prepare_fileout{
 	my ($outfile) = @_;
 
 	my $fileout;
-	if ($outfile) {
-		if(-f $outfile){
-			print "File $outfile already exist.\n";
-			exit;
-		}
-		else {
-			open(my $fh, '>', $outfile) or die "Could not open file '$outfile' $!";
-			$fileout=IO::File->new(">".$outfile ) or croak( sprintf( "Can not open '%s' for writing %s", $outfile, $! ));
-		}
-	}
+        if ($outfile) {
+                if(-f $outfile){
+                        my $msg = "File $outfile already exist.\n";
+                        warn $msg if $AGAT::AGAT::CONFIG->{verbose};
+                        exit;
+                }
+                else {
+                        open(my $fh, '>', $outfile) or die "Could not open file '$outfile' $!";
+                        $fileout=IO::File->new(">".$outfile ) or croak( sprintf( "Can not open '%s' for writing %s", $outfile, $! ));
+                }
+        }
 	else{
 		$fileout = \*STDOUT or die ( sprintf( "Can not open '%s' for writing %s", "STDOUT", $! ));
 	}


### PR DESCRIPTION
## Summary
- guard intron and UTR management scripts with `dual_print` so quiet mode suppresses stdout
- ensure Omniscient helpers warn respectfully or croak for errors

## Testing
- `make test_agat_sp_manage` *(fails: Can't locate Bio/Tools/GFF.pm ...)*

------
https://chatgpt.com/codex/tasks/task_e_68aa04538540832a90cdf61d778ee628