### PR TITLE
Fix uninitialized warning in OmniscientTool

### DIFF
--- a/lib/AGAT/OmniscientTool.pm
+++ b/lib/AGAT/OmniscientTool.pm
@@ -236,9 +236,16 @@ sub complement_omniscients {
 # rename ID in hash_omniscient2 that already exist in hash_omniscient1
 sub rename_ID_existing_in_omniscient {
 
-	my ($hash_omniscient1, $hash_omniscient2, $verbose)=@_;
+        my ($hash_omniscient1, $hash_omniscient2, $verbose)=@_;
 
-	if(! $verbose){$verbose=1;}
+        if(! defined $verbose){
+                if(defined $AGAT::AGAT::CONFIG->{verbose}){
+                        $verbose = $AGAT::AGAT::CONFIG->{verbose};
+                }
+                else{
+                        $verbose = 1;
+                }
+        }
 
 	my $hash_whole_IDs = get_all_IDs($hash_omniscient1);
 	my $hash2_whole_IDs = get_all_IDs($hash_omniscient2);
@@ -1585,8 +1592,8 @@ sub info_omniscient {
                 if ( $level eq 'level2' or $level eq 'level3' ) {
                         foreach my $tag ( keys %{ $hash_omniscient->{$level} } ) {
                                 foreach my $id ( keys %{ $hash_omniscient->{$level}{$tag} } ) {
-                                        my $nb =
-                                          $# { $hash_omniscient->{$level}{$tag}{$id} } + 1;
+                                       my $nb =
+                                          $#{ $hash_omniscient->{$level}{$tag}{$id} } + 1;
                                         if ( exists_keys( \%resu, ($tag) ) ) {
                                                 $resu{$tag} += $nb;
                                         }


### PR DESCRIPTION
## Summary
- avoid accessing special variable `$#` by correctly dereferencing arrays
- restore rename summary printouts when verbosity is enabled
- respect quiet mode by deferring to configured verbosity

## Testing
- `prove -Iblib/lib -Iblib/arch -lv t/agat_sp_complement_annotations.t`
- `make test_agat_other` *(fails: stdout contains AGAT banner)*
- `make test` *(fails: output mismatch in agat_convert_embl2gff.pl and others)*

------
https://chatgpt.com/codex/tasks/task_e_68aa02afc450832a995db13c83980d5c