### PR TITLE
Fix duplicate variable declarations in manage UTRs script

### DIFF
--- a/bin/agat_sp_manage_UTRs.pl
+++ b/bin/agat_sp_manage_UTRs.pl
@@ -41,13 +41,6 @@ if ( my $log_name = $config->{log_path} ) {
 }
 dual_print( $log, $header, $opt_verbose );
 
-my $opt_verbose = $config->{verbose};
-my $log;
-if ( my $log_name = $config->{log_path} ) {
-  open( $log, '>', $log_name ) or die "Can not open $log_name for printing: $!";
-}
-dual_print( $log, $header, $opt_verbose );
-
 my $opt_utr3 = ($mode && $mode eq 'three') ? 1 : 0;
 my $opt_utr5 = ($mode && $mode eq 'five') ? 1 : 0;
 my $opt_bst  = ($mode && $mode eq 'both') ? 1 : 0;


### PR DESCRIPTION
## Summary
- remove duplicate `$opt_verbose` and `$log` declarations in `agat_sp_manage_UTRs.pl`

## Testing
- `.agents/with-perl-local.sh prove -lr t/smoke` *(fails: Cannot detect source of 't/smoke')*
- `.agents/with-perl-local.sh make test` *(fails: multiple tests failing, e.g. gff_other_zip_and_fasta.t)*

------
https://chatgpt.com/codex/tasks/task_e_68ab24e5dbcc832a837166d01e4829e1