### PR TITLE
Refactor verbosity handling

### DIFF
--- a/bin/agat_convert_bed2gff.pl
+++ b/bin/agat_convert_bed2gff.pl
@@ -80,7 +80,7 @@ while( my $line = <$fh>)  {
   chomp $line;
 
         if ($line =~ /#/) {
-            dual_print( $log, "skip commented line: $line\n", $opt_verbose );
+            dual_print( $log, "skip commented line: $line\n");
             next;
         }    #skip commented lines
 
@@ -240,7 +240,7 @@ foreach my $id ( sort {$a <=> $b} keys %bedOmniscent){
     $gffout->write_feature($feature);
 
 		if ( exists_keys ( \%bedOmniscent, ($id, 'blockCount') ) and ! $inflating_off){
-                    dual_print( $log, "inflating $inflating_off\n", $opt_verbose );
+                    dual_print( $log, "inflating $inflating_off\n");
 			my $l3_start_line = $bedOmniscent{$id}{'blockStarts'};
 			$l3_start_line =~ s/^\s+//; # remove spaces
 			my @l3_start_list = split /,/, $l3_start_line;
@@ -416,11 +416,11 @@ sub skip_line{
 		$skip=1;
 	}
 	if($field0 =~ /^track/){
-            dual_print( $log, "Skip track line, we skip it because we cannot render it properly in a gff file.\n", $opt_verbose );
+            dual_print( $log, "Skip track line, we skip it because we cannot render it properly in a gff file.\n");
 		$skip=1;
 	}
 	if($field0 =~ /^browser/){
-            dual_print( $log, "Skip browser line, we skip it because we cannot render it properly in a gff file.\n", $opt_verbose );
+            dual_print( $log, "Skip browser line, we skip it because we cannot render it properly in a gff file.\n");
 		$skip=1;
 	}
 	return $skip;

--- a/bin/agat_convert_mfannot2gff.pl
+++ b/bin/agat_convert_mfannot2gff.pl
@@ -67,13 +67,13 @@ sub read_mfannot {
 			}
 		}
         elsif ($_ =~ /^\s*(\d+)\s+([ATCGatcgNn]+)/) {
-			dual_print( $log, "DNA sequence line\n", $opt_verbose );
+			dual_print( $log, "DNA sequence line\n");
             # If line is a numbered sequence line
             my ($pos_begin,$seqline) = ($1, $2);   # Sequence position
             $current_pos = length($seqline) + $pos_begin - 1;
         }
         elsif ( ($_ =~ /^;+\s+G-(\w.*)/) or ($_ =~ /^;; mfannot:\s+(\/group=.*)/) or ($_ =~ /^;; mfannot:$/) or ($_ =~ /^;+\s+(rnl.*)/) or ($_ =~ /^;+\s+(rns.*)/) ){
-			dual_print( $log, "Feature line\n", $opt_verbose );
+			dual_print( $log, "Feature line\n");
 			if ( ($_ =~ /^;+\s+G-(\w.*)/) or ($_ =~ /^;+\s+(rnl.*)/) or ($_ =~ /^;+\s+(rns.*)/) ){
 
 				# If line is a feature boundary, save that information
@@ -88,7 +88,7 @@ sub read_mfannot {
 					if (defined $startend_hash{$current_contig}{$previousIntron}{$type}{"end"}{0}) {
 							my $i = keys %{$startend_hash{$current_contig}{$previousIntron}{$type}{"end"}};
 							$startend_hash{$current_contig}{$previousIntron}{$type}{"end"}{$i} = $current_pos;
-							dual_print( $log, "Feature ". $previousIntron. " already defined. Please manually verify in $mfannot_file\n", $opt_verbose );
+							dual_print( $log, "Feature ". $previousIntron. " already defined. Please manually verify in $mfannot_file\n");
 					}
 					else { 
 						$startend_hash{$current_contig}{$previousIntron}{$type}{"end"}{0} = $current_pos; 
@@ -101,7 +101,7 @@ sub read_mfannot {
 					if (defined $startend_hash{$current_contig}{$previousRns}{$type}{"end"}{0}) {
 							my $i = keys %{$startend_hash{$current_contig}{$previousRns}{$type}{"end"}};
 							$startend_hash{$current_contig}{$previousRns}{$type}{"end"}{$i} = $current_pos;
-							dual_print( $log, "Feature ". $previousRns. " already defined. Please manually verify in $mfannot_file\n", $opt_verbose );
+							dual_print( $log, "Feature ". $previousRns. " already defined. Please manually verify in $mfannot_file\n");
 					}
 					else { $startend_hash{$current_contig}{$previousRns}{$type}{"end"}{0} = $current_pos; }
 					$previousRns = undef;
@@ -112,7 +112,7 @@ sub read_mfannot {
 					if (defined $startend_hash{$current_contig}{$previousRnl}{$type}{"end"}{0}) {
 							my $i = keys %{$startend_hash{$current_contig}{$previousRnl}{$type}{"end"}};
 							$startend_hash{$current_contig}{$previousRnl}{$type}{"end"}{$i} = $current_pos;
-							dual_print( $log, "Feature ". $previousRnl. " already defined. Please manually verify in $mfannot_file\n", $opt_verbose );
+							dual_print( $log, "Feature ". $previousRnl. " already defined. Please manually verify in $mfannot_file\n");
 					}
 					else { $startend_hash{$current_contig}{$previousRnl}{$type}{"end"}{0} = $current_pos; }
 					$previousRnl = undef;
@@ -128,7 +128,7 @@ sub read_mfannot {
 							if (defined $startend_hash{$current_contig}{$previousRnl}{"rRNA"}{"end"}{0}) {
 									my $i = keys %{$startend_hash{$current_contig}{$previousRnl}{"rRNA"}{"end"}};
 									$startend_hash{$current_contig}{$previousRnl}{"rRNA"}{"end"}{$i} = $current_pos;
-									dual_print( $log, "Feature ". $previousRnl. " already defined. Please manually verify in $mfannot_file\n", $opt_verbose );
+									dual_print( $log, "Feature ". $previousRnl. " already defined. Please manually verify in $mfannot_file\n");
 							}
 							else { $startend_hash{$current_contig}{$previousRnl}{"rRNA"}{"end"}{0} = $current_pos; }
 							$previousRnl = undef;
@@ -138,7 +138,7 @@ sub read_mfannot {
 						if (defined $startend_hash{$current_contig}{$current_name}{"rRNA"}{"start"}{0} ) {
 								my $i = keys %{$startend_hash{$current_contig}{$current_name}{"rRNA"}{"start"}};
 								$startend_hash{$current_contig}{$current_name}{"rRNA"}{"start"}{$i} = $current_pos + 1;
-								dual_print( $log, "Feature ". $current_name. " already defined. Please manually verify in $mfannot_file\n", $opt_verbose );
+								dual_print( $log, "Feature ". $current_name. " already defined. Please manually verify in $mfannot_file\n");
 						}
 						else { $startend_hash{$current_contig}{$current_name}{"rRNA"}{"start"}{0} = $current_pos + 1;}
 						$previousRnl=$current_name;
@@ -149,7 +149,7 @@ sub read_mfannot {
 							if (defined $startend_hash{$current_contig}{$previousRns}{"rRNA"}{"end"}{0}) {
 									my $i = keys %{$startend_hash{$current_contig}{$previousRns}{"rRNA"}{"end"}};
 									$startend_hash{$current_contig}{$previousRns}{"rRNA"}{"end"}{$i} = $current_pos;
-									dual_print( $log, "Feature ". $previousRns. " already defined. Please manually verify in $mfannot_file\n", $opt_verbose );
+									dual_print( $log, "Feature ". $previousRns. " already defined. Please manually verify in $mfannot_file\n");
 							}
 							else { $startend_hash{$current_contig}{$previousRns}{"rRNA"}{"end"}{0} = $current_pos; }
 							$previousRns = undef;
@@ -159,7 +159,7 @@ sub read_mfannot {
 						if (defined $startend_hash{$current_contig}{$current_name}{"rRNA"}{"start"}{0} ) {
 								my $i = keys %{$startend_hash{$current_contig}{$current_name}{"rRNA"}{"start"}};
 								$startend_hash{$current_contig}{$current_name}{"rRNA"}{"start"}{$i} = $current_pos + 1;
-								dual_print( $log, "Feature ". $current_name. " already defined. Please manually verify in $mfannot_file\n", $opt_verbose );
+								dual_print( $log, "Feature ". $current_name. " already defined. Please manually verify in $mfannot_file\n");
 						}
 						else { $startend_hash{$current_contig}{$current_name}{"rRNA"}{"start"}{0} = $current_pos + 1;}
 						$previousRns=$current_name;
@@ -192,13 +192,13 @@ sub read_mfannot {
 							if ($previousDirection eq $current_direction and $previousStartEnd eq $current_startend){ #keep the first key and the second value
 								my $i = keys %{$startend_hash{$current_contig}{$current_name}{$type}{"start"}};
 								$startend_hash{$current_contig}{$current_name}{$type}{"start"}{$i-1} = $current_pos;
-								dual_print( $log, "11 - Feature ". $current_name. " already defined. Please manually verify in $mfannot_file\n", $opt_verbose );
+								dual_print( $log, "11 - Feature ". $current_name. " already defined. Please manually verify in $mfannot_file\n");
 								next;
 							}
 
 							my $i = keys %{$startend_hash{$current_contig}{$current_name}{$type}{"start"}};
 							$startend_hash{$current_contig}{$current_name}{$type}{"start"}{$i} = $current_pos;
-							dual_print( $log, "1 - Feature ". $current_name. " already defined. Please manually verify in $mfannot_file\n", $opt_verbose );
+							dual_print( $log, "1 - Feature ". $current_name. " already defined. Please manually verify in $mfannot_file\n");
 						}
 						else { $startend_hash{$current_contig}{$current_name}{$type}{"start"}{0} = $current_pos; }
 					}
@@ -209,13 +209,13 @@ sub read_mfannot {
 							if ($previousDirection eq $current_direction and $previousStartEnd eq $current_startend){ #keep the first key and the second value
 								my $i = keys %{$startend_hash{$current_contig}{$current_name}{$type}{"end"}};
 								$startend_hash{$current_contig}{$current_name}{$type}{"end"}{$i-1} = $current_pos;
-								dual_print( $log, "22 - Feature ". $current_name. " already defined. Please manually verify in $mfannot_file\n", $opt_verbose );
+								dual_print( $log, "22 - Feature ". $current_name. " already defined. Please manually verify in $mfannot_file\n");
 								next;
 							}
 
 							my $i = keys %{$startend_hash{$current_contig}{$current_name}{$type}{"end"}};
 							$startend_hash{$current_contig}{$current_name}{$type}{"end"}{$i} = $current_pos;
-							dual_print( $log, "2 - Feature ". $current_name. " already defined. Please manually verify in $mfannot_file\n", $opt_verbose );
+							dual_print( $log, "2 - Feature ". $current_name. " already defined. Please manually verify in $mfannot_file\n");
 						}
 						else { $startend_hash{$current_contig}{$current_name}{$type}{"end"}{0} = $current_pos; }
 
@@ -225,13 +225,13 @@ sub read_mfannot {
 						if (defined $startend_hash{$current_contig}{$current_name}{$type}{"start"}{0}) {
 
 							if ($previousDirection eq $current_direction and $previousStartEnd eq $current_startend){
-								dual_print( $log, "3 - Feature ". $current_name. " already defined. Please manually verify in $mfannot_file\n", $opt_verbose );
+								dual_print( $log, "3 - Feature ". $current_name. " already defined. Please manually verify in $mfannot_file\n");
 								next;
 							} #keep the first key and the first value
 
 							my $i = keys %{$startend_hash{$current_contig}{$current_name}{$type}{"start"}};
 							$startend_hash{$current_contig}{$current_name}{$type}{"start"}{$i} = $value;
-							dual_print( $log, "3 - Feature ". $current_name. " already defined. Please manually verify in $mfannot_file\n", $opt_verbose );
+							dual_print( $log, "3 - Feature ". $current_name. " already defined. Please manually verify in $mfannot_file\n");
 						}
 						else { $startend_hash{$current_contig}{$current_name}{$type}{"start"}{0} = $value; }
 					}
@@ -240,13 +240,13 @@ sub read_mfannot {
 						if (defined $startend_hash{$current_contig}{$current_name}{$type}{"end"}{0}) {
 
 							if ($previousDirection eq $current_direction and $previousStartEnd eq $current_startend){
-							dual_print( $log, "44 - Feature ". $current_name. " already defined. Please manually verify in $mfannot_file\n", $opt_verbose );
+							dual_print( $log, "44 - Feature ". $current_name. " already defined. Please manually verify in $mfannot_file\n");
 							next;
 							} #keep the first key and the first val
 
 							my $i = keys %{$startend_hash{$current_contig}{$current_name}{$type}{"end"}};
 							$startend_hash{$current_contig}{$current_name}{$type}{"end"}{$i} = $value;
-							dual_print( $log, "4 - Feature ". $current_name. " already defined. Please manually verify in $mfannot_file\n", $opt_verbose );
+							dual_print( $log, "4 - Feature ". $current_name. " already defined. Please manually verify in $mfannot_file\n");
 						}
 						else { $startend_hash{$current_contig}{$current_name}{$type}{"end"}{0} = $value; }
 					}
@@ -268,7 +268,7 @@ sub read_mfannot {
 					if (defined $startend_hash{$current_contig}{$previousIntron}{$type}{"end"}{0}) {
 							my $i = keys %{$startend_hash{$current_contig}{$previousIntron}{$type}{"end"}};
 							$startend_hash{$current_contig}{$previousIntron}{$type}{"end"}{$i} = $current_pos;
-							dual_print( $log, "Feature ". $previousIntron. " already defined. Please manually verify in $mfannot_file\n", $opt_verbose );
+							dual_print( $log, "Feature ". $previousIntron. " already defined. Please manually verify in $mfannot_file\n");
 					}
 					else { 
 						$startend_hash{$current_contig}{$previousIntron}{$type}{"end"}{0} = $current_pos; 
@@ -280,7 +280,7 @@ sub read_mfannot {
 				if (defined $startend_hash{$current_contig}{$1}{$type}{"start"}{0} ) {
 						my $i = keys %{$startend_hash{$current_contig}{$1}{$type}{"start"}};
 						$startend_hash{$current_contig}{$1}{$type}{"start"}{$i} = $current_pos + 1;
-						dual_print( $log, "Feature ".$1. " already defined. Please manually verify in $mfannot_file\n", $opt_verbose );
+						dual_print( $log, "Feature ".$1. " already defined. Please manually verify in $mfannot_file\n");
 				}
 				else { 
 					$startend_hash{$current_contig}{$1}{$type}{"start"}{0} = $current_pos + 1;
@@ -293,7 +293,7 @@ sub read_mfannot {
 					if (defined $startend_hash{$current_contig}{$previousIntron}{$type}{"end"}{0}) {
 							my $i = keys %{$startend_hash{$current_contig}{$previousIntron}{$type}{"end"}};
 							$startend_hash{$current_contig}{$previousIntron}{$type}{"end"}{$i} = $current_pos;
-							dual_print( $log, "Feature ". $previousIntron. " already defined. Please manually verify in $mfannot_file\n", $opt_verbose );
+							dual_print( $log, "Feature ". $previousIntron. " already defined. Please manually verify in $mfannot_file\n");
 					}
 					else { 
 						$startend_hash{$current_contig}{$previousIntron}{$type}{"end"}{0} = $current_pos; 

--- a/bin/agat_convert_sp_gff2gtf.pl
+++ b/bin/agat_convert_sp_gff2gtf.pl
@@ -39,14 +39,12 @@ if ( my $log_name = $config->{log_path} ) {
 # resolve version
 if ( defined $gtf_version ) {
     dual_print( $log,
-        "GTF version $gtf_version selected by command line interface.\n",
-        $config->{verbose} );
+        "GTF version $gtf_version selected by command line interface.\n");
 }
 else {
     $gtf_version = $config->{gtf_output_version};
     dual_print( $log,
-        "GTF version $gtf_version selected from the agat config file.\n",
-        $config->{verbose} );
+        "GTF version $gtf_version selected from the agat config file.\n");
 }
 
 # Update config
@@ -57,13 +55,13 @@ $config->{"output_format"}="gtf";
 # Manage output file #
 my $gffout = prepare_gffout($config, $opt_output);
 
-dual_print( $log, "Reading input file\n", $config->{verbose} );
+dual_print( $log, "Reading input file\n");
 ######################
 ### Parse GFF input #
 ### Read gff input file.
 my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $gff,
                                                                  config => $config });
-dual_print( $log, "converting to GTF$gtf_version\n", $config->{verbose} );
+dual_print( $log, "converting to GTF$gtf_version\n");
 # Now print  omniscient
 print_omniscient( {omniscient => $hash_omniscient, output => $gffout} );
 

--- a/bin/agat_convert_sp_gff2tsv.pl
+++ b/bin/agat_convert_sp_gff2tsv.pl
@@ -46,7 +46,7 @@ else{
 ### Parse GFF input #
 my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $gff,
                                                                  config => $config });
-dual_print( $log, "GFF3 file parsed\n", $config->{verbose} );
+dual_print( $log, "GFF3 file parsed\n");
 
 # ---- List attributes ----
 my $attribute_bucket = get_all_attributes($hash_omniscient);

--- a/bin/agat_convert_sp_gxf2gxf.pl
+++ b/bin/agat_convert_sp_gxf2gxf.pl
@@ -40,7 +40,7 @@ my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({
                                                                 input  => $opt_gfffile,
                                                                 config => $config
 });
-dual_print($log, "GFF3 file parsed\n", $config->{verbose});
+dual_print($log, "GFF3 file parsed\n");
 
 ###
 # Print result
@@ -50,8 +50,8 @@ print_omniscient( {omniscient => $hash_omniscient,
 
 my $end_run = time();
 my $run_time = $end_run - $start_run;
-dual_print($log, "usage: $0 @copyARGV\n", $config->{verbose});
-dual_print($log, "Job done in $run_time seconds\n", $config->{verbose});
+dual_print($log, "usage: $0 @copyARGV\n");
+dual_print($log, "Job done in $run_time seconds\n");
 
 __END__
 =head1 NAME

--- a/bin/agat_sp_add_attribute_shortest_exon_size.pl
+++ b/bin/agat_sp_add_attribute_shortest_exon_size.pl
@@ -43,7 +43,7 @@ my $string1 = strftime "%m/%d/%Y at %Hh%Mm%Ss", localtime;
 $string1 .= "\n\nusage: $0 @copyARGV\n\n";
 
 print $ostreamReport $string1;
-dual_print( $log, $string1, $config->{verbose} ) if $opt_output;
+dual_print( $log, $string1) if $opt_output;
 
                                                       #######################
                                                       #        MAIN         #
@@ -51,10 +51,10 @@ dual_print( $log, $string1, $config->{verbose} ) if $opt_output;
 
 ######################
 ### Parse GFF input #
-dual_print( $log, "Reading $opt_file\n", $config->{verbose} );
+dual_print( $log, "Reading $opt_file\n");
 my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $opt_file,
                                                                  config => $config });
-dual_print( $log, "Parsing Finished\n\n", $config->{verbose} );
+dual_print( $log, "Parsing Finished\n\n");
 ### END Parse GFF input #
 #########################
 
@@ -105,7 +105,7 @@ foreach my $tag_l1 (keys %{$hash_omniscient->{'level1'}}){
 
 my $toprint = "$nb_cases_l1 $tag flags/attributes added to level1 features and $nb_cases_l2 $tag flags/attributes added to level2 features. The value of the attribute is size of the shortest exon found.\n";
 print $ostreamReport $toprint;
-dual_print( $log, $toprint, $config->{verbose} ) if $opt_output;
+dual_print( $log, $toprint) if $opt_output;
 print_omniscient( {omniscient => $hash_omniscient, output => $gffout} );
       #########################
       ######### END ###########

--- a/bin/agat_sp_add_attribute_shortest_intron_size.pl
+++ b/bin/agat_sp_add_attribute_shortest_intron_size.pl
@@ -42,7 +42,7 @@ my $string1 = strftime "%m/%d/%Y at %Hh%Mm%Ss", localtime;
 $string1 .= "\n\nusage: $0 @copyARGV\n\n";
 
 print $ostreamReport $string1;
-if($opt_output){ dual_print($log, $string1, $config->{verbose}); }
+if($opt_output){ dual_print($log, $string1); }
 
                                                       #######################
                                                       #        MAIN         #
@@ -50,10 +50,10 @@ if($opt_output){ dual_print($log, $string1, $config->{verbose}); }
 
 ######################
 ### Parse GFF input #
-dual_print($log, "Reading $opt_file\n", $config->{verbose});
+dual_print($log, "Reading $opt_file\n");
 my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $opt_file,
                                                                  config => $config });
-dual_print($log, "Parsing Finished\n\n", $config->{verbose});
+dual_print($log, "Parsing Finished\n\n");
 ### END Parse GFF input #
 #########################
 
@@ -113,7 +113,7 @@ foreach my $tag_l1 (keys %{$hash_omniscient->{'level1'}}){
 
 my $toprint = "$nb_cases_l1 $tag flags/attributes added to level1 features and $nb_cases_l2 $tag flags/attributes added to level2 features. The value of the attribute is size of the shortest exon found.\n";
 print $ostreamReport $toprint;
-if($opt_output){ dual_print($log, $toprint, $config->{verbose}); }
+if($opt_output){ dual_print($log, $toprint); }
 print_omniscient( {omniscient => $hash_omniscient, output => $gffout} );
       #########################
       ######### END ###########

--- a/bin/agat_sp_add_intergenic_regions.pl
+++ b/bin/agat_sp_add_intergenic_regions.pl
@@ -36,12 +36,12 @@ my $gffout = prepare_gffout($config, $opt_output);
   ### Parse GFF input #
   my ($omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $opt_file,
                                                               config => $config });
-  dual_print($log, "Parsing Finished\n", $config->{verbose});
+  dual_print($log, "Parsing Finished\n");
   ### END Parse GFF input #
   #########################
 
 if(! exists_keys($omniscient,('level1', "gene") ) ){
-  dual_print($log, "No gene feature found in $opt_file, intergenic regions cannot be determinded!\n", $config->{verbose});
+  dual_print($log, "No gene feature found in $opt_file, intergenic regions cannot be determinded!\n");
   exit 0;
 }
 
@@ -49,7 +49,7 @@ if(! exists_keys($omniscient,('level1', "gene") ) ){
 my $sortBySeq = gather_and_sort_l1_by_seq_id_for_l1type($omniscient, 'gene');
 
 # --------------------------- COLLECT GENE LOCATIONS -----------------------
-dual_print($log, "Now colleting the gene locations\n", $config->{verbose});
+dual_print($log, "Now colleting the gene locations\n");
 my $flattened_locations = {};
 foreach my $locusID ( sort keys %{$sortBySeq}){ # tag_l1 = gene or repeat etc...
   # check if gene  exits for this sequence
@@ -70,7 +70,7 @@ foreach my $locusID ( sort keys %{$sortBySeq}){ # tag_l1 = gene or repeat etc...
 # --------------------------- FIX OVERLAPPING LOCATIONS -----------------------
 # Will merge locations that overlap
 
-dual_print($log, "Now flattening the locations\n", $config->{verbose});
+dual_print($log, "Now flattening the locations\n");
 foreach my $locusID (  keys %{$flattened_locations} ){
 
   my @newlocations;
@@ -108,7 +108,7 @@ foreach my $locusID (  keys %{$flattened_locations} ){
 }
 
 # --------------------------- NOW creating intergenic location -----------------------
-dual_print($log, "Now creating intergenic regions\n", $config->{verbose});
+dual_print($log, "Now creating intergenic regions\n");
 my $intergenic_added=0;
 # Go through location from left to right ### !! if not empty
 foreach my $locusID ( sort keys %{$flattened_locations}){ # tag_l1 = gene or repeat etc...
@@ -147,7 +147,7 @@ foreach my $locusID ( sort keys %{$flattened_locations}){ # tag_l1 = gene or rep
 # print result
 print_omniscient( {omniscient => $omniscient, output => $gffout} );
 
-dual_print($log, "$intergenic_added intergenic_region added!\nBye Bye\n", $config->{verbose});
+dual_print($log, "$intergenic_added intergenic_region added!\nBye Bye\n");
       #########################
       ######### END ###########
       #########################

--- a/bin/agat_sp_add_introns.pl
+++ b/bin/agat_sp_add_introns.pl
@@ -47,7 +47,7 @@ my $gffout = prepare_gffout( $config, $config->{output} );
   my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $opt_file,
                                                                    config => $config });
 
-  dual_print( $log, "Parsing Finished\n\n", $config->{verbose} );
+  dual_print( $log, "Parsing Finished\n\n");
   
   ### END Parse GFF input #
   #########################
@@ -74,7 +74,7 @@ my $intron_added=0;
         }
       }
       if(! $feature_l1){
-        dual_print( $log, "Problem ! We didnt retrieve the level1 feature with id $id_l1\n", $config->{verbose} );
+        dual_print( $log, "Problem ! We didnt retrieve the level1 feature with id $id_l1\n");
         exit;
       }
 
@@ -138,7 +138,7 @@ my $intron_added=0;
 print_omniscient( {omniscient => $hash_omniscient, output => $gffout} );
 
 
-dual_print( $log, "$intron_added introns added\nBye Bye\n", $config->{verbose} );
+dual_print( $log, "$intron_added introns added\nBye Bye\n");
 
       #########################
       ######### END ###########

--- a/bin/agat_sp_add_splice_sites.pl
+++ b/bin/agat_sp_add_splice_sites.pl
@@ -48,7 +48,7 @@ my $gffout = prepare_gffout($config, $opt_output);
   ### Parse GFF input #
   my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $opt_file,
                                                                    config => $config });
-  dual_print($log, "Parsing Finished\n", $verbose);
+  dual_print($log, "Parsing Finished\n");
   ### END Parse GFF input #
   #########################
 
@@ -73,7 +73,7 @@ my $splice_added=0;
           last;
         }
       }
-      if(! $feature_l1){dual_print($log, "Problem ! We didnt retrieve the level1 feature with id $id_l1\n", $verbose);exit;}
+      if(! $feature_l1){dual_print($log, "Problem ! We didnt retrieve the level1 feature with id $id_l1\n");exit;}
 
       #####
       # get all level2
@@ -166,7 +166,7 @@ my $splice_added=0;
 
 print_omniscient( {omniscient => $hash_omniscient, output => $gffout} );
 
-dual_print($log, "$splice_added five_prime_cis_splice_site and $splice_added three_prime_cis_splice_site added!\nBye Bye\n", $verbose);
+dual_print($log, "$splice_added five_prime_cis_splice_site and $splice_added three_prime_cis_splice_site added!\nBye Bye\n");
       #########################
       ######### END ###########
       #########################

--- a/bin/agat_sp_add_start_and_stop.pl
+++ b/bin/agat_sp_add_start_and_stop.pl
@@ -48,7 +48,7 @@ if ( my $log_name = $config->{log_path} ) {
 # #######################
 my $gffout = prepare_gffout( $config, $config->{output} );
 
-$codon_table_id = get_proper_codon_table($codon_table_id, $log, $opt_verbose);
+$codon_table_id = get_proper_codon_table($codon_table_id, $log);
 
 my $codon_table = Bio::Tools::CodonTable->new( -id => $codon_table_id, -no_iupac => 0 );
 # #####################################
@@ -67,14 +67,14 @@ my $codon_table = Bio::Tools::CodonTable->new( -id => $codon_table_id, -no_iupac
 ### Parse GFF input #
 my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $opt_file,
                                                                  config => $config });
-dual_print( $log, "Parsing Finished\n\n", $opt_verbose );
+dual_print( $log, "Parsing Finished\n\n");
 ### END Parse GFF input #
 #########################
 
 ####################
 # index the genome #
 my $db = Bio::DB::Fasta->new($file_fasta);
-dual_print( $log, "Fasta file parsed\n", $opt_verbose );
+dual_print( $log, "Fasta file parsed\n");
 
 my $counter_start_missing = 0;
 my $counter_start_added = 0;
@@ -94,9 +94,9 @@ foreach my $tag_l2 (sort keys %{$hash_omniscient->{'level2'}}){
       if ($feature_l2->strand == -1 or $feature_l2->strand eq "-"){
         $strand="-";
       }
-      dual_print( $log, "feature strand = $strand\n", $opt_verbose );
+      dual_print( $log, "feature strand = $strand\n");
       my $seq_id = $feature_l2->seq_id();
-      dual_print( $log, "sequence length ".$db->length($seq_id)."\n", $opt_verbose );
+      dual_print( $log, "sequence length ".$db->length($seq_id)."\n");
       
       ##############################
       #If it's a mRNA = have CDS. #
@@ -111,20 +111,20 @@ foreach my $tag_l2 (sort keys %{$hash_omniscient->{'level2'}}){
         #-------------------------
         #       START CASE
         #-------------------------
-        dual_print( $log, "---START CODON TEST---\n", $opt_verbose );
+        dual_print( $log, "---START CODON TEST---\n");
         if ( exists ($hash_omniscient->{'level3'}{'start_codon'}{$id_level2} ) ){
-          dual_print( $log, "start_codon already exists for $id_level2\n", $opt_verbose );
+          dual_print( $log, "start_codon already exists for $id_level2\n");
         }
         else{
           # ----- Find the start codon -----
           my $extension=0;
           my $start_codon = undef;
           if ( !$start_codon ){
-            dual_print( $log, " Try find a start codon in the CDS (GFF and GTF case) \n", $opt_verbose );
+            dual_print( $log, " Try find a start codon in the CDS (GFF and GTF case) \n");
             $start_codon = next_codon_is_start(\@cds_feature_list, -3);
           } 
           if ( $opt_extend and !$start_codon ){
-            dual_print( $log, " Try to extend the sequence to find a start codon further...\n", $opt_verbose );
+            dual_print( $log, " Try to extend the sequence to find a start codon further...\n");
             $extension += 3;  
             # check end of seq
             my $out=undef;
@@ -217,9 +217,9 @@ foreach my $tag_l2 (sort keys %{$hash_omniscient->{'level2'}}){
         #-------------------------
         #       STOP CASE
         #-------------------------
-        dual_print( $log, "---STOP CODON TEST---\n", $opt_verbose );
+        dual_print( $log, "---STOP CODON TEST---\n");
         if ( exists ($hash_omniscient->{'level3'}{'stop_codon'}{$id_level2} ) ){
-          dual_print( $log, "stop_codon already exists for $id_level2\n", $opt_verbose );
+          dual_print( $log, "stop_codon already exists for $id_level2\n");
         }
         else{ 
           # ----- Find a stop codon -----
@@ -227,11 +227,11 @@ foreach my $tag_l2 (sort keys %{$hash_omniscient->{'level2'}}){
           my $extension = 0;
           my $terminal_codon = undef;
           if ( !$terminal_codon ){
-            dual_print( $log, " Try find a stop codon in the CDS (GFF case) \n", $opt_verbose );
+            dual_print( $log, " Try find a stop codon in the CDS (GFF case) \n");
             $terminal_codon = next_codon_is_ter(\@cds_feature_list, -3);
           } 
           if ( !$terminal_codon ){
-              dual_print( $log, " Try find a stop codon next codon out of the CDS (GTF case) \n", $opt_verbose );
+              dual_print( $log, " Try find a stop codon next codon out of the CDS (GTF case) \n");
             $terminal_codon = next_codon_is_ter(\@cds_feature_list, 0);
 
             if($strand eq "+"){
@@ -241,7 +241,7 @@ foreach my $tag_l2 (sort keys %{$hash_omniscient->{'level2'}}){
             }
           } # with extend option 
           if ($opt_extend and !$terminal_codon){
-            dual_print( $log, " Try to extend the sequence to find a stop codon further...\n", $opt_verbose );
+            dual_print( $log, " Try to extend the sequence to find a stop codon further...\n");
             $extension += 3;  
             # check end of seq
             my $out=undef;
@@ -346,9 +346,9 @@ if ($opt_extend){
   print_omniscient( {omniscient => $hash_omniscient, output => $gffout} );
 }
 
-dual_print( $log, "$counter_start_added start codon added and $counter_start_missing CDS do not start by a start codon\n", $opt_verbose );
-dual_print( $log, "$counter_end_added stop codon added and $counter_end_missing CDS do not end by a stop codon \n", $opt_verbose );
-dual_print( $log, "bye bye\n", $opt_verbose );
+dual_print( $log, "$counter_start_added start codon added and $counter_start_missing CDS do not start by a start codon\n");
+dual_print( $log, "$counter_end_added stop codon added and $counter_end_missing CDS do not end by a stop codon \n");
+dual_print( $log, "bye bye\n");
 
       #########################
       ######### END ###########
@@ -377,10 +377,10 @@ sub create_cds_object{
     my $seqid=$feature->seq_id();
     $seq .= $db->seq( $seqid, $start, $end );
   }
-  dual_print( $log, "sequence: $seq\n", $opt_verbose );
+  dual_print( $log, "sequence: $seq\n");
   my $debut = $db->seq( $feature_list->[0]->seq_id(), $feature_list->[0]->start-1, $feature_list->[0]->start -3 );
   my $fin = $db->seq( $feature_list->[0]->seq_id(), $feature_list->[-1]->end+1, $feature_list->[-1]->end+ 3 );
-  dual_print( $log, "sequence_extended: $debut$seq$fin\n", $opt_verbose );
+  dual_print( $log, "sequence_extended: $debut$seq$fin\n");
 
   #create the cds object
   my $cds_obj = Bio::Seq->new(-seq => $seq, -alphabet => 'dna' );
@@ -390,8 +390,8 @@ sub create_cds_object{
   if ($feature_list->[0]->strand == -1 or $feature_list->[0]->strand eq "-"){
       $cds_obj = $cds_obj->revcom();
       $strand = "-";
-      dual_print( $log, "feature on minus strand\n", $opt_verbose );
-      dual_print( $log, "sequence: ".$cds_obj->seq."\n", $opt_verbose );
+      dual_print( $log, "feature on minus strand\n");
+      dual_print( $log, "sequence: ".$cds_obj->seq."\n");
   }
   
   return $cds_obj;
@@ -402,7 +402,7 @@ sub next_codon_is_start{
   if(! $more){
     $more=0;
   }
-  dual_print( $log, "next_codon_is_start test: \n", $opt_verbose );
+  dual_print( $log, "next_codon_is_start test: \n");
   my $cds_obj;
   my $seqid=$feature_list->[0]->seq_id();
 
@@ -412,20 +412,20 @@ sub next_codon_is_start{
       my $seq = $db->seq( $seqid,$end+1+$more, $end+3+$more);
       $cds_obj = Bio::Seq->new(-seq => $seq, -alphabet => 'dna' );
       $cds_obj = $cds_obj->revcom();
-      dual_print( $log, "  Minus strand - most right side: ".($end+3+$more)."\n", $opt_verbose );
+      dual_print( $log, "  Minus strand - most right side: ".($end+3+$more)."\n");
   }
   else{ # Plus strand
       my $start=$feature_list->[0]->start();
       my $seq = $db->seq( $seqid, $start-3-$more,  $start-1-$more);
       $cds_obj = Bio::Seq->new(-seq => $seq, -alphabet => 'dna' );
-      dual_print( $log, "  Plus strand - most right side: ".($start-3-$more)."\n", $opt_verbose );
+      dual_print( $log, "  Plus strand - most right side: ".($start-3-$more)."\n");
   }
 
   my $codon = $cds_obj->seq ;
-  dual_print( $log, "  codon tested is = $codon \n", $opt_verbose );
+  dual_print( $log, "  codon tested is = $codon \n");
 
   if ( !is_ambiguous_codon($codon) and $codon_table->is_start_codon( $codon )){
-    dual_print( $log, "  It is considered as a start codon!\n", $opt_verbose );;
+    dual_print( $log, "  It is considered as a start codon!\n");;
     return 1;
   } else{
     return 0;
@@ -438,7 +438,7 @@ sub next_codon_is_ter{
   if(! $more){
     $more=0;
   }
-  dual_print( $log, "next_codon_is_ter test: \n", $opt_verbose );
+  dual_print( $log, "next_codon_is_ter test: \n");
   my $cds_obj;
   my $seqid=$feature_list->[0]->seq_id();
 
@@ -448,20 +448,20 @@ sub next_codon_is_ter{
       my $seq = $db->seq( $seqid,$start-3-$more, $start-1-$more);
       $cds_obj = Bio::Seq->new(-seq => $seq, -alphabet => 'dna' );
       $cds_obj = $cds_obj->revcom();
-      dual_print( $log, "  Minus strand - most right side: ".($start-3-$more)."\n", $opt_verbose );
+      dual_print( $log, "  Minus strand - most right side: ".($start-3-$more)."\n");
   }
   else{ # Plus strand
       my $end=$feature_list->[-1]->end();
       my $seq = $db->seq( $seqid, $end+1+$more,  $end+3+$more);
       $cds_obj = Bio::Seq->new(-seq => $seq, -alphabet => 'dna' );
-      dual_print( $log, "  Plus strand - most right side: ".($end+3+$more)."\n", $opt_verbose );
+      dual_print( $log, "  Plus strand - most right side: ".($end+3+$more)."\n");
   }
   
   my $codon = $cds_obj->seq ;
-  dual_print( $log, "  codon tested is = $codon \n", $opt_verbose );
+  dual_print( $log, "  codon tested is = $codon \n");
 
   if ( !is_ambiguous_codon($codon) and $codon_table->is_ter_codon( $codon )){
-    dual_print( $log, "  It is considered as a stop codon!\n", $opt_verbose );
+    dual_print( $log, "  It is considered as a stop codon!\n");
     return 1;
   } else{
     return 0;
@@ -483,13 +483,13 @@ sub is_out_of_seq_start{
   if($strand eq "+"){
     if( $feature_list->[0]->start() - $more < 1 ){
       $out = 1;
-      dual_print( $log, "is_out_of_seq_start!! Plus strand - Most left out of seq: ".($feature_list->[0]->start() - $more)."\n", $opt_verbose );
+      dual_print( $log, "is_out_of_seq_start!! Plus strand - Most left out of seq: ".($feature_list->[0]->start() - $more)."\n");
     }
   }
   else{
     if( $feature_list->[-1]->end() + $more > $length_seqid ){
       $out = 1;
-      dual_print( $log, "is_out_of_seq_start!! Minus strand - Most right out of seq: ".($feature_list->[-1]->end() + $more)."\n", $opt_verbose );
+      dual_print( $log, "is_out_of_seq_start!! Minus strand - Most right out of seq: ".($feature_list->[-1]->end() + $more)."\n");
     }
   }
   return $out;
@@ -509,13 +509,13 @@ sub is_out_of_seq_stop{
   if($strand eq "+"){
     if( $feature_list->[-1]->end() + $more > $length_seqid ){
       $out = 1;
-      dual_print( $log, "is_out_of_seq_stop!! Plus strand - Most right out of seq: ".($feature_list->[-1]->end() + $more)."\n", $opt_verbose );
+      dual_print( $log, "is_out_of_seq_stop!! Plus strand - Most right out of seq: ".($feature_list->[-1]->end() + $more)."\n");
     }
   }
   else{
     if( $feature_list->[0]->start() - $more < 1 ){
       $out = 1;
-      dual_print( $log, "is_out_of_seq_stop!! Minus strand - Most right out of seq: ".($feature_list->[0]->start() - $more)."\n", $opt_verbose );
+      dual_print( $log, "is_out_of_seq_stop!! Minus strand - Most right out of seq: ".($feature_list->[0]->start() - $more)."\n");
     }
   }
   return $out;
@@ -528,7 +528,7 @@ sub is_ambiguous_codon{
 
   if ($opt_no_iupac){
     if ( $codon !~ /[ATGC]{3}/) {
-      dual_print( $log, "$codon is an ambiguous codon we skip it because the no_iupac option is activated!\n", $opt_verbose );
+      dual_print( $log, "$codon is an ambiguous codon we skip it because the no_iupac option is activated!\n");
       return 1;
     } 
   }

--- a/bin/agat_sp_alignment_output_style.pl
+++ b/bin/agat_sp_alignment_output_style.pl
@@ -35,7 +35,7 @@ my ($hash_omniscient, $hash_mRNAGeneLink) =  slurp_gff3_file_JD({
                                                                input => $opt_gfffile,
                                                                config => $config
                                                                });
-dual_print( $log, "GFF3 file parsed\n", $opt_verbose );
+dual_print( $log, "GFF3 file parsed\n");
 
 ###
 # Print result
@@ -43,7 +43,7 @@ print_omniscient_as_match( {omniscient => $hash_omniscient, output => $gffout} )
 
 my $end_run = time();
 my $run_time = $end_run - $start_run;
-dual_print( $log, "Job done in $run_time seconds\n", $opt_verbose );
+dual_print( $log, "Job done in $run_time seconds\n");
 __END__
 
 =head1 NAME

--- a/bin/agat_sp_clipN_seqExtremities_and_fixCoordinates.pl
+++ b/bin/agat_sp_clipN_seqExtremities_and_fixCoordinates.pl
@@ -46,11 +46,11 @@ my $gffout = prepare_gffout($config, $opt_output_gff);
 #### read gff file and save info in memory
 ######################
 ### Parse GFF input #
-dual_print($log, "Reading file $opt_gfffile\n", $opt_verbose );
+dual_print($log, "Reading file $opt_gfffile\n");
 my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $opt_gfffile,
                                                                  config => $config
                                                               });
-dual_print($log, "Parsing Finished\n", $opt_verbose );
+dual_print($log, "Parsing Finished\n");
 ### END Parse GFF input #
 #########################
 
@@ -141,13 +141,13 @@ foreach my $seq_id (@ids ){
 # print annotation whith shifter location
 print_omniscient( {omniscient => $hash_omniscient, output => $gffout} );
 
-dual_print($log, "We found $cpt_Nleft sequence(s) starting with N\n", $opt_verbose );
-dual_print($log, "We found $cpt_Nright sequence(s) ending with N\n", $opt_verbose );
-dual_print($log, "We found $cpt_Nboth sequence(s) having N both extremities\n", $opt_verbose );
+dual_print($log, "We found $cpt_Nleft sequence(s) starting with N\n");
+dual_print($log, "We found $cpt_Nright sequence(s) ending with N\n");
+dual_print($log, "We found $cpt_Nboth sequence(s) having N both extremities\n");
 
 my $end_run = time();
 my $run_time = $end_run - $start_run;
-dual_print($log, "Job done in $run_time seconds\n", $opt_verbose );
+dual_print($log, "Job done in $run_time seconds\n");
 
 close $log if $log;
 

--- a/bin/agat_sp_compare_two_BUSCOs.pl
+++ b/bin/agat_sp_compare_two_BUSCOs.pl
@@ -181,7 +181,7 @@ foreach my $type1 (keys %busco1){
             print $streamOut  $busco1{$type1}{$id1};
           }
           else{
-            dual_print( $log, "$id1 was $type1 and it is now $type2\n", $verbose );
+            dual_print( $log, "$id1 was $type1 and it is now $type2\n");
           }
         }
       }
@@ -205,7 +205,7 @@ if (-d $augustus_gff_folder){
   my %track_found;
   my @list_cases=("complete","fragmented","duplicated");
   foreach my $type (@list_cases){
-    dual_print( $log, "extract gff for $type cases\n", $verbose );
+    dual_print( $log, "extract gff for $type cases\n");
     foreach my $id (sort keys %{$busco1{$type}}){
       my @list = split(/\s/,$busco1{$type}{$id});
       my $seqId = $list[2];
@@ -218,7 +218,7 @@ if (-d $augustus_gff_folder){
           my $path = $augustus_gff_folder."/".$match;
           if (-f $path ){
             my  $found=undef;
-            dual_print( $log, "$path\n", $verbose );
+            dual_print( $log, "$path\n");
 
             my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $path,
                                                                              config => $config
@@ -250,7 +250,7 @@ if (-d $augustus_gff_folder){
 
               if ($found){
                 if(@listIDl1ToRemove){
-                  dual_print( $log, "lets remove those supernumary annotation: @listIDl1ToRemove \n", $verbose );
+                  dual_print( $log, "lets remove those supernumary annotation: @listIDl1ToRemove \n");
                   remove_omniscient_elements_from_level1_id_list($hash_omniscient, \@listIDl1ToRemove);
                 }
 
@@ -267,20 +267,20 @@ if (-d $augustus_gff_folder){
                 }
               }
               else{
-                dual_print( $log, "No annotation as described in the tsv file found in the gff file $path\n", $verbose );
+                dual_print( $log, "No annotation as described in the tsv file found in the gff file $path\n");
               }
             }
             else{
-              dual_print( $log, "No annotation in the file $path, lets look the next one.\n", $verbose );
+              dual_print( $log, "No annotation in the file $path, lets look the next one.\n");
             }
           }
           else{
-            dual_print( $log, "A) file $id not found among augustus gff output\n", $verbose );
+            dual_print( $log, "A) file $id not found among augustus gff output\n");
           }
         }
       }
       else{
-        dual_print( $log, "file $id not found among augustus gff output\n", $verbose );
+        dual_print( $log, "file $id not found among augustus gff output\n");
       }
       if(! exists_keys(\%track_found,($type,$id))){
         warn "WARNING After reading all the files related to id $id we didn't found any annotation matching its described in the tsv file.\n" if $verbose;
@@ -292,7 +292,7 @@ if (-d $augustus_gff_folder){
     $list_uID_new_omniscient=undef; #Empty Id used;
     my $nb = keys %{$track_found{$type}};
     $loop = 0;
-    dual_print( $log, "We found $nb annotations from $type busco\n", $verbose );
+    dual_print( $log, "We found $nb annotations from $type busco\n");
   }
 
 }
@@ -304,7 +304,7 @@ else{ die "$augustus_gff_folder folder doesn't exits\n"; }
 ##Last round
 my $end_run = time();
 my $run_time = $end_run - $start_run;
-dual_print( $log, "Job done in $run_time seconds\n", $verbose );
+dual_print( $log, "Job done in $run_time seconds\n");
 #######################################################################################################################
         ####################
          #     methods    #

--- a/bin/agat_sp_compare_two_annotations.pl
+++ b/bin/agat_sp_compare_two_annotations.pl
@@ -33,7 +33,7 @@ if ( my $log_name = $config->{log_path} ) {
 # Manage output folder #
 
 if ( !$opt_output ) {
-  dual_print( $log, "Default output name: split_result\n", $verbose );
+  dual_print( $log, "Default output name: split_result\n");
   $opt_output = 'comparison_result';
 }
 
@@ -54,26 +54,26 @@ $verbose=1 if ($debug);
 
 ######################
 ### Parse GFF input #
-dual_print( $log, "Parsing $gff1\n", $verbose );
+dual_print( $log, "Parsing $gff1\n");
 my ($omniscient1, $hash_mRNAGeneLink1) = slurp_gff3_file_JD({ input => $gff1,
                                                               config => $config
                                                               });
-dual_print( $log, "\n\nParsing $gff2\n", $verbose );
+dual_print( $log, "\n\nParsing $gff2\n");
 my ($omniscient2, $hash_mRNAGeneLink2) = slurp_gff3_file_JD({ input => $gff2,
                                                               config => $config
                                                               });
-dual_print( $log, "-- Files parsed --\n", $verbose );
+dual_print( $log, "-- Files parsed --\n");
 
 
 my $sortBySeq1 = gather_and_sort_l1_location_by_seq_id_and_strand_chimere($omniscient1);
 my $sortBySeq2 = gather_and_sort_l1_location_by_seq_id_and_strand_chimere($omniscient2);
-dual_print( $log, "GFF3 files sorted\n", $verbose );
+dual_print( $log, "GFF3 files sorted\n");
 
 my %overlap_info; # <= Will contain the overlap information
 # ------------------------------------------------------------------------------
 # ---------------------------- COLLECT ALL LOCATIONS ---------------------------
 # ------------------------------------------------------------------------------
-dual_print( $log, "COLLECT LOCATIONS\n", $verbose );
+dual_print( $log, "COLLECT LOCATIONS\n");
 my $bucket_locations1 = {};
 my $bucket_locations2 = {};
 my $cpt = 0;
@@ -148,7 +148,7 @@ foreach my $sortBySeq ($sortBySeq1, $sortBySeq2){
 # ------------------------- FLATTEN OVERLAPPING LOCATIONS ----------------------
 # ------------------------------------------------------------------------------
 # Will merge same location types that overlap
-dual_print( $log, "FLATTEN LOCATIONS\n", $verbose );
+dual_print( $log, "FLATTEN LOCATIONS\n");
 my $flattened_locations_clean;
 my $flattened_locations1_clean = {};
 my $flattened_locations2_clean = {};
@@ -277,7 +277,7 @@ foreach my $locusID ( sort  keys %{$flattened_locations2_clean} ){
 # ------------------------------------------------------------------------------
 
 # When already checked the location is removed from flattened_locationsX_clean_sorted hash
-dual_print( $log, "COMPARE LOCATIONS\n", $verbose );
+dual_print( $log, "COMPARE LOCATIONS\n");
 my %seen1;
 my %seen2;
 foreach my $locusID ( sort  keys %{$flattened_locations1_clean_sorted} ){
@@ -431,7 +431,7 @@ foreach my $locusID ( sort  keys %{$flattened_locations1_clean_sorted} ){
 
 # ---- NOw deal with what is remaining in annotationA
 # Gather False positive => seq only annotated in annotationB, or type of feature annotated only in annotationB that was missing in annotatoin A
-dual_print( $log, "\nLook now what is specific to annotationA \n", $verbose );
+dual_print( $log, "\nLook now what is specific to annotationA \n");
 foreach my $locusID (  keys %{$flattened_locations1_clean_sorted} ){
   foreach my $chimere_type ( keys %{$flattened_locations1_clean_sorted->{$locusID}}){
     foreach my $locations1 ( @{$flattened_locations1_clean_sorted->{$locusID}{$chimere_type}} ){
@@ -443,7 +443,7 @@ foreach my $locusID (  keys %{$flattened_locations1_clean_sorted} ){
 
 # ---- NOw deal with what is remaining in annotationB-
 # Gather False positive => seq only annotated in annotationB, or type of feature annotated only in annotationB that was missing in annotatoin A
-dual_print( $log, "\nLook now what is specific to annotationB \n", $verbose );
+dual_print( $log, "\nLook now what is specific to annotationB \n");
 foreach my $locusID (  keys %{$flattened_locations2_clean_sorted} ){
   foreach my $chimere_type ( keys %{$flattened_locations2_clean_sorted->{$locusID}}){
     foreach my $locations2 ( @{$flattened_locations2_clean_sorted->{$locusID}{$chimere_type}} ){
@@ -456,10 +456,10 @@ foreach my $locusID (  keys %{$flattened_locations2_clean_sorted} ){
 ##############
 # STATISTICS #
 if($verbose){
-  dual_print( $log, "Compute statistics for $gff1:\n", $verbose );
+  dual_print( $log, "Compute statistics for $gff1:\n");
 	print_omniscient_statistics ({ input => $omniscient1 });
 
-    dual_print( $log, "Compute statistics for $gff2:\n", $verbose );
+    dual_print( $log, "Compute statistics for $gff2:\n");
 	print_omniscient_statistics ({ input => $omniscient2 });
 }
 
@@ -552,8 +552,8 @@ $string_to_print .= "\n";
 if ($opt_output){
   print $report $string_to_print;
 }
-dual_print( $log, $string_to_print, $verbose );
-dual_print( $log, "Bye Bye.\n", $verbose );
+dual_print( $log, $string_to_print);
+dual_print( $log, "Bye Bye.\n");
 #######################################################################################################################
         ####################
          #     METHODS    #
@@ -570,7 +570,7 @@ dual_print( $log, "Bye Bye.\n", $verbose );
  # return t1 is location overlap
 sub remove_loc_by_id{
 	my($list_location, $locusID, $chimere_type, $id)=@_;
-    dual_print( $log, "Remove $id from locations \n", $verbose );
+    dual_print( $log, "Remove $id from locations \n");
 	my @new_list;
 	foreach my $locations ( @{$list_location->{$locusID}{$chimere_type}} ){
 		if ( lc($locations->[0][3]) ne lc($id) ) {

--- a/bin/agat_sp_complement_annotations.pl
+++ b/bin/agat_sp_complement_annotations.pl
@@ -47,7 +47,7 @@ my $gffout = prepare_gffout($config, $opt_output);
 my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $ref,
                                                                  config => $config
                                                               });
-dual_print( $log, "$ref GFF3 file parsed\n", $verbose );
+dual_print( $log, "$ref GFF3 file parsed\n");
 info_omniscient($hash_omniscient, $log, $verbose);
 
 #Add the features of the other file in the first omniscient. It takes care of name to not have duplicates
@@ -55,13 +55,13 @@ foreach my $next_file (@opt_files){
   my ($hash_omniscient2, $hash_mRNAGeneLink2) = slurp_gff3_file_JD({ input => $next_file,
 	                                                                   config => $config
                                                                 });
-  dual_print( $log, "$next_file GFF3 file parsed\n", $verbose );
+  dual_print( $log, "$next_file GFF3 file parsed\n");
   info_omniscient($hash_omniscient2, $log, $verbose);
 
   ################################
   # First rename ID to be sure to not add feature with ID already used
   rename_ID_existing_in_omniscient($hash_omniscient, $hash_omniscient2);
-  dual_print( $log, "\n$next_file IDs checked and fixed.\n", $verbose );
+  dual_print( $log, "\n$next_file IDs checked and fixed.\n");
 
 
   # Quick stat hash before complement
@@ -75,7 +75,7 @@ foreach my $next_file (@opt_files){
 
   ####### COMPLEMENT #######
   complement_omniscients($hash_omniscient, $hash_omniscient2, $size_min);
-  dual_print( $log, "\nComplement done !\n", $verbose );
+  dual_print( $log, "\nComplement done !\n");
 
 
  #RESUME COMPLEMENT
@@ -93,7 +93,7 @@ foreach my $next_file (@opt_files){
   foreach my $level ( ('level1', 'level2') ){
     foreach my $tag (keys %{$quick_stat1{$level}}){
       if ($quick_stat1{$level}{$tag} != $quick_stat2{$level}{$tag} ){
-        dual_print( $log, "We added ".($quick_stat2{$level}{$tag}-$quick_stat1{$level}{$tag})." $tag(s)\n", $verbose );
+        dual_print( $log, "We added ".($quick_stat2{$level}{$tag}-$quick_stat1{$level}{$tag})." $tag(s)\n");
         $complemented=1;
       }
     }
@@ -102,17 +102,17 @@ foreach my $next_file (@opt_files){
   foreach my $level ( ('level1', 'level2') ){
     foreach my $tag (keys %{$quick_stat2{$level}}){
       if (! exists $quick_stat1{$level}{$tag} ){
-        dual_print( $log, "We added ".$quick_stat2{$level}{$tag}." $tag(s)\n", $verbose );
+        dual_print( $log, "We added ".$quick_stat2{$level}{$tag}." $tag(s)\n");
         $complemented=1;
       }
     }
   }
   #If nothing added
   if(! $complemented){
-    dual_print( $log, "\nNothing has been added\n", $verbose );
+    dual_print( $log, "\nNothing has been added\n");
   }
   else{
-    dual_print( $log, "\nNow the data contains:\n", $verbose );
+    dual_print( $log, "\nNow the data contains:\n");
     info_omniscient($hash_omniscient, $log, $verbose);
   }
 }
@@ -121,10 +121,10 @@ foreach my $next_file (@opt_files){
 # Print results
 print_omniscient( {omniscient => $hash_omniscient, output => $gffout} );
 #END
-dual_print( $log, "usage: $0 @copyARGV\n", $verbose );
+dual_print( $log, "usage: $0 @copyARGV\n");
 my $end_run = time();
 my $run_time = $end_run - $start_run;
-dual_print( $log, "Job done in $run_time seconds\n", $verbose );
+dual_print( $log, "Job done in $run_time seconds\n");
 __END__
 
 =head1 NAME

--- a/bin/agat_sp_ensembl_output_style.pl
+++ b/bin/agat_sp_ensembl_output_style.pl
@@ -36,7 +36,7 @@ my ($hash_omniscient, $hash_mRNAGeneLink) =  slurp_gff3_file_JD({
                                                                input => $opt_gfffile,
                                                                config => $config
                                                                });
-dual_print( $log, "GFF3 file parsed\n", $verbose );
+dual_print( $log, "GFF3 file parsed\n");
 
 
 #######################
@@ -49,7 +49,7 @@ print_omniscient( {omniscient => $hash_omniscient, output => $gffout} );
 
 my $end_run = time();
 my $run_time = $end_run - $start_run;
-dual_print( $log, "Job done in $run_time seconds\n", $verbose );
+dual_print( $log, "Job done in $run_time seconds\n");
 __END__
 
 =head1 NAME

--- a/bin/agat_sp_extract_attributes.pl
+++ b/bin/agat_sp_extract_attributes.pl
@@ -50,19 +50,19 @@ if ($one_tsv) {
 # Manage $primaryTag
 my @ptagList;
 if(! $primaryTag or $primaryTag eq "all"){
-  dual_print( $log, "We will work on attributes from all features\n", $verbose );
+  dual_print( $log, "We will work on attributes from all features\n");
   push(@ptagList, "all");
 }elsif($primaryTag =~/^level[123]$/){
-  dual_print( $log, "We will work on attributes from all the $primaryTag features\n", $verbose );
+  dual_print( $log, "We will work on attributes from all the $primaryTag features\n");
   push(@ptagList, $primaryTag);
 }else{
    @ptagList= split(/,/, $primaryTag);
    foreach my $tag (@ptagList){
       if($tag =~/^level[123]$/){
-        dual_print( $log, "We will work on attributes from all the $tag features\n", $verbose );
+        dual_print( $log, "We will work on attributes from all the $tag features\n");
       }
       else{
-       dual_print( $log, "We will work on attributes from $tag feature.\n", $verbose );
+       dual_print( $log, "We will work on attributes from $tag feature.\n");
       }
    }
 }
@@ -75,10 +75,10 @@ if ($attributes){
 
   foreach my $attribute (@attList){
       push @attListOk, $attribute;
-      dual_print( $log, "$attribute attribute will be processed.\n", $verbose );
+      dual_print( $log, "$attribute attribute will be processed.\n");
 
   }
-  dual_print( $log, "\n", $verbose );
+  dual_print( $log, "\n");
 }
 
 
@@ -92,7 +92,7 @@ if ($attributes){
 my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $gff,
                                                                  config => $config
                                                               });
-dual_print( $log, "GFF3 file parsed\n", $verbose );
+dual_print( $log, "GFF3 file parsed\n");
 
 
 foreach my $tag_l1 (sort keys %{$hash_omniscient->{'level1'}}){

--- a/bin/agat_sp_extract_sequences.pl
+++ b/bin/agat_sp_extract_sequences.pl
@@ -72,7 +72,7 @@ if ( defined $config->{log_path} ) {
     open( $log, '>', $config->{log_path} )
       or die "Can not open $config->{log_path} for printing: $!";
 }
-dual_print( $log, $header, $opt_verbose );
+dual_print( $log, $header);
 
 # --- Check codon table
 # --- Check codon table
@@ -93,7 +93,7 @@ else{
   $ostream = Bio::SeqIO->new(-fh => \*STDOUT, -format => 'Fasta');
 }
 
-dual_print($log, "We will extract the $opt_type sequences.\n", $opt_verbose);
+dual_print($log, "We will extract the $opt_type sequences.\n");
 $opt_type=lc($opt_type);
 
 # deal with OFS
@@ -111,11 +111,11 @@ if ($opt_keep_parent_attributes){
 #### read gff file and save info in memory
 ######################
 ### Parse GFF input #
-dual_print($log, "Reading file $opt_gfffile\n", $opt_verbose);
+dual_print($log, "Reading file $opt_gfffile\n");
 my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $opt_gfffile,
                                                                  config => $config
                                                               });
-dual_print($log, "Parsing Finished\n", $opt_verbose);
+dual_print($log, "Parsing Finished\n");
 ### END Parse GFF input #
 #########################
 
@@ -131,7 +131,7 @@ my %allIDs; # save ID in lower case to avoid cast problems
 foreach my $id (@ids ){$allIDs{lc($id)}=$id;}
 
 
-dual_print($log, "Fasta file parsed\n", $opt_verbose);
+dual_print($log, "Fasta file parsed\n");
 # ----------------------------------- LEVEL 1 ----------------------------------
 foreach my $seqname (sort { (($a =~ /(\d+)$/)[0] || 0) <=> (($b =~ /(\d+)$/)[0] || 0) } keys %{$hash_l1_grouped}) {
 
@@ -146,7 +146,7 @@ foreach my $seqname (sort { (($a =~ /(\d+)$/)[0] || 0) <=> (($b =~ /(\d+)$/)[0] 
       my $id_seq = clean_string($id_l1);
       my $description.=clean_tag("seq_id=").clean_string($seqname).$OFS.clean_tag("type=").clean_string($opt_type);
 			if($opt_keep_attributes){
-                           dual_print($log, "Extract attributes level1\n", $opt_verbose);
+                           dual_print($log, "Extract attributes level1\n");
 				my $attributes = extract_attributes($feature_l1);
 				$description.=$OFS.$attributes;
 			}
@@ -171,7 +171,7 @@ foreach my $seqname (sort { (($a =~ /(\d+)$/)[0] || 0) <=> (($b =~ /(\d+)$/)[0] 
           if( $opt_type eq $ptag_l2 or $opt_type eq "l2" or $opt_type eq "level2" ){
 
 						if($opt_keep_attributes ){
-                                                   dual_print($log, "Extract attributes level2\n", $opt_verbose);
+                                                   dual_print($log, "Extract attributes level2\n");
 							my @List_l1=($feature_l1);
 							my $attributes = extract_attributes( $feature_l2, \@List_l1 );
 							$description.=$OFS.$attributes;
@@ -198,30 +198,27 @@ foreach my $seqname (sort { (($a =~ /(\d+)$/)[0] || 0) <=> (($b =~ /(\d+)$/)[0] 
 }
 
 #END
-dual_print($log, "usage: $0 @copyARGV\n", $opt_verbose);
+dual_print($log, "usage: $0 @copyARGV\n");
 
 if($opt_upstreamRegion and $opt_downRegion){
   dual_print($log,
-              "$nbFastaSeq $opt_type converted in fasta with $opt_upstreamRegion upstream nucleotides and $opt_downRegion downstream nucleotides.\n",
-              $opt_verbose);
+              "$nbFastaSeq $opt_type converted in fasta with $opt_upstreamRegion upstream nucleotides and $opt_downRegion downstream nucleotides.\n");
 }
 elsif($opt_upstreamRegion){
   dual_print($log,
-              "$nbFastaSeq $opt_type converted in fasta with $opt_upstreamRegion upstream nucleotides.\n",
-              $opt_verbose);
+              "$nbFastaSeq $opt_type converted in fasta with $opt_upstreamRegion upstream nucleotides.\n");
 }
 elsif($opt_downRegion){
   dual_print($log,
-              "$nbFastaSeq $opt_type converted in fasta with $opt_downRegion downstream nucleotides.\n",
-              $opt_verbose);
+              "$nbFastaSeq $opt_type converted in fasta with $opt_downRegion downstream nucleotides.\n");
 }
 else{
-  dual_print($log, "$nbFastaSeq $opt_type converted in fasta.\n", $opt_verbose);
+  dual_print($log, "$nbFastaSeq $opt_type converted in fasta.\n");
 }
 
 my $end_run = time();
 my $run_time = $end_run - $start_run;
-dual_print($log, "Job done in $run_time seconds\n", $opt_verbose);
+dual_print($log, "Job done in $run_time seconds\n");
 close $log if $log;
 
 #######################################################################################################################
@@ -402,7 +399,7 @@ sub extract_sequences{
 
 		# catch attributes for Level3
 		if($opt_keep_attributes and $level eq 'level3' ){ #update header's id information
-                   dual_print($log, "Extract attributes level3 full\n", $opt_verbose);
+                   dual_print($log, "Extract attributes level3 full\n");
 			my $attributes = extract_attributes(\@sortedList, $lpa);
 			$description.=$OFS.$attributes;
 		}
@@ -463,7 +460,7 @@ sub extract_sequences{
 
 				# catch attributes for Level3
 				if( $opt_keep_attributes ){ #update header's id information
-                                   dual_print($log, "Extract attributes level3 split\n", $opt_verbose);
+                                   dual_print($log, "Extract attributes level3 split\n");
 					my $attributes = extract_attributes($feature, $lpa);
 					$updated_description.=$OFS.$attributes;
 				}
@@ -548,7 +545,7 @@ sub extract_sequences{
 
 			# catch attributes for Level3
 			if($opt_keep_attributes and $level eq 'level3' ){ #update header's id information
-                           dual_print($log, "Extract attributes level3 natural spread merged\n", $opt_verbose);
+                           dual_print($log, "Extract attributes level3 natural spread merged\n");
 				my $attributes = extract_attributes(\@sortedList, $lpa);
 				$description.=$OFS.$attributes;
 			}
@@ -592,7 +589,7 @@ sub extract_sequences{
 
 					# catch attributes for Level3
 					if( $opt_keep_attributes ){ #update header's id information
-                                           dual_print($log, "Extract attributes level3 natural not spread or spread not merged\n", $opt_verbose);
+                                           dual_print($log, "Extract attributes level3 natural not spread or spread not merged\n");
 						my $attributes = extract_attributes($feature, $lpa);
 						$updated_description.=$OFS.$attributes;
 					}
@@ -746,7 +743,7 @@ sub  get_sequence{
 
 # Print the sequence object
 sub print_seqObj{
-  my($ostream, $seqObj, $opt_AA, $opt_codonTable, $phase, $log, $verbose) = @_;
+  my($ostream, $seqObj, $opt_AA, $opt_codonTable, $phase, $log) = @_;
 
 
   if($opt_AA){ #translate if asked
@@ -764,8 +761,7 @@ sub print_seqObj{
           my $translated_seq = substr($transObj->seq(),1); # removing first AA
           $transObj->seq("M".$translated_seq);  # adding M as first AA
           dual_print($log,
-                     "Replacing valid alternative start codon (AA=$first_AA) by a methionine (AA=M) for ".$seqObj->id().".\n",
-                     $verbose);
+                     "Replacing valid alternative start codon (AA=$first_AA) by a methionine (AA=M) for ".$seqObj->id().".\n");
         }
       }
 

--- a/bin/agat_sp_filter_by_ORF_size.pl
+++ b/bin/agat_sp_filter_by_ORF_size.pl
@@ -63,7 +63,7 @@ my $gffout_notpass = prepare_gffout($config, $gffout_notpass_file);
 my $stringPrint = strftime "%m/%d/%Y at %Hh%Mm%Ss", localtime;
 $stringPrint = "Launched the ".$stringPrint."\nusage: $0 @copyARGV\n";
 $stringPrint .= "We are filtering the gene with protein size $opt_test $PROT_LENGTH\n";
-dual_print( $log, $stringPrint, $config->{verbose} );
+dual_print( $log, $stringPrint);
 
                 #####################
                 #     MAIN          #
@@ -74,7 +74,7 @@ dual_print( $log, $stringPrint, $config->{verbose} );
   my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $gff,
                                                                    config => $config
                                                                  });
-  dual_print( $log, "GFF3 file parsed\n", $config->{verbose} );
+  dual_print( $log, "GFF3 file parsed\n");
 
 # Create an empty omniscient hash to store the discarded features and copy the config in
 my %hash_omniscient_discarded;
@@ -87,7 +87,7 @@ foreach my $primary_tag_l1 (keys %{$hash_omniscient->{'level1'}}){ # primary_tag
   foreach my $gene_id_l1 (keys %{$hash_omniscient->{'level1'}{$primary_tag_l1}}){
     
     my $gene_feature=$hash_omniscient->{'level1'}{$primary_tag_l1}{$gene_id_l1};
-      dual_print( $log, "Study gene $gene_id_l1\n", $config->{verbose} );
+      dual_print( $log, "Study gene $gene_id_l1\n");
 		my $no_l2=1;# see if standalone or topfeature
 
     foreach my $primary_tag_l2 (keys %{$hash_omniscient->{'level2'}}){ # primary_tag_key_level2 = mrna or mirna or ncrna or trna etc...
@@ -133,7 +133,7 @@ foreach my $primary_tag_l1 (keys %{$hash_omniscient->{'level1'}}){ # primary_tag
         if( $there_is_cds ){
           # All transcript discarded
           if( @l2_to_keep == 0){
-            dual_print( $log, "Case all L2 discarded \n", $config->{verbose} );
+            dual_print( $log, "Case all L2 discarded \n");
             $number_gene_discarded++;
             $number_gene_affected++;
             # move L3
@@ -151,7 +151,7 @@ foreach my $primary_tag_l1 (keys %{$hash_omniscient->{'level1'}}){ # primary_tag
           }
           # Only part of the isoforms have been discarded
           elsif ( @l2_to_discard > 0){
-            dual_print( $log, "Case some L2 discarded \n", $config->{verbose} );
+            dual_print( $log, "Case some L2 discarded \n");
             $number_gene_affected++;
             # handle L3
             
@@ -183,12 +183,12 @@ foreach my $primary_tag_l1 (keys %{$hash_omniscient->{'level1'}}){ # primary_tag
         }
         # ---------- CASE there is no CDS -----------
         else{
-          dual_print( $log, "No cds for $gene_id_l1\n", $config->{verbose} );
+          dual_print( $log, "No cds for $gene_id_l1\n");
         }
       }
       # ---------- CASE NO L2 -----------
       if($no_l2){ # case of l1 feature without child
-        dual_print( $log, "No child for $gene_id_l1\n", $config->{verbose} );
+        dual_print( $log, "No child for $gene_id_l1\n");
       }
     }
   }
@@ -198,14 +198,14 @@ foreach my $primary_tag_l1 (keys %{$hash_omniscient->{'level1'}}){ # primary_tag
 print_omniscient( {omniscient => $hash_omniscient, output => $gffout_pass} );
 print_omniscient( {omniscient => \%hash_omniscient_discarded, output => $gffout_notpass} );
 
-dual_print( $log, "\n$number_gene_affected genes have at least one transcript removed.\n", $config->{verbose} );
-dual_print( $log, "$number_gene_discarded genes discarded\n", $config->{verbose} );
-dual_print( $log, "$number_mRNA_discarded transcripts discarded.\n", $config->{verbose} );
+dual_print( $log, "\n$number_gene_affected genes have at least one transcript removed.\n");
+dual_print( $log, "$number_gene_discarded genes discarded\n");
+dual_print( $log, "$number_mRNA_discarded transcripts discarded.\n");
 
 # END
 my $end_run = time();
 my $run_time = $end_run - $start_run;
-dual_print( $log, "Job done in $run_time seconds\n", $config->{verbose} );
+dual_print( $log, "Job done in $run_time seconds\n");
 #######################################################################################################################
         ####################
          #     METHODS    #

--- a/bin/agat_sp_filter_by_locus_distance.pl
+++ b/bin/agat_sp_filter_by_locus_distance.pl
@@ -42,7 +42,7 @@ my $gffout = prepare_gffout($config, $outfile);
 my ($omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $gff,
                                                             config => $config
                                                               });
-dual_print( $log, "GFF3 file parsed\n", $config->{verbose} );
+dual_print( $log, "GFF3 file parsed\n");
 
 #counters
 my $geneCounter_skip=0;
@@ -93,7 +93,7 @@ foreach my $locusID ( sort keys %{$sortBySeq}){ # tag_l1 = gene or repeat etc...
           my $location2 = @{$sortBySeq->{$locusID}{$tag_l1}}[0];
           my $id2_l1 = $location2->[0];
           my $dist = $location2->[1] - $location->[2] + 1;
-          dual_print( $log, "distance $id_l1 - id2_l1 = $dist\n", $config->{verbose} );
+          dual_print( $log, "distance $id_l1 - id2_l1 = $dist\n");
 
           ############################
           #deal with overlap
@@ -193,8 +193,8 @@ my $string_to_print="usage: $0 @copyARGV\n".
   "Total number investigated: $total\n".
   "Number of skipped loci: $geneCounter_skip\n".
   "Number of loci with distance to the surrounding loci over $opt_dist: $geneCounter_ok \n";
-dual_print( $log, $string_to_print, $config->{verbose} );
-dual_print( $log, "Bye Bye.\n", $config->{verbose} );
+dual_print( $log, $string_to_print);
+dual_print( $log, "Bye Bye.\n");
 #######################################################################################################################
         ####################
          #     METHODS    #
@@ -213,12 +213,12 @@ sub add_info{
 
   if($feature->has_tag('low_dist')){
     $feature->add_tag_value('low_dist', $value);
-    dual_print( $log, $feature->_tag_value('ID')." add $value\n", $config->{verbose} );
+    dual_print( $log, $feature->_tag_value('ID')." add $value\n");
   }
   else{
     create_or_replace_tag($feature, 'low_dist', $value);
     $geneCounter_skip++;
-    dual_print( $log, $feature->_tag_value('ID')." create $value\n", $config->{verbose} );
+    dual_print( $log, $feature->_tag_value('ID')." create $value\n");
   }
 
 }

--- a/bin/agat_sp_filter_by_mrnaBlastValue.pl
+++ b/bin/agat_sp_filter_by_mrnaBlastValue.pl
@@ -36,11 +36,11 @@ my $out = prepare_gffout($config, $outfile);
 my $killlist = parse_blast($blast);
 
 ### Parse GFF input #
-dual_print($log, "Parse file $gff\n", $opt_verbose);
+dual_print($log, "Parse file $gff\n");
 my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $gff,
                                                                  config => $config
                                                               });
-dual_print($log, "$gff file parsed\n", $opt_verbose);
+dual_print($log, "$gff file parsed\n");
 
 # Remove all mRNA specified by the kill-list from their (gene-) parents.
 remove_omniscient_elements_from_level2_ID_list ($hash_omniscient, $killlist);
@@ -147,7 +147,7 @@ sub parse_blast
 
     #print "We will removed $cptCount more.\n";
     my $nbremove = @answer;
-    dual_print($log, "$nbremove gene will be removed !\n", $opt_verbose);
+    dual_print($log, "$nbremove gene will be removed !\n");
 
 close $log if $log;
 

--- a/bin/agat_sp_filter_feature_by_attribute_presence.pl
+++ b/bin/agat_sp_filter_feature_by_attribute_presence.pl
@@ -85,10 +85,10 @@ if ($opt_attribute){
 
   foreach my $attribute (@attList){
       push @attListOk, $attribute;
-      dual_print($log, "$attribute attribute will be processed.\n", $opt_verbose);
+      dual_print($log, "$attribute attribute will be processed.\n");
 
   }
-  dual_print($log, "\n", $opt_verbose);
+  dual_print($log, "\n");
 }
 
 # start with some interesting information
@@ -96,7 +96,7 @@ my $stringPrint = strftime "%m/%d/%Y at %Hh%Mm%Ss", localtime;
 $stringPrint .= "\nusage: $0 @copyARGV\n";
 $stringPrint .= "We will discard $print_feature_string that have the attribute $opt_attribute.\n";
 
-dual_print($log, $stringPrint, $opt_verbose);
+dual_print($log, $stringPrint);
 print $ostreamReport $stringPrint if $ostreamReport;
 
 													#######################
@@ -109,7 +109,7 @@ my %all_cases = ('l1' => 0, 'l2' => 0, 'l3' => 0, 'all' => 0);
 my ($hash_omniscient, $hash_mRNAGeneLink) =  slurp_gff3_file_JD({ input => $opt_gff,
                                                                   config => $config
                                                                 });
-dual_print($log, "Parsing Finished\n", $opt_verbose);
+dual_print($log, "Parsing Finished\n");
 ### END Parse GFF input #
 #########################
 # sort by seq id
@@ -201,7 +201,7 @@ $stringPrint = $all_cases{'all'}." features removed:\n";
 $stringPrint .= $all_cases{'l1'}." features level1 (e.g. gene) removed\n";
 $stringPrint .= $all_cases{'l2'}." features level2 (e.g. mRNA) removed\n";
 $stringPrint .= $all_cases{'l3'}." features level3 (e.g. exon) removed\n";
-dual_print($log, $stringPrint, $opt_verbose);
+dual_print($log, $stringPrint);
 print $ostreamReport $stringPrint if $ostreamReport;
 
 close $log if $log;

--- a/bin/agat_sp_filter_feature_by_attribute_value.pl
+++ b/bin/agat_sp_filter_feature_by_attribute_value.pl
@@ -121,7 +121,7 @@ if ($opt_value_insensitive){
    $stringPrint .= " case sensitive.\n";
 }
 
-dual_print( $log, $stringPrint, $config->{verbose} );
+dual_print( $log, $stringPrint);
 print $ostreamReport $stringPrint if $ostreamReport;
                           #######################
 # >>>>>>>>>>>>>>>>>>>>>>>>#        MAIN         #<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
@@ -134,7 +134,7 @@ my %all_cases = ( 'left' => {'l1' => 0, 'l2' => 0, 'l3' => 0, 'all' => 0},
 my ($hash_omniscient, $hash_mRNAGeneLink) =  slurp_gff3_file_JD({ input => $opt_gff,
                                                                   config => $config
                                                                 });
-dual_print( $log, "Parsing Finished\n", $config->{verbose} );
+dual_print( $log, "Parsing Finished\n");
 ### END Parse GFF input #
 #########################
 # sort by seq id
@@ -251,7 +251,7 @@ if($opt_na_aside){
   $stringPrint .= $all_cases{'na'}{'l3'}." features level3 (e.g. exon) removed\n";
 }
 
-dual_print( $log, $stringPrint, $config->{verbose} );
+dual_print( $log, $stringPrint);
 print $ostreamReport $stringPrint if $ostreamReport;
 
 close $log if $log;
@@ -309,18 +309,18 @@ sub should_we_remove_feature{
         }
         # for string values replace = by eq and ! by ne and avoid other type of test
         if ( ! looks_like_number ($given_value) or ! looks_like_number ($file_value)){
-          dual_print( $log, "String case\n", $config->{verbose} );
+          dual_print( $log, "String case\n");
           if ($opt_test eq "="){ 
-            if ($file_value eq $given_value) { dual_print( $log, "equal\n", $config->{verbose} ); return 1; }
-            else { dual_print( $log, "not equal\n", $config->{verbose} ); }
+            if ($file_value eq $given_value) { dual_print( $log, "equal\n"); return 1; }
+            else { dual_print( $log, "not equal\n"); }
           }
           elsif ($opt_test eq "!"){
-            if ($file_value ne $given_value){ dual_print( $log, "different\n", $config->{verbose} ); return 1; }
-            else { dual_print( $log, "not different\n", $config->{verbose} ); }
+            if ($file_value ne $given_value){ dual_print( $log, "different\n"); return 1; }
+            else { dual_print( $log, "not different\n"); }
           }
         }
         else{
-          dual_print( $log, "Number case\n", $config->{verbose} );
+          dual_print( $log, "Number case\n");
           if ($opt_test eq "="){
             if ($file_value == $given_value){return 1; }
           }
@@ -344,7 +344,7 @@ sub should_we_remove_feature{
     }
     return 0;
   } else {
-    dual_print( $log, "Attribute not found  case\n", $config->{verbose} );
+    dual_print( $log, "Attribute not found  case\n");
     return 2;
   }
 }

--- a/bin/agat_sp_filter_feature_from_keep_list.pl
+++ b/bin/agat_sp_filter_feature_from_keep_list.pl
@@ -90,7 +90,7 @@ $stringPrint .= "The keep list contains $nb_to_keep uniq IDs\n";
 if ($opt_output){
   print $ostreamReport $stringPrint;
 }
-dual_print( $log, $stringPrint, $opt_verbose );
+dual_print( $log, $stringPrint);
 
                           #######################
 # >>>>>>>>>>>>>>>>>>>>>>>>#        MAIN         #<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
@@ -101,7 +101,7 @@ my %all_cases = ('l1' => 0, 'l2' => 0, 'l3' => 0, 'all' => 0);
 my ($hash_omniscient, $hash_mRNAGeneLink) =  slurp_gff3_file_JD({ input => $opt_gff,
                                                                   config => $config
                                                                 });
-dual_print( $log, "Parsing Finished\n", $opt_verbose );
+dual_print( $log, "Parsing Finished\n");
 ### END Parse GFF input #
 #########################
 # sort by seq id
@@ -176,7 +176,7 @@ $stringPrint = ($#keeplist+1)." records kept!\n";
 if ($opt_output){
   print $ostreamReport $stringPrint;
 }
-dual_print( $log, $stringPrint, $opt_verbose );
+dual_print( $log, $stringPrint);
 
 
 #######################################################################################################################

--- a/bin/agat_sp_filter_feature_from_kill_list.pl
+++ b/bin/agat_sp_filter_feature_from_kill_list.pl
@@ -90,7 +90,7 @@ $stringPrint .= "\nusage: $0 @copyARGV\n";
 $stringPrint .= "We will discard $print_feature_string that share the value of the $opt_attribute attribute with the kill list.\n";
 $stringPrint .= "The kill list contains $nb_to_kill uniq IDs\n";
 
-dual_print($log, $stringPrint, $opt_verbose);
+dual_print($log, $stringPrint);
 print $ostreamReport $stringPrint if $ostreamReport;
                           #######################
 # >>>>>>>>>>>>>>>>>>>>>>>>#        MAIN         #<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
@@ -101,7 +101,7 @@ my %all_cases = ('l1' => 0, 'l2' => 0, 'l3' => 0, 'all' => 0);
 my ($hash_omniscient, $hash_mRNAGeneLink) =  slurp_gff3_file_JD({ input => $opt_gff,
                                                                   config => $config
                                                                 });
-dual_print($log, "Parsing Finished\n", $opt_verbose);
+dual_print($log, "Parsing Finished\n");
 ### END Parse GFF input #
 #########################
 # sort by seq id
@@ -193,7 +193,7 @@ $stringPrint = $all_cases{'all'}." features removed:\n";
 $stringPrint .= $all_cases{'l1'}." features level1 (e.g. gene) removed\n";
 $stringPrint .= $all_cases{'l2'}." features level2 (e.g. mRNA) removed\n";
 $stringPrint .= $all_cases{'l3'}." features level3 (e.g. exon) removed\n";
-dual_print($log, $stringPrint, $opt_verbose);
+dual_print($log, $stringPrint);
 print $ostreamReport $stringPrint if $ostreamReport;
 
 close $log if $log;

--- a/bin/agat_sp_filter_gene_by_intron_numbers.pl
+++ b/bin/agat_sp_filter_gene_by_intron_numbers.pl
@@ -69,7 +69,7 @@ my $stringPrint = strftime "%m/%d/%Y at %Hh%Mm%Ss", localtime;
 $stringPrint .= "\nusage: $0 @copyARGV\n";
 $stringPrint .= "We will select genes that contain $opt_test $opt_nb introns.\n";
 
-dual_print($log, $stringPrint, $opt_verbose);
+dual_print($log, $stringPrint);
 print $ostreamReport $stringPrint if $ostreamReport;
                           #######################
 # >>>>>>>>>>>>>>>>>>>>>>>>#        MAIN         #<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
@@ -80,7 +80,7 @@ print $ostreamReport $stringPrint if $ostreamReport;
 my ($hash_omniscient, $hash_mRNAGeneLink) =  slurp_gff3_file_JD({ input => $opt_gff,
                                                                   config => $config
                                                                 });
-dual_print($log, "Parsing Finished\n", $opt_verbose);
+dual_print($log, "Parsing Finished\n");
 ### END Parse GFF input #
 #########################
 # sort by seq id
@@ -151,7 +151,7 @@ my $test_fail = scalar @list2;
 
 $stringPrint = "$test_success genes selected with at least one RNA with $opt_test $opt_nb intron(s).\n";
 $stringPrint .= "$test_fail remaining genes that not pass the test.\n";
-dual_print($log, $stringPrint, $opt_verbose);
+dual_print($log, $stringPrint);
 print $ostreamReport $stringPrint if $ostreamReport;
 
 close $log if $log;

--- a/bin/agat_sp_filter_gene_by_length.pl
+++ b/bin/agat_sp_filter_gene_by_length.pl
@@ -75,7 +75,7 @@ $stringPrint .= "We will select l1 feature (e.g. gene) that have length $opt_tes
 if ($opt_output) {
   print $ostreamReport $stringPrint;
 }
-dual_print( $log, $stringPrint, $opt_verbose );
+dual_print( $log, $stringPrint);
                           #######################
 # >>>>>>>>>>>>>>>>>>>>>>>>#        MAIN         #<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                           #######################
@@ -85,7 +85,7 @@ dual_print( $log, $stringPrint, $opt_verbose );
 my ( $hash_omniscient, $hash_mRNAGeneLink ) = slurp_gff3_file_JD({ input => $opt_gff,
                                                                   config => $config
                                                                 });
-dual_print( $log, "Parsing Finished\n", $opt_verbose );
+dual_print( $log, "Parsing Finished\n");
 ### END Parse GFF input #
 #########################
 # sort by seq id
@@ -133,26 +133,26 @@ foreach my $seqid (sort { (($a =~ /(\d+)$/)[0] || 0) <=> (($b =~ /(\d+)$/)[0] ||
 	    }
       # case we had exon (we look at the longest mRNA)
       if($longer_concat_exon){
-        dual_print( $log, "$id_l1 does have exon(s). Longest concatenated exons: $longer_concat_exon\n", $opt_verbose );
+        dual_print( $log, "$id_l1 does have exon(s). Longest concatenated exons: $longer_concat_exon\n");
         if( test_size( $longer_concat_exon, $opt_test, $opt_size ) ){
-          dual_print( $log, "$id_l1 pass the test\n", $opt_verbose );
+          dual_print( $log, "$id_l1 pass the test\n");
           push @listok, $id_l1;
         }
         else{
-          dual_print( $log, "$id_l1 do not pass the test\n", $opt_verbose );
+          dual_print( $log, "$id_l1 do not pass the test\n");
           push @listNotOk, $id_l1;
         }
       }
       else{
-        dual_print( $log, "$id_l1 does not have any exon. $tag_l1 size: $gene_length\n", $opt_verbose );
+        dual_print( $log, "$id_l1 does not have any exon. $tag_l1 size: $gene_length\n");
         # No exon, L1 pass test
         if($successl1){
-          dual_print( $log, "$id_l1 pass the test\n", $opt_verbose );
+          dual_print( $log, "$id_l1 pass the test\n");
           push @listok, $id_l1;
         }
         # No exon, L1 do not pass test
         else{
-          dual_print( $log, "$id_l1 do not pass the test\n", $opt_verbose );
+          dual_print( $log, "$id_l1 do not pass the test\n");
           push @listNotOk, $id_l1;
         }
       }
@@ -179,7 +179,7 @@ $stringPrint .= "$test_fail remaining l1 feature (e.g. gene) do not pass the tes
 if ($opt_output) {
   print $ostreamReport $stringPrint;
 }
-dual_print( $log, $stringPrint, $opt_verbose );
+dual_print( $log, $stringPrint);
 
 #######################################################################################################################
         ####################

--- a/bin/agat_sp_filter_incomplete_gene_coding_models.pl
+++ b/bin/agat_sp_filter_incomplete_gene_coding_models.pl
@@ -42,7 +42,7 @@ if ( my $log_name = $config->{log_path} ) {
 }
 
 # --- Check codon table ---
-$codonTableId = get_proper_codon_table($codonTableId, $log, $opt_verbose);
+$codonTableId = get_proper_codon_table($codonTableId, $log);
 
 my $codonTable = Bio::Tools::CodonTable->new( -id => $codonTableId);
 
@@ -69,7 +69,7 @@ my $gffout_incomplete = prepare_gffout($config, $gffout_incomplete_file);
 my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $gff,
                                                                  config => $config
                                                               });
-dual_print( $log, "GFF3 file parsed\n", $opt_verbose );
+dual_print( $log, "GFF3 file parsed\n");
 
 
 ####################
@@ -79,7 +79,7 @@ my $db = Bio::DB::Fasta->new($file_fasta);
 my @ids      = $db->get_all_primary_ids;
 my %allIDs; # save ID in lower case to avoid cast problems
 foreach my $id (@ids ){$allIDs{lc($id)}=$id;}
-dual_print( $log, "Fasta file parsed\n", $opt_verbose );
+dual_print( $log, "Fasta file parsed\n");
 ####################
 
 #counters
@@ -93,7 +93,7 @@ foreach my $primary_tag_key_level1 (keys %{$hash_omniscient->{'level1'}}){ # pri
   foreach my $gene_id (keys %{$hash_omniscient->{'level1'}{$primary_tag_key_level1}}){
     my $gene_feature = $hash_omniscient->{'level1'}{$primary_tag_key_level1}{$gene_id};
     my $strand = $gene_feature->strand();
-    dual_print( $log, "gene_id = $gene_id\n", $opt_verbose );
+    dual_print( $log, "gene_id = $gene_id\n");
 
     my @level1_list=();
     my @level2_list=();
@@ -123,7 +123,7 @@ foreach my $primary_tag_key_level1 (keys %{$hash_omniscient->{'level1'}}){ # pri
               if (! $skip_start_check){
                 my $start_codon = $seqobj->subseq(1,3);
                 if(! $codonTable->is_start_codon( $start_codon )){
-                  dual_print( $log, "start= $start_codon  is not a valid start codon\n", $opt_verbose );
+                  dual_print( $log, "start= $start_codon  is not a valid start codon\n");
                   $start_missing="true";
                   if($add_flag){
                     create_or_replace_tag($level2_feature, 'incomplete', '1');
@@ -136,7 +136,7 @@ foreach my $primary_tag_key_level1 (keys %{$hash_omniscient->{'level1'}}){ # pri
                 my $stop_codon = $seqobj->subseq($seqlength - 2, $seqlength) ;
 
                 if(! $codonTable->is_ter_codon( $stop_codon )){
-                  dual_print( $log, "stop= $stop_codon is not a valid stop codon\n", $opt_verbose );
+                  dual_print( $log, "stop= $stop_codon is not a valid stop codon\n");
                   $stop_missing="true";
                   if($add_flag){
                     if($start_missing){
@@ -150,11 +150,11 @@ foreach my $primary_tag_key_level1 (keys %{$hash_omniscient->{'level1'}}){ # pri
               }
             }
             else{ #short CDS
-              dual_print( $log, "CDS too short ($length_CDS nt) we skip it\n", $opt_verbose );
+              dual_print( $log, "CDS too short ($length_CDS nt) we skip it\n");
             }
           }
           else{ #No CDS
-            dual_print( $log, "Not a coding rna (no CDS) we skip it\n", $opt_verbose );
+            dual_print( $log, "Not a coding rna (no CDS) we skip it\n");
           }
 
           if($start_missing or $stop_missing){
@@ -193,7 +193,7 @@ foreach my $primary_tag_key_level1 (keys %{$hash_omniscient->{'level1'}}){ # pri
     }
     #after checking all mRNA of a gene
     if($ncGene){
-      dual_print( $log, "This is a non coding gene (no cds to any of its RNAs)", $opt_verbose );
+      dual_print( $log, "This is a non coding gene (no cds to any of its RNAs)");
     }
   }
 }
@@ -213,7 +213,7 @@ if ($geneCounter) {
 else{
   $string_to_print .="No gene with incomplete mRNA!\n";
 }
-dual_print( $log, $string_to_print, $opt_verbose );
+dual_print( $log, $string_to_print);
 
 if(! $add_flag){
   #clean for printing
@@ -227,15 +227,15 @@ if(! $add_flag){
   }
 }
 
-dual_print( $log, "Now printing complete models\n", $opt_verbose );
+dual_print( $log, "Now printing complete models\n");
 print_omniscient( {omniscient => $hash_omniscient, output => $gffout} );
 
 if(@incomplete_mRNA){
-  dual_print( $log, "Now printing incomplete models\n", $opt_verbose );
+  dual_print( $log, "Now printing incomplete models\n");
   print_omniscient( {omniscient => \%omniscient_incomplete, output => $gffout_incomplete} );
 }
 
-dual_print( $log, "Bye Bye.\n", $opt_verbose );
+dual_print( $log, "Bye Bye.\n");
 #######################################################################################################################
         ####################
          #     METHODS    #

--- a/bin/agat_sp_filter_record_by_coordinates.pl
+++ b/bin/agat_sp_filter_record_by_coordinates.pl
@@ -35,12 +35,12 @@ if ( my $log_name = $config->{log_path} ) {
 # Manage Output
 
 if (! $opt_output) {
-  dual_print( $log, "Default output name: filter_record_by_coordinates\n", $opt_verbose );
+  dual_print( $log, "Default output name: filter_record_by_coordinates\n");
   $opt_output="filter_record_by_coordinates";
 }
 
 if (-d $opt_output){
-  dual_print( $log, "The output directory choosen already exists. Please give me another Name.\n", $opt_verbose );
+  dual_print( $log, "The output directory choosen already exists. Please give me another Name.\n");
   exit();
 }
 mkdir $opt_output;
@@ -77,7 +77,7 @@ while (my $line = <$in_range>) {
       $nb_ranges++;
     }
     else{
-      dual_print( $log, "skip line $cpt_line (At least 3 values expected, only $size_array available): $line\n", $opt_verbose );
+      dual_print( $log, "skip line $cpt_line (At least 3 values expected, only $size_array available): $line\n");
     }
 }
 
@@ -86,7 +86,7 @@ my $stringPrint = strftime "%m/%d/%Y at %Hh%Mm%Ss", localtime;
 $stringPrint .= "\nusage: $0 @copyARGV\n";
 $stringPrint .= "We will get features that are within the $nb_ranges selected ranges.\n";
 
-dual_print( $log, $stringPrint, $opt_verbose );
+dual_print( $log, $stringPrint);
 print $ostreamReport $stringPrint if $ostreamReport;
 
 # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>     MAIN     <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
@@ -96,7 +96,7 @@ print $ostreamReport $stringPrint if $ostreamReport;
 my ($hash_omniscient, $hash_mRNAGeneLink) =  slurp_gff3_file_JD({ input => $opt_gff,
                                                                   config => $config
                                                                 });
-dual_print($log, "Parsing Finished\n", $opt_verbose);
+dual_print($log, "Parsing Finished\n");
 ### END Parse GFF input #
 #########################
 
@@ -158,7 +158,7 @@ $stringPrint .= "$test_fail record(s) out of the range(s).\n";
 if ($ostreamReport){
   print $ostreamReport $stringPrint;
 }
-dual_print( $log, $stringPrint, $opt_verbose );
+dual_print( $log, $stringPrint);
 
 #######################################################################################################################
         ####################
@@ -182,14 +182,14 @@ sub test_overlap_with_ranges{
     foreach my $range ( @{$range_hash{lc($feature_l1->seq_id)}} ){
       if(! $opt_exclude_ov){
         if(_overlap($range, [$start,$end])){
-          dual_print( $log, "feature [".$feature_l1->primary_tag." $start,$end] is included or overlap the range [@$range]\n", $opt_verbose );
+          dual_print( $log, "feature [".$feature_l1->primary_tag." $start,$end] is included or overlap the range [@$range]\n");
           my $range_string = $feature_l1->seq_id."_".$range->[0]."_".$range->[1];
           push @list_ranges, $range_string;
         }
       }
       else{
         if(_include($range, [$start,$end])){
-          dual_print( $log, "feature [".$feature_l1->primary_tag." $start,$end] is included in the range [@$range]\n", $opt_verbose );
+          dual_print( $log, "feature [".$feature_l1->primary_tag." $start,$end] is included in the range [@$range]\n");
           my $range_string = $feature_l1->seq_id."_".$range->[0]."_".$range->[1];
           push @list_ranges, $range_string;
         }

--- a/bin/agat_sp_fix_cds_phases.pl
+++ b/bin/agat_sp_fix_cds_phases.pl
@@ -36,12 +36,12 @@ my $gffout = prepare_gffout($config, $opt_output);
 my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $opt_gfffile,
                                                                  config => $config
                                                             });
-dual_print($log, "GFF3 file parsed\n", $opt_verbose);
+dual_print($log, "GFF3 file parsed\n");
 
 ####################
 # index the genome #
 my $db = Bio::DB::Fasta->new($opt_fasta);
-dual_print($log, "Fasta file parsed\n", $opt_verbose);
+dual_print($log, "Fasta file parsed\n");
 
 ###
 # Fix frame
@@ -53,7 +53,7 @@ print_omniscient( {omniscient => $hash_omniscient, output => $gffout} );
 
 my $end_run  = time();
 my $run_time = $end_run - $start_run;
-dual_print( $log, "Job done in $run_time seconds\n", $opt_verbose );
+dual_print( $log, "Job done in $run_time seconds\n");
 
 close $log if $log;
 __END__

--- a/bin/agat_sp_fix_features_locations_duplicated.pl
+++ b/bin/agat_sp_fix_features_locations_duplicated.pl
@@ -69,18 +69,18 @@ if(!($model_to_test)){
 my $string1 = strftime "%m/%d/%Y at %Hh%Mm%Ss", localtime;
 $string1 .= "\n\nusage: $0 @copyARGV\n\n";
 print $reportout $string1;
-dual_print( $log, $string1, $verbose );
+dual_print( $log, $string1);
 
 # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>     MAIN     <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
 my $nb_gene_removed=0;
 
 ### Parse GFF input #
-dual_print( $log, "Parse file $ref\n", $verbose );
+dual_print( $log, "Parse file $ref\n");
 my ($omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $ref,
                                                             config => $config
                                                               });
-dual_print( $log, "$ref file parsed\n", $verbose );
+dual_print( $log, "$ref file parsed\n");
 
 # sort by seq id
 my $hash_sortBySeq = gather_and_sort_l1_location_by_seq_id_and_strand($omniscient);
@@ -105,7 +105,7 @@ foreach my $seqid (sort keys %{$hash_sortBySeq}){ # loop over all the feature le
 
         #################################################
         # START Take care of isoforms with duplicated location:
-        dual_print( $log, "START Take care of isoforms with duplicated locations\n", $verbose );
+        dual_print( $log, "START Take care of isoforms with duplicated locations\n");
         my @L2_list_to_remove = ();
         foreach my $l2_type ( sort keys %{$omniscient->{'level2'}}){ # primary_tag_key_level2 = mrna or mirna or ncrna or trna etc...
 
@@ -134,25 +134,25 @@ foreach my $seqid (sort keys %{$hash_sortBySeq}){ # loop over all the feature le
 
                           #Check their subfeature are  identicals
                           if(featuresList_identik(\@{$omniscient->{'level3'}{'exon'}{$id_l2_1}}, \@{$omniscient->{'level3'}{'exon'}{$id_l2_2}}, $verbose )){
-                            dual_print( $log, "case1: $id_l2_2 and $id_l2_1 have same exon list\n", $verbose );
+                            dual_print( $log, "case1: $id_l2_2 and $id_l2_1 have same exon list\n");
 
                             my $size_cds1 =  cds_size($omniscient, $id_l2_1);
                             my $size_cds2 =  cds_size($omniscient, $id_l2_2);
                             if($size_cds1 >= $size_cds2 ){
                               push(@L2_list_to_remove, $id_l2_2);
-                              dual_print( $log, "case1: push1\n", $verbose );
+                              dual_print( $log, "case1: push1\n");
                             }
                             elsif($size_cds1 < $size_cds2){
                               push(@L2_list_to_remove, $id_l2_1);
-                              dual_print( $log, "case1: push2\n", $verbose );
+                              dual_print( $log, "case1: push2\n");
                             }
                             elsif($size_cds1){
                               push(@L2_list_to_remove, $id_l2_2);
-                              dual_print( $log, "case1: push3\n", $verbose );
+                              dual_print( $log, "case1: push3\n");
                             }
                             else{
                               push(@L2_list_to_remove, $id_l2_1);
-                              dual_print( $log, "case1: push4\n", $verbose );
+                              dual_print( $log, "case1: push4\n");
                             }
                           }
                         }
@@ -169,7 +169,7 @@ foreach my $seqid (sort keys %{$hash_sortBySeq}){ # loop over all the feature le
           if (exists($ListModel{1})){
             my @L2_list_to_remove_filtered = uniq(@L2_list_to_remove);
             $ListModel{1} += scalar @L2_list_to_remove_filtered;
-            dual_print( $log, "case1 (removing mRNA isoform identic ): ".join(",", @L2_list_to_remove_filtered)."\n", $verbose );
+            dual_print( $log, "case1 (removing mRNA isoform identic ): ".join(",", @L2_list_to_remove_filtered)."\n");
             remove_omniscient_elements_from_level2_ID_list($omniscient, \@L2_list_to_remove_filtered);
           }
         }
@@ -181,7 +181,7 @@ foreach my $seqid (sort keys %{$hash_sortBySeq}){ # loop over all the feature le
         #######################################################
         # START Take care of other gene with duplicated location
         #
-        dual_print( $log, "START Take care of gene with duplicated locations\n", $verbose );
+        dual_print( $log, "START Take care of gene with duplicated locations\n");
         #foreach my $gene_feature_id2 (@sorted_genefeature_ids){
         foreach my $location2 (sort {$a->[1].$a->[0] cmp $b->[1].$b->[0]}  @{$hash_sortBySeq->{$seqid}{$tag}}){
           my $gene_feature_id2 = lc($location2->[0]);
@@ -199,7 +199,7 @@ foreach my $seqid (sort keys %{$hash_sortBySeq}){ # loop over all the feature le
             #The two genes overlap
             if( ($gene_feature2->start <= $gene_feature->end() ) and ($gene_feature2->end >= $gene_feature->start) ){
 
-              dual_print( $log, "$gene_feature_id and $gene_feature_id2 overlap\n", $verbose );
+              dual_print( $log, "$gene_feature_id and $gene_feature_id2 overlap\n");
 
               # Loop over the L2 from the first gene feature
               foreach my $l2_type ( sort keys %{$omniscient->{'level2'}}){ # primary_tag_key_level2 = mrna or mirna or ncrna or trna etc...
@@ -218,7 +218,7 @@ foreach my $seqid (sort keys %{$hash_sortBySeq}){ # loop over all the feature le
                         #check their position are identical
                         if($l2_2->start().$l2_2->end() eq $l2_1->start().$l2_1->end()){
 
-                          dual_print( $log, "$id_l2_2  and $id_l2_1 have same start and stop\n", $verbose );
+                          dual_print( $log, "$id_l2_2  and $id_l2_1 have same start and stop\n");
 
                           if(exists_keys($omniscient,('level3', 'exon', $id_l2_1))){
                             if(exists_keys($omniscient,('level3', 'exon', $id_l2_2))){
@@ -226,16 +226,16 @@ foreach my $seqid (sort keys %{$hash_sortBySeq}){ # loop over all the feature le
                               my $resu_overlap = check_feature_overlap_from_l3_to_l1($omniscient, $omniscient , $gene_feature_id, $gene_feature_id2);
                               if ($resu_overlap){
 
-                                dual_print( $log, "$id_l2_2  and $id_l2_1 overlap at $resu_overlap\n", $verbose );
+                                dual_print( $log, "$id_l2_2  and $id_l2_1 overlap at $resu_overlap\n");
 
                                 #EXON identicals
                                 if(featuresList_identik(\@{$omniscient->{'level3'}{'exon'}{$id_l2_1}}, \@{$omniscient->{'level3'}{'exon'}{$id_l2_2}}, $verbose )){
 
-                                  dual_print( $log, "$id_l2_2 and $id_l2_1 have same exon list\n", $verbose );
+                                  dual_print( $log, "$id_l2_2 and $id_l2_1 have same exon list\n");
                                   # NO CDS
                                   if ( ! exists_keys($omniscient, ('level3','cds',$id_l2_1)) and  ! exists_keys($omniscient, ('level3','cds',$id_l2_2) ) ) {
                                     if (exists($ListModel{2})){
-                                       dual_print( $log, "case2: $id_l2_2 and $id_l2_1 have no CDS\n", $verbose );
+                                       dual_print( $log, "case2: $id_l2_2 and $id_l2_1 have no CDS\n");
                                        $ListModel{2}++;
                                        push(@L2_list_to_remove, $id_l2_2);
                                     }
@@ -243,7 +243,7 @@ foreach my $seqid (sort keys %{$hash_sortBySeq}){ # loop over all the feature le
                                   else{ # WITH CDS
                                     if(featuresList_identik(\@{$omniscient->{'level3'}{'cds'}{$id_l2_1}}, \@{$omniscient->{'level3'}{'cds'}{$id_l2_2}}, $verbose ) ){
                                       if ( exists($ListModel{3}) ){
-                                        dual_print( $log, "case3: $id_l2_2 and $id_l2_1 have same CDS list\n", $verbose );
+                                        dual_print( $log, "case3: $id_l2_2 and $id_l2_1 have same CDS list\n");
                                         $ListModel{3}++;
                                         #identik because no CDS, we could remove one randomly
 
@@ -251,19 +251,19 @@ foreach my $seqid (sort keys %{$hash_sortBySeq}){ # loop over all the feature le
                                         my $size_cds2 =  cds_size($omniscient, $id_l2_2);
                                         if($size_cds1 >= $size_cds2 ){
                                           push(@L2_list_to_remove, $id_l2_2);
-                                          dual_print( $log, "case3: push1 $size_cds1 $size_cds2\n", $verbose );
+                                          dual_print( $log, "case3: push1 $size_cds1 $size_cds2\n");
                                         }
                                         elsif($size_cds1 < $size_cds2){
                                           push(@L2_list_to_remove, $id_l2_1);
-                                          dual_print( $log, "case3: push2\n", $verbose );
+                                          dual_print( $log, "case3: push2\n");
                                         }
                                         elsif($size_cds1){
                                           push(@L2_list_to_remove, $id_l2_2);
-                                          dual_print( $log, "case3: push3\n", $verbose );
+                                          dual_print( $log, "case3: push3\n");
                                         }
                                         else{
                                           push(@L2_list_to_remove, $id_l2_1);
-                                          dual_print( $log, "case3: push4\n", $verbose );
+                                          dual_print( $log, "case3: push4\n");
                                         }
                                       }
                                     }
@@ -271,7 +271,7 @@ foreach my $seqid (sort keys %{$hash_sortBySeq}){ # loop over all the feature le
                                     # CDS are not identic Let's reshape UTRS
                                     elsif ( exists($ListModel{4})){
                                       $ListModel{4}++;
-                                      dual_print( $log, "case4 (Exon structure identic from different genes, but CDS different, Let's reshape the UTRs to make them different.): $id_l2_1 <=> $id_l2_2\n", $verbose );
+                                      dual_print( $log, "case4 (Exon structure identic from different genes, but CDS different, Let's reshape the UTRs to make them different.): $id_l2_1 <=> $id_l2_2\n");
                                       reshape_the_2_l2_models($omniscient, $gene_feature, $l2_1, $gene_feature2, $l2_2, $verbose, 4);
                                     }
                                   }
@@ -279,13 +279,13 @@ foreach my $seqid (sort keys %{$hash_sortBySeq}){ # loop over all the feature le
                                 # Exon structure different inside
                                 elsif ( exists($ListModel{5})) {
                                   $ListModel{5}++;
-                                  dual_print( $log, "case5 (Exons overlap but structure different (Same extremities but different internal locations) Let's reshape the UTRs to make them different.): $id_l2_1 <=> $id_l2_2\n", $verbose );
+                                  dual_print( $log, "case5 (Exons overlap but structure different (Same extremities but different internal locations) Let's reshape the UTRs to make them different.): $id_l2_1 <=> $id_l2_2\n");
                                   reshape_the_2_l2_models($omniscient, $gene_feature, $l2_1, $gene_feature2, $l2_2, $verbose, 5);
                                 }
                               }
                               # CDS and Exon does not overlap
                               else{
-                                dual_print( $log, "CDS and Exon does not overlap\n", $verbose );
+                                dual_print( $log, "CDS and Exon does not overlap\n");
 
                               }
                             }
@@ -297,7 +297,7 @@ foreach my $seqid (sort keys %{$hash_sortBySeq}){ # loop over all the feature le
                 }
               }
               if(@L2_list_to_remove){
-                dual_print( $log, "case2 (removing mRNA identic from different genes: ".join(",", @L2_list_to_remove)."\n", $verbose );
+                dual_print( $log, "case2 (removing mRNA identic from different genes: ".join(",", @L2_list_to_remove)."\n");
                 remove_omniscient_elements_from_level2_ID_list($omniscient, \@L2_list_to_remove);
                 if (! exists_keys($omniscient, ('level1',$tag,$gene_feature_id2) ) or ! exists_keys($omniscient, ('level1',$tag,$gene_feature_id) ) ){ $nb_gene_removed++;}
               }
@@ -338,7 +338,7 @@ $string_print .= "AGAT removed $nb_gene_removed genes because no more l2 were li
 print_omniscient( {omniscient => $omniscient, output => $gffout} );
 
 print $reportout $string_print;
-dual_print( $log, $string_print, $verbose );
+dual_print( $log, $string_print);
 
 #######################################################################################################################
         ####################
@@ -371,28 +371,28 @@ sub reshape_the_2_l2_models{
   my $right_UTR2 = get_extremity_feature_l3_from_l2id($omniscient, $gene_feature2, $id_l2_2, "UTR", "right");
 
   if ($left_UTR1){
-    dual_print( $log, "modify $id_l2_1 left\n", $verbose );
+    dual_print( $log, "modify $id_l2_1 left\n");
     $left_UTR1->start($left_UTR1->start+1);
     my $left_exon = get_extremity_feature_l3_from_l2id($omniscient, $gene_feature, $id_l2_1, "exon", "left");
     $left_exon->start($left_exon->start+1);
     check_record_positions($omniscient, $parent_l2_1);
   }
   elsif ($right_UTR1){
-    dual_print( $log, "modify $id_l2_1 right\n", $verbose );
+    dual_print( $log, "modify $id_l2_1 right\n");
     $right_UTR1->end($right_UTR1->end-1);
     my $right_exon = get_extremity_feature_l3_from_l2id($omniscient, $gene_feature, $id_l2_1, "exon", "right");
     $right_exon->end($right_exon->end-1);
     check_record_positions($omniscient, $parent_l2_1);
   }
   elsif ($left_UTR2){
-    dual_print( $log, "modify $id_l2_2 left\n", $verbose );
+    dual_print( $log, "modify $id_l2_2 left\n");
     $left_UTR2->start($left_UTR2->start+1);
     my $left_exon = get_extremity_feature_l3_from_l2id($omniscient, $gene_feature2, $id_l2_1, "exon", "left");
     $left_exon->start($left_exon->start-1);
     check_record_positions($omniscient, $parent_l2_2);
   }
   elsif ($right_UTR2){
-    dual_print( $log, "modify $id_l2_2 right\n", $verbose );
+    dual_print( $log, "modify $id_l2_2 right\n");
     $right_UTR2->end($right_UTR2->end-1);
     my $right_exon = get_extremity_feature_l3_from_l2id($omniscient, $gene_feature2, $id_l2_1, "exon", "right");
     $right_exon->end($right_exon->end-1);
@@ -401,7 +401,7 @@ sub reshape_the_2_l2_models{
   else{
     dual_print( $log, "$id_l2_1 and $id_l2_2 do not have UTRs, we cannot modify one to make the features different.\n" .
     "You might try EvidenceModeler to choose or modify the gene models automatically," .
-    " or you can manually modify them.\n", $verbose );
+    " or you can manually modify them.\n");
     # We might add UTR but in someway we should avoid to goes over extremities" 
     $ListModel{$case}--;
     $ListModel{"noclip"}{$case}++;

--- a/bin/agat_sp_fix_fusion.pl
+++ b/bin/agat_sp_fix_fusion.pl
@@ -65,18 +65,18 @@ my $gffout2 = prepare_gffout($config, $gffout2_file);
 my $gffout3 = prepare_gffout($config, $gffout3_file);
 my $logout = prepare_fileout($logout_file);
 
-$opt_codonTableID = get_proper_codon_table($opt_codonTableID, $log, $verbose);
+$opt_codonTableID = get_proper_codon_table($opt_codonTableID, $log);
 
 if(!$threshold){
   $threshold=100;
 }
-dual_print( $log, "Minimum protein length taken in account = $threshold AA\n", $verbose );
+dual_print( $log, "Minimum protein length taken in account = $threshold AA\n");
 
 if($stranded){
   $stranded=1;
-  dual_print( $log, "You say that annotation has been done using stranded RNA. So, most probable fusion will be between close gene in same direction. We will focuse on that !\n", $verbose );
+  dual_print( $log, "You say that annotation has been done using stranded RNA. So, most probable fusion will be between close gene in same direction. We will focuse on that !\n");
 }
-else{ dual_print( $log, "You didn't use the option stranded. We will look for fusion in all strand (+ and -)!\n", $verbose ); }
+else{ dual_print( $log, "You didn't use the option stranded. We will look for fusion in all strand (+ and -)!\n"); }
 
 # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>     MAIN     <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
@@ -85,12 +85,12 @@ else{ dual_print( $log, "You didn't use the option stranded. We will look for fu
 my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $gff,
                                                                  config => $config
                                                               });
-dual_print( $log, "GFF3 file parsed\n", $verbose );
+dual_print( $log, "GFF3 file parsed\n");
 
 ####################
 # index the genome #
 my $db = Bio::DB::Fasta->new($file_fasta);
-dual_print( $log, "Fasta file parsed\n", $verbose );
+dual_print( $log, "Fasta file parsed\n");
 
 ####################
 
@@ -121,7 +121,7 @@ foreach my $primary_tag_key_level1 ( keys %{$hash_omniscient->{'level1'}}){ # pr
     if ($progress_bar && (10 - (time - $startP)) < 0) {
         my $done = ($featureChecked*100)/$TotalFeatureL1;
         $done = sprintf ('%.0f', $done);
-        dual_print( $log, "Progress : $done %\n", $verbose );
+        dual_print( $log, "Progress : $done %\n");
         $startP= time;
     }
 
@@ -154,7 +154,7 @@ foreach my $primary_tag_key_level1 ( keys %{$hash_omniscient->{'level1'}}){ # pr
           if ( exists_keys($hash_omniscient, ('level3', 'three_prime_utr', $id_level2)) ){
 
             while($oneRoundAgain){
-              dual_print($log, "\nNew round three_prime_utr\n", $verbose);
+              dual_print($log, "\nNew round three_prime_utr\n");
               my ($breakRound, $nbNewUTRgene, $mRNAlistToTakeCare) = take_care_utr('three_prime_utr', $tmpOmniscient, $mRNAlistToTakeCare, $stranded, $gffout);
               $oneRoundAgain = $breakRound;
               $nbNewUTR3gene += $nbNewUTRgene;
@@ -167,7 +167,7 @@ foreach my $primary_tag_key_level1 ( keys %{$hash_omniscient->{'level1'}}){ # pr
           if ( exists_keys($hash_omniscient, ('level3', 'five_prime_utr', $id_level2)) ){
 
             while($oneRoundAgain){
-                dual_print($log, "\nNew round five_prime_utr\n", $verbose);
+                dual_print($log, "\nNew round five_prime_utr\n");
                 my ($breakRound, $nbNewUTRgene, $mRNAlistToTakeCare) = take_care_utr('five_prime_utr', $tmpOmniscient, $mRNAlistToTakeCare, $stranded, $gffout);
                 $oneRoundAgain = $breakRound;
                 $nbNewUTR5gene += $nbNewUTRgene;
@@ -201,7 +201,7 @@ foreach my $primary_tag_key_level1 ( keys %{$hash_omniscient->{'level1'}}){ # pr
 }
 # end progreesion bar
 if ($progress_bar) {
-  dual_print( $log, "Progress : 100 %\n", $verbose );
+  dual_print( $log, "Progress : 100 %\n");
 }
 
 ###
@@ -211,14 +211,14 @@ fil_cds_frame($hash_omniscient, $db, $log, $verbose, $opt_codonTableID);
 
 #####################################
 # Manage modified gene to be sure they not overlap already existing gene. If yes => we give the same gene ID and remove one.
-dual_print( $log, "Managing spurious labelling at gene level\n", $verbose );
+dual_print( $log, "Managing spurious labelling at gene level\n");
 # 1) create a hash omniscient intact
 my $hash_omniscient_intact={}; initialize_omni_from($hash_omniscient_intact, $hash_omniscient);
 fill_omniscient_from_other_omniscient_level1_id(\@intact_gene_list, $hash_omniscient, $hash_omniscient_intact);
 delete $hash_omniscient->{$_} for (keys %{$hash_omniscient});
 
 # 2) print the intact one
-dual_print( $log, "print intact...\n", $verbose );
+dual_print( $log, "print intact...\n");
 print_omniscient( {omniscient => $hash_omniscient_intact, output => $gffout} );
 
 # 3) Sort by seq_id - review all newly created gene
@@ -253,9 +253,9 @@ foreach my $tag_l1 ( keys %{$omniscient_modified_gene{'level1'}} ){ # primary_ta
 }
 
 # 5) Print modified genes
-dual_print( $log, "print modified...\n", $verbose );
+dual_print( $log, "print modified...\n");
 if (exists_undef_value(\%omniscient_modified_gene)){
-  dual_print($log, "there is an undef value\n", $verbose);
+  dual_print($log, "there is an undef value\n");
   exit;
 }
 
@@ -263,11 +263,11 @@ print_omniscient( {omniscient => \%omniscient_modified_gene, output => $gffout2}
 
 # 6) Print all together
 merge_omniscients_fuse_l1duplicates($hash_omniscient_intact, \%omniscient_modified_gene);
-dual_print( $log, "print all together...\n", $verbose );
+dual_print( $log, "print all together...\n");
 print_omniscient( {omniscient => $hash_omniscient_intact, output => $gffout3} );
 
 if ($overlap){
-  dual_print($log, "We found $overlap case gene overlapping at CDS level wihout the same ID, we fixed them.\n", $verbose);
+  dual_print($log, "We found $overlap case gene overlapping at CDS level wihout the same ID, we fixed them.\n");
 }
 # End manage overlaping name
 #####################################
@@ -283,8 +283,8 @@ $string_to_print .= "Job done in $run_time seconds\n";
 if($outfile){
   print $logout $string_to_print
 }
-dual_print( $log, $string_to_print, $verbose );
-dual_print( $log, "Bye Bye.\n", $verbose );
+dual_print( $log, $string_to_print);
+dual_print( $log, "Bye Bye.\n");
 #######################################################################################################################
         ####################
          #     METHODS    #
@@ -499,7 +499,7 @@ sub take_care_utr{
             foreach my $mRNAtoTakeCare (@{$mRNAlistToTakeCare}){
 
               if($mRNAtoTakeCare eq $id_level2){ # ok is among the list of those to analyze
-                dual_print($log, "id_level2 -- $id_level2 ***** to take_care -- $mRNAtoTakeCare  \n", $verbose);
+                dual_print($log, "id_level2 -- $id_level2 ***** to take_care -- $mRNAtoTakeCare  \n");
                 if(exists_keys ($tmpOmniscient, ('level3', $utr_tag) ) and exists_keys ($tmpOmniscient, ('level3', $utr_tag,$id_level2) ) ){
 
                   ##################################################
@@ -568,7 +568,7 @@ sub take_care_utr{
                   # prediction is longer than threshold#
                   if($longest_ORF_prot_obj->length() > $threshold){
 
-                      dual_print($log, "Longer AA in utr = ".$longest_ORF_prot_obj->length()."\n".$longest_ORF_prot_obj->seq."\n", $verbose);
+                      dual_print($log, "Longer AA in utr = ".$longest_ORF_prot_obj->length()."\n".$longest_ORF_prot_obj->seq."\n");
 
                     my @exons_features = sort {$a->start <=> $b->start} @{$tmpOmniscient->{'level3'}{'exon'}{$id_level2}};# be sure that list is sorted
                     my ($exonExtremStart, $mrna_seq, $exonExtremEnd) = concatenate_feature_list(\@exons_features);
@@ -630,11 +630,11 @@ sub take_care_utr{
                     $nbNewUTRgene++;
                     } # We predict something in UTR
                     else{
-                      dual_print($log, "Nothing predicted over threshold :". $longest_ORF_prot_obj->length()." ! Next\n", $verbose);
+                      dual_print($log, "Nothing predicted over threshold :". $longest_ORF_prot_obj->length()." ! Next\n");
                     }
                   } # End there is UTR
                   else{
-                    dual_print($log, "There is no UTR ! Next\n", $verbose);
+                    dual_print($log, "There is no UTR ! Next\n");
                   }
               }
               #else{print "Not among the list mRNAtoTakeCare. Next \n";}
@@ -677,7 +677,7 @@ sub split_gene_model{
         ####################################
         # Remodelate ancient gene
         ####################################
-                    dual_print($log, "Remodelate ancient gene\n", $verbose);
+                    dual_print($log, "Remodelate ancient gene\n");
                   #############################################################
                   #  Remove all level3 feature execept cds
                   my @tag_list=('cds');
@@ -695,7 +695,7 @@ sub split_gene_model{
 
                   ########
                   # calcul utr
-                    dual_print($log, "Remodelate ancient gene ($gene_id)".$gene_feature->start." ".$gene_feature->end."\n", $verbose);
+                    dual_print($log, "Remodelate ancient gene ($gene_id)".$gene_feature->start." ".$gene_feature->end."\n");
 
                   my ($original_utr5_list, $variable_not_needed, $original_utr3_list) = modelate_utr_and_cds_features_from_exon_features_and_cds_start_stop($newOrignal_exon_list, $cdsExtremStart, $cdsExtremEnd);
                   @{$tmpOmniscient->{'level3'}{'five_prime_utr'}{$id_level2}}=@$original_utr5_list;
@@ -715,7 +715,7 @@ sub split_gene_model{
 
                   }
                   else{
-                      dual_print($log, "*** remove IT *** because exon and CDS IDENTIK ! $id_level2 \n", $verbose);
+                      dual_print($log, "*** remove IT *** because exon and CDS IDENTIK ! $id_level2 \n");
                     my @l2_feature_list=($level2_feature);
                     remove_omniscient_elements_from_level2_feature_list($tmpOmniscient, \@l2_feature_list);
                   }
@@ -727,7 +727,7 @@ sub split_gene_model{
         ###################################
         # Remodelate New Prediction
         ###################################
-                    dual_print($log, "Remodelate New Prediction\n", $verbose);
+                    dual_print($log, "Remodelate New Prediction\n");
                   # If newPred_exon_list list is empty we skipt the new gene modeling part
                   #if(!@$newPred_exon_list){
                   #  next;
@@ -792,7 +792,7 @@ sub split_gene_model{
                     }
                   }
                   else{
-                      dual_print($log, "*** Not creating mRNA *** because exon and CDS IDENTIK ! \n", $verbose);
+                      dual_print($log, "*** Not creating mRNA *** because exon and CDS IDENTIK ! \n");
                   }
 
   return $mRNAlistToTakeCare;
@@ -979,7 +979,7 @@ sub must_be_a_new_gene_new_mrna{
                   if(featuresList_identik(\@cds_feature_list, $new_pred_cds_list)){
                     #print "cds identik !\n";
                     if(featuresList_identik(\@exon_feature_list, $newPred_exon_list)){
-                        dual_print($log, "RNA identik BETWEEN $featureL2_id and $featureL2_original_id \n", $verbose);
+                        dual_print($log, "RNA identik BETWEEN $featureL2_id and $featureL2_original_id \n");
                       $Need_new_mRNA=undef;
                       $overlaping_mrna_ft=$featureL2_id;
                       last;

--- a/bin/agat_sp_fix_longest_ORF.pl
+++ b/bin/agat_sp_fix_longest_ORF.pl
@@ -51,7 +51,7 @@ if ( my $log_name = $config->{log_path} ) {
 }
 
 # --- Check codon table
-$codonTable = get_proper_codon_table($codonTable, $log, $verbose);
+$codonTable = get_proper_codon_table($codonTable, $log);
 
 ######################
 # Manage output file #
@@ -100,13 +100,13 @@ if(!($model_to_test)){
 my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $gff,
                                                                 config => $config
                                                               });
-dual_print( $log, "GFF3 file parsed\n", $verbose );
+dual_print( $log, "GFF3 file parsed\n");
 
 
 ####################
 # index the genome #
 my $db = Bio::DB::Fasta->new($file_fasta);
-dual_print( $log, "Fasta file parsed\n", $verbose );
+dual_print( $log, "Fasta file parsed\n");
 
 ####################
 my $pseudo_threshold=70;
@@ -204,7 +204,7 @@ foreach my $primary_tag_key_level1 (keys %{$hash_omniscient->{'level1'}}){ # pri
 
             ########################
             # prediction is longer #
-            dual_print( $log, $id_level2." - size before: ".$originalProt_size." size after: ".$longest_ORF_prot_obj->length()."\n", $verbose );
+            dual_print( $log, $id_level2." - size before: ".$originalProt_size." size after: ".$longest_ORF_prot_obj->length()."\n");
                                             dual_print( $log, "Original: ".$original_prot_obj->seq."\n", $verbose > 3 );
                                             dual_print( $log, "Prediction: ".$longest_ORF_prot_obj->seq."\n", $verbose > 3 );
             if($longest_ORF_prot_obj->length() > $originalProt_size){
@@ -217,8 +217,8 @@ foreach my $primary_tag_key_level1 (keys %{$hash_omniscient->{'level1'}}){ # pri
 									if( pass_ambiguous_start($longest_ORF_prot_obj, $originalProt_size) ){
 
                     $ListModel{1}++;
-                    dual_print($log, "Model 1: gene=$gene_id_tag_key mRNA=$id_level2\n", $verbose);
-                    dual_print( $log, "original:$cds_prot\nnew:". $longest_ORF_prot_obj->seq."\n", $verbose );
+                    dual_print($log, "Model 1: gene=$gene_id_tag_key mRNA=$id_level2\n");
+                    dual_print( $log, "original:$cds_prot\nnew:". $longest_ORF_prot_obj->seq."\n");
                     modify_gene_model($hash_omniscient, \%omniscient_modified_gene, $gene_feature, $gene_id_tag_key, $level2_feature, $id_level2, \@exons_features, \@cds_feature_list, $cdsExtremStart, $cdsExtremEnd, $realORFstart, $realORFend, 'model1', $gffout);
                     $ORFmodified="yes";
 
@@ -236,7 +236,7 @@ foreach my $primary_tag_key_level1 (keys %{$hash_omniscient->{'level1'}}){ # pri
 
                   if( exists($ListModel{2}) ){
                     $ListModel{2}++;
-                    dual_print($log, "Model 2: gene=$gene_id_tag_key mRNA=$id_level2\n", $verbose);
+                    dual_print($log, "Model 2: gene=$gene_id_tag_key mRNA=$id_level2\n");
                     $model=1;
                     if($split_opt){
                       split_gene_model(\@intact_gene_list, $hash_omniscient, \%omniscient_modified_gene, $gene_feature, $gene_id_tag_key, $level2_feature, $id_level2, \@exons_features, \@cds_feature_list, $cdsExtremStart, $cdsExtremEnd, $realORFstart, $realORFend, 'model2', $gffout);
@@ -255,7 +255,7 @@ foreach my $primary_tag_key_level1 (keys %{$hash_omniscient->{'level1'}}){ # pri
                   # original protein and predicted one are different; the predicted one is longest, they overlap each other.
                   if( exists($ListModel{3}) ){
                     $ListModel{3}++;
-                    dual_print($log, "Model 3: gene=$gene_id_tag_key mRNA=$id_level2\n", $verbose);
+                    dual_print($log, "Model 3: gene=$gene_id_tag_key mRNA=$id_level2\n");
 
                     modify_gene_model($hash_omniscient, \%omniscient_modified_gene, $gene_feature, $gene_id_tag_key, $level2_feature, $id_level2, \@exons_features, \@cds_feature_list, $cdsExtremStart, $cdsExtremEnd, $realORFstart, $realORFend, 'model3', $gffout);
                     $ORFmodified="yes";
@@ -270,14 +270,14 @@ foreach my $primary_tag_key_level1 (keys %{$hash_omniscient->{'level1'}}){ # pri
 
               # contains stop codon but not at the last position
               if( (index($original_prot_obj->seq, '*') != -1 ) and (index($original_prot_obj->seq, '*') != length($original_prot_obj->seq)-1) ){
-                dual_print( $log, "Original sequence contains premature stop codon.\n", $verbose );
+                dual_print( $log, "Original sequence contains premature stop codon.\n");
                 #Model4     ###############
                 # /!\ Here we compare the CDS traduction (traduct in IUPAC) against longest CDS in mRNA IUPAC modified to take in account for stops codon only those that are trustable only (TGA, TAR...).
                 if( exists($ListModel{4}) ){
                   $ListModel{4}++;
-                  dual_print($log, "Model 4: gene=$gene_id_tag_key mRNA=$id_level2\n", $verbose);
-                  dual_print( $log, "Original: ".$original_prot_obj->seq."\n", $verbose );
-                  dual_print( $log, "longestl: ".$longest_ORF_prot_obj->seq."\n", $verbose );
+                  dual_print($log, "Model 4: gene=$gene_id_tag_key mRNA=$id_level2\n");
+                  dual_print( $log, "Original: ".$original_prot_obj->seq."\n");
+                  dual_print( $log, "longestl: ".$longest_ORF_prot_obj->seq."\n");
                   #remodelate a shorter gene
                   modify_gene_model($hash_omniscient, \%omniscient_modified_gene, $gene_feature, $gene_id_tag_key, $level2_feature, $id_level2, \@exons_features, \@cds_feature_list, $cdsExtremStart, $cdsExtremEnd, $realORFstart, $realORFend, 'model4', $gffout);
                   $ORFmodified="yes";
@@ -294,9 +294,9 @@ foreach my $primary_tag_key_level1 (keys %{$hash_omniscient->{'level1'}}){ # pri
               else{
                 if( exists($ListModel{5}) ){
                   $ListModel{5}++;
-                  dual_print( $log, "Model 5: gene=$gene_id_tag_key mRNA=$id_level2\n", $verbose );
-                  dual_print( $log, "Original: ".$original_prot_obj->seq."\n", $verbose );
-                  dual_print( $log, "longestl: ".$longest_ORF_prot_obj->seq."\n", $verbose );
+                  dual_print( $log, "Model 5: gene=$gene_id_tag_key mRNA=$id_level2\n");
+                  dual_print( $log, "Original: ".$original_prot_obj->seq."\n");
+                  dual_print( $log, "longestl: ".$longest_ORF_prot_obj->seq."\n");
                   #remodelate a shorter gene
                   modify_gene_model($hash_omniscient, \%omniscient_modified_gene, $gene_feature, $gene_id_tag_key, $level2_feature, $id_level2, \@exons_features, \@cds_feature_list, $cdsExtremStart, $cdsExtremEnd, $realORFstart, $realORFend, 'model4', $gffout);
                   $ORFmodified="yes";
@@ -308,9 +308,9 @@ foreach my $primary_tag_key_level1 (keys %{$hash_omniscient->{'level1'}}){ # pri
             elsif( (index($original_prot_obj->seq, '*') != -1 ) and (index($original_prot_obj->seq, '*') != length($original_prot_obj->seq)-1) ){
               if( exists($ListModel{6}) ){
                 $ListModel{6}++;
-                dual_print( $log, "Model 6: gene=$gene_id_tag_key mRNA=$id_level2\n", $verbose );
-                dual_print( $log, "Original: ".$original_prot_obj->seq."\n", $verbose );
-                dual_print( $log, "longestl: ".$longest_ORF_prot_obj->seq."\n", $verbose );
+                dual_print( $log, "Model 6: gene=$gene_id_tag_key mRNA=$id_level2\n");
+                dual_print( $log, "Original: ".$original_prot_obj->seq."\n");
+                dual_print( $log, "longestl: ".$longest_ORF_prot_obj->seq."\n");
                 modify_gene_model($hash_omniscient, \%omniscient_modified_gene, $gene_feature, $gene_id_tag_key, $level2_feature, $id_level2, \@exons_features, \@cds_feature_list, $cdsExtremStart, $cdsExtremEnd, $realORFstart, $realORFend, 'model3', $gffout);
                 $ORFmodified="yes";
               }
@@ -366,19 +366,19 @@ fil_cds_frame(\%omniscient_modified_gene, $db, $log, $verbose, $codonTable);
 fil_cds_frame($hash_omniscient, $db, $log, $verbose, $codonTable);
 
 #Clean omniscient_modified_gene of duplicated/identical genes and isoforms
-dual_print( $log, "removing duplicates\n", $verbose );
+dual_print( $log, "removing duplicates\n");
 merge_overlap_loci(undef, \%omniscient_modified_gene, undef, $verbose);
 
 ########
 # Print results
-dual_print( $log, "print intact...\n", $verbose );
+dual_print( $log, "print intact...\n");
 print_omniscient_from_level1_id_list( {omniscient => $hash_omniscient, level_id_list =>\@intact_gene_list, output => $gffout} );
 
-dual_print( $log, "print modified...\n", $verbose );
+dual_print( $log, "print modified...\n");
 print_omniscient( {omniscient => \%omniscient_modified_gene, output => $gffout2} );
 
 # create a hash containing everything
-dual_print( $log, "print all with name of overlapping features resolved...\n", $verbose );
+dual_print( $log, "print all with name of overlapping features resolved...\n");
 my $hash_all = subsample_omniscient_from_level1_id_list_delete($hash_omniscient, \@intact_gene_list);
 merge_omniscients( $hash_all, \%omniscient_modified_gene);
 merge_overlap_loci(undef, \%omniscient_modified_gene, undef, $verbose);
@@ -429,11 +429,11 @@ if ($codonTable == 1){
 	"Particular case: If we have a triplet as WTG, AYG, RTG, RTR or ATK it will be seen as a possible start codon (but translated into X)\n";
 	#"An arbitrary choisce has been done: The longer translate can begin by a L only if it's longer by 21 AA than the longer translate beginning by M. It's happened $counter_case21 times here.\n";
 }
-dual_print( $log, $string_to_print, $verbose );
+dual_print( $log, $string_to_print);
 if($outfile){
   print $report $string_to_print;
 }
-dual_print( $log, "Bye Bye.\n", $verbose );
+dual_print( $log, "Bye Bye.\n");
 
 
 #######################################################################################################################

--- a/bin/agat_sp_fix_overlaping_genes.pl
+++ b/bin/agat_sp_fix_overlaping_genes.pl
@@ -35,11 +35,11 @@ my $gffout = prepare_gffout($config, $outfile);
 
 my $error_found=undef;
 ### Parse GFF input #
-dual_print( $log, "Parse file $ref\n", $verbose );
+dual_print( $log, "Parse file $ref\n");
 my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $ref,
                                                                  config => $config
                                                               });
-dual_print( $log, "$ref file parsed\n", $verbose );
+dual_print( $log, "$ref file parsed\n");
 
 # sort by seq id
 my %hash_sortBySeq;
@@ -91,7 +91,7 @@ foreach my $tag ( sort {$a cmp $b} keys %hash_sortBySeq){ # loop over all the fe
 
 					#now check at each CDS feature independently
           if (two_features_overlap($hash_omniscient,$gene_id, $gene_id2)){
-            dual_print( $log, "These two features overlap without same id ! :\n".$gene_feature->gff_string."\n".$gene_feature2->gff_string."\n", $verbose );
+            dual_print( $log, "These two features overlap without same id ! :\n".$gene_feature->gff_string."\n".$gene_feature2->gff_string."\n");
             $error_found="yes";
             $nb_feat_overlap++;
             $total_overlap++;
@@ -103,9 +103,9 @@ foreach my $tag ( sort {$a cmp $b} keys %hash_sortBySeq){ # loop over all the fe
       # Now manage name if some feature overlap
       if( $nb_feat_overlap > 0){
         push(@ListOverlapingGene, $gene_feature);
-        dual_print( $log, "$nb_feat_overlap overlapping feature found ! We will treat them now:\n", $verbose );
+        dual_print( $log, "$nb_feat_overlap overlapping feature found ! We will treat them now:\n");
         my ($reference_feature, $ListToRemove)=take_one_as_reference(\@ListOverlapingGene, $opt_merge);
-        dual_print( $log, "We decided to keep that one: ".$reference_feature->gff_string."\n", $verbose );
+        dual_print( $log, "We decided to keep that one: ".$reference_feature->gff_string."\n");
 
         my $gene_id_ref  = $reference_feature->_tag_value('ID');
 
@@ -146,19 +146,19 @@ foreach my $tag ( sort {$a cmp $b} keys %hash_sortBySeq){ # loop over all the fe
         ###
         # check end and start of the new feature
         check_level1_positions( { omniscient => $hash_omniscient, feature => $reference_feature } );
-        dual_print( $log, "\n\n", $verbose );
+        dual_print( $log, "\n\n");
       }
     }
   }
 }
 
 if(! $error_found){
-  dual_print( $log, "No gene overlaping with different name has been found !\n", $verbose );
+  dual_print( $log, "No gene overlaping with different name has been found !\n");
 }else{
-  dual_print( $log, "$total_overlap genes overlap\n", $verbose );
+  dual_print( $log, "$total_overlap genes overlap\n");
 }
 print_omniscient( {omniscient => $hash_omniscient, output => $gffout} );
-dual_print( $log, "END\n", $verbose );
+dual_print( $log, "END\n");
 
 #######################################################################################################################
         ####################

--- a/bin/agat_sp_fix_small_exon_from_extremities.pl
+++ b/bin/agat_sp_fix_small_exon_from_extremities.pl
@@ -42,7 +42,7 @@ my $gffout = prepare_gffout($config, $outfile);
 # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>    EXTRA     <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
 # --- Check codon table
-$codonTableId = get_proper_codon_table($codonTableId, $log, $verbose);
+$codonTableId = get_proper_codon_table($codonTableId, $log);
 
 # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>     MAIN     <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
@@ -51,13 +51,13 @@ $codonTableId = get_proper_codon_table($codonTableId, $log, $verbose);
 my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $gff,
                                                                  config => $config
                                                               });
-dual_print( $log, "GFF3 file parsed\n", $verbose );
+dual_print( $log, "GFF3 file parsed\n");
 
 
 ####################
 # index the genome #
 my $db = Bio::DB::Fasta->new($file_fasta);
-dual_print( $log, "Fasta file parsed\n", $verbose );
+dual_print( $log, "Fasta file parsed\n");
 
 ####################
 
@@ -72,7 +72,7 @@ foreach my $primary_tag_key_level1 (keys %{$hash_omniscient->{'level1'}}){ # pri
 
     my $gene_feature = $hash_omniscient->{'level1'}{$primary_tag_key_level1}{$gene_id};
     my $strand = $gene_feature->strand();
-    dual_print( $log, "gene_id = $gene_id\n", $verbose );
+    dual_print( $log, "gene_id = $gene_id\n");
 
     foreach my $primary_tag_key_level2 (keys %{$hash_omniscient->{'level2'}}){ # primary_tag_key_level2 = mrna or mirna or ncrna or trna etc...
       if ( exists_keys( $hash_omniscient, ('level2', $primary_tag_key_level2, $gene_id) ) ){
@@ -103,7 +103,7 @@ foreach my $primary_tag_key_level1 (keys %{$hash_omniscient->{'level1'}}){ # pri
               $exonCounter++;
               $exonFix=1;
 
-              dual_print( $log, "left_exon start fixed\n", $verbose );
+              dual_print( $log, "left_exon start fixed\n");
 
               #take care of CDS if needed
               if ( exists_keys( $hash_omniscient, ('level3', 'cds', $level2_ID) ) ){
@@ -161,7 +161,7 @@ foreach my $primary_tag_key_level1 (keys %{$hash_omniscient->{'level1'}}){ # pri
                 $exonCounter++;
                 $exonFix=1;
 
-                dual_print( $log, "right_exon end fixed\n", $verbose );
+                dual_print( $log, "right_exon end fixed\n");
 
                 #take care of CDS if needed
                 if ( exists_keys( $hash_omniscient, ('level3', 'cds', $level2_ID) ) ){
@@ -181,7 +181,7 @@ foreach my $primary_tag_key_level1 (keys %{$hash_omniscient->{'level1'}}){ # pri
                     my $this_codon = substr( $sequence, $original_cds_end-3, 3);
 
                     if($strand eq "+" or $strand == "1"){
-                      dual_print( $log, "last plus strand\n", $verbose );
+                      dual_print( $log, "last plus strand\n");
                        #Check if it is not terminal codon, otherwise we have to extend the CDS.
 
                       if(! $codonTable->is_ter_codon( $this_codon )){
@@ -191,7 +191,7 @@ foreach my $primary_tag_key_level1 (keys %{$hash_omniscient->{'level1'}}){ # pri
 
                     }
                     if($strand eq "-" or $strand == "-1"){
-                      dual_print( $log, "last minus strand\n", $verbose );
+                      dual_print( $log, "last minus strand\n");
 
                       #reverse complement
                       my $seqobj = Bio::Seq->new(-seq => $this_codon);
@@ -228,11 +228,11 @@ $string_to_print .="Results:\n";
 $string_to_print .="nb gene affected: $geneCounter\n";
 $string_to_print .="nb rna affected: $mrnaCounter\n";
 $string_to_print .="nb exon affected: $exonCounter\n";
-dual_print( $log, $string_to_print, $verbose );
+dual_print( $log, $string_to_print);
 
 print_omniscient( {omniscient => $hash_omniscient, output => $gffout} );
 
-dual_print( $log, "Bye Bye.\n", $verbose );
+dual_print( $log, "Bye Bye.\n");
 #######################################################################################################################
         ####################
          #     METHODS    #

--- a/bin/agat_sp_flag_premature_stop_codons.pl
+++ b/bin/agat_sp_flag_premature_stop_codons.pl
@@ -29,7 +29,7 @@ if ( my $log_name = $config->{log_path} ) {
       or die "Can not open $log_name for printing: $!";
     dual_print( $log, $header, 0 );
 }
-$codonTable = get_proper_codon_table( $codonTable, $log, $config->{verbose} );
+$codonTable = get_proper_codon_table( $codonTable, $log);
 # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>    PARAMS    <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
 my $ostreamReport_file;
@@ -48,7 +48,7 @@ my $string1 = strftime "%m/%d/%Y at %Hh%Mm%Ss", localtime;
 $string1 .= "\n\nusage: $0 @copyARGV\n\n";
 
 print $ostreamReport $string1 if $ostreamReport;
-dual_print( $log, $string1, $config->{verbose} );
+dual_print( $log, $string1);
 
 # activate warnings limit
 my %warnings;
@@ -58,11 +58,11 @@ activate_warning_limit(\%warnings, 10);
 
 ######################
 ### Parse GFF input #
-dual_print( $log, "Reading $opt_file\n", $config->{verbose} );
+dual_print( $log, "Reading $opt_file\n");
 my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $opt_file,
 	                                                             config => $config
                                                               });
-dual_print( $log, "Parsing Finished\n\n", $config->{verbose} );
+dual_print( $log, "Parsing Finished\n\n");
 ### END Parse GFF input #
 #########################
 
@@ -73,7 +73,7 @@ my $db_fasta = Bio::DB::Fasta->new($file_fasta);
 my %allIDs;
 my @ids_db_fasta     = $db_fasta->get_all_primary_ids;
 foreach my $id (@ids_db_fasta ){$allIDs{lc($id)}=$id;}
-dual_print( $log, "Fasta file parsed\n", $config->{verbose} );
+dual_print( $log, "Fasta file parsed\n");
 
 
 my $nb_cases=0;
@@ -165,7 +165,7 @@ foreach my $seqid (sort { (($a =~ /(\d+)$/)[0] || 0) <=> (($b =~ /(\d+)$/)[0] ||
 							my $arrSize = @positions;
                                                     my $toprint = "We flag the $tag_l2 $level2_ID that contained $arrSize premature stop codons\n";
                                                     print $ostreamReport $toprint if $ostreamReport;
-                                                    dual_print( $log, $toprint, $config->{verbose} );
+                                                    dual_print( $log, $toprint);
 						  $nb_cases++;
 							$nb_this_l2_pseudo++;
 						}
@@ -176,7 +176,7 @@ foreach my $seqid (sort { (($a =~ /(\d+)$/)[0] || 0) <=> (($b =~ /(\d+)$/)[0] ||
 					$nb_cases_l1++;
 				}
 				elsif($nb_this_l2_pseudo){
-                                dual_print( $log, "Not all isoforms of $id_l1 are pseudogenes, so we do not flag the gene.\n", $config->{verbose} );
+                                dual_print( $log, "Not all isoforms of $id_l1 are pseudogenes, so we do not flag the gene.\n");
 				}
 			}
 	  }
@@ -186,7 +186,7 @@ foreach my $seqid (sort { (($a =~ /(\d+)$/)[0] || 0) <=> (($b =~ /(\d+)$/)[0] ||
 my $toprint = "We found $nb_cases cases where mRNAs contain premature stop codons. They have been flagged as pseudogene.\n".
                                                         "$nb_cases_l1 genes have been flagged as pseudogene.\n";
 print $ostreamReport $toprint if $ostreamReport;
-dual_print( $log, $toprint, $config->{verbose} );
+dual_print( $log, $toprint);
 
 print_omniscient( {omniscient => $hash_omniscient, output => $gffout} );
 

--- a/bin/agat_sp_flag_short_introns.pl
+++ b/bin/agat_sp_flag_short_introns.pl
@@ -44,17 +44,17 @@ my $string1 = strftime "%m/%d/%Y at %Hh%Mm%Ss", localtime;
 $string1 .= "\n\nusage: $0 @copyARGV\n\n";
 
 print $ostreamReport $string1 if $ostreamReport;
-dual_print( $log, $string1, $config->{verbose} );
+dual_print( $log, $string1);
 
 # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>     MAIN     <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
 ######################
 ### Parse GFF input #
-dual_print( $log, "Reading $opt_file\n", $config->{verbose} );
+dual_print( $log, "Reading $opt_file\n");
 my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $opt_file,
                                                                  config => $config
                                                               });
-dual_print( $log, "Parsing Finished\n\n", $config->{verbose} );
+dual_print( $log, "Parsing Finished\n\n");
 ### END Parse GFF input #
 #########################
 
@@ -89,7 +89,7 @@ foreach my $tag_l1 (keys %{$hash_omniscient->{'level1'}}){
     }
     dual_print( $log, "Shortest intron for $id_l1:".$shortest_intron."\n", ($shortest_intron != 10000000000 && $config->{verbose}) );
     if ($shortest_intron < $Xsize){
-      dual_print( $log, "flag the gene $id_l1\n", $config->{verbose} );
+      dual_print( $log, "flag the gene $id_l1\n");
       $nb_cases++;
 
       my $feature_l1 = $hash_omniscient->{'level1'}{$tag_l1}{$id_l1};
@@ -117,7 +117,7 @@ foreach my $tag_l1 (keys %{$hash_omniscient->{'level1'}}){
 
 my $toprint = "We found $nb_cases cases where introns were < $Xsize, we flagged them with the attribute $tag. The value of this tag is size of the shortest intron found in this gene.\n";
 print $ostreamReport $toprint if $ostreamReport;
-dual_print( $log, $toprint, $config->{verbose} );
+dual_print( $log, $toprint);
 
 print_omniscient( {omniscient => $hash_omniscient, output => $gffout} );
 

--- a/bin/agat_sp_flag_short_introns_ebi.pl
+++ b/bin/agat_sp_flag_short_introns_ebi.pl
@@ -44,17 +44,17 @@ my $string1 = strftime "%m/%d/%Y at %Hh%Mm%Ss", localtime;
 $string1 .= "\n\nusage: $0 @copyARGV\n\n";
 
 print $ostreamReport $string1 if $ostreamReport;
-dual_print( $log, $string1, $config->{verbose} );
+dual_print( $log, $string1);
 
 # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>     MAIN     <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
 ######################
 ### Parse GFF input #
-dual_print( $log, "Reading $opt_file\n", $config->{verbose} );
+dual_print( $log, "Reading $opt_file\n");
 my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $opt_file,
                                                                  config => $config
                                                               });
-dual_print( $log, "Parsing Finished\n\n", $config->{verbose} );
+dual_print( $log, "Parsing Finished\n\n");
 ### END Parse GFF input #
 #########################
 
@@ -89,7 +89,7 @@ foreach my $tag_l1 (keys %{$hash_omniscient->{'level1'}}){
     }
     dual_print($log, "Shortest intron for $id_l1:".$shortest_intron."\n", ($shortest_intron != 10000000000 && $config->{verbose}));
     if ($shortest_intron < $Xsize){
-      dual_print($log, "flag the gene $id_l1\n", $config->{verbose});
+      dual_print($log, "flag the gene $id_l1\n");
       $nb_cases++;
 
       my $feature_l1 = $hash_omniscient->{'level1'}{$tag_l1}{$id_l1};
@@ -128,7 +128,7 @@ foreach my $tag_l1 (keys %{$hash_omniscient->{'level1'}}){
 
 my $toprint = "We found $nb_cases cases where introns were < $Xsize, we flagged them with the attribute $tag. The value of this tag is size of the shortest intron found in this gene.\n";
 print $ostreamReport $toprint if $ostreamReport;
-dual_print($log, $toprint, $config->{verbose});
+dual_print($log, $toprint);
 
 close $log if $log;
 

--- a/bin/agat_sp_functional_statistics.pl
+++ b/bin/agat_sp_functional_statistics.pl
@@ -53,11 +53,11 @@ my $stat_out = prepare_fileout($stat_file);
 
 ######################
 ### Parse GFF input #
-dual_print( $log, "Reading file $gff\n", $opt_verbose );
+dual_print( $log, "Reading file $gff\n");
 my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $gff,
                                                                  config => $config
                                                               });
-dual_print( $log, "Parsing Finished\n", $opt_verbose );
+dual_print( $log, "Parsing Finished\n");
 ### END Parse GFF input #
 #########################
 
@@ -65,7 +65,7 @@ dual_print( $log, "Parsing Finished\n", $opt_verbose );
 ### Print Statistics structural first
 ###############################################################
 
-dual_print( $log, "Compute statistics\n", $opt_verbose );
+dual_print( $log, "Compute statistics\n");
 print_omniscient_statistics ({ input  => $hash_omniscient,
 															 genome => $opt_genomeSize,
 															 output => $stat_out
@@ -141,7 +141,7 @@ foreach my $chimerel1l2 (sort keys %link_tags){
 
 # END STATISTICS #
 ##################
-dual_print( $log, "Result available in <$opt_output>. Bye Bye.\n", $opt_verbose );
+dual_print( $log, "Result available in <$opt_output>. Bye Bye.\n");
 close $log if $log;
 #######################################################################################################################
         ####################

--- a/bin/agat_sp_keep_longest_isoform.pl
+++ b/bin/agat_sp_keep_longest_isoform.pl
@@ -34,11 +34,11 @@ my $gffout = prepare_gffout($config, $opt_output);
 
 ######################
 ### Parse GFF input #
-dual_print( $log, "Reading file $gff\n", $opt_verbose );
+dual_print( $log, "Reading file $gff\n");
 my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $gff,
                                                                  config => $config
                                                               });
-dual_print( $log, "Parsing Finished\n", $opt_verbose );
+dual_print( $log, "Parsing Finished\n");
 ### END Parse GFF input #
 #########################
 
@@ -48,12 +48,12 @@ my ($nb_iso_removed_cds,  $nb_iso_removed_exon) = remove_shortest_isoforms($hash
 # print omniscientNew containing only the longest isoform per gene
 print_omniscient( {omniscient => $hash_omniscient, output => $gffout} );
 
-dual_print( $log, $nb_iso_removed_cds . " L2 isoforms with CDS removed (shortest CDS)\n", $opt_verbose );
-dual_print( $log, $nb_iso_removed_exon . " L2 isoforms wihtout CDS removed (Either no isoform has CDS, we removed those with shortest concatenated exons, or at least one isoform has CDS, we removed those wihtout)\n", $opt_verbose );
+dual_print( $log, $nb_iso_removed_cds . " L2 isoforms with CDS removed (shortest CDS)\n");
+dual_print( $log, $nb_iso_removed_exon . " L2 isoforms wihtout CDS removed (Either no isoform has CDS, we removed those with shortest concatenated exons, or at least one isoform has CDS, we removed those wihtout)\n");
 
 # END STATISTICS #
 ##################
-dual_print( $log, "Done\n", $opt_verbose );
+dual_print( $log, "Done\n");
 
 close $log if $log;
 

--- a/bin/agat_sp_kraken_assess_liftover.pl
+++ b/bin/agat_sp_kraken_assess_liftover.pl
@@ -44,7 +44,7 @@ my $log;
 if ( my $log_name = $config->{log_path} ) {
     open( $log, '>', $log_name ) or die "Can not open $log_name for printing: $!";
 }
-dual_print( $log, $header, $opt_verbose );
+dual_print( $log, $header);
 
 sub _kraken_has_tag {
     my ($feature) = @_;
@@ -102,7 +102,7 @@ $messageValue .= "The kraken attribute tag that will be used is: $kraken_tag\n";
 
 #print info
 print $outReport $messageValue if $opt_output;
-dual_print( $log, $messageValue, $opt_verbose );
+dual_print( $log, $messageValue);
 
 # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>     MAIN     <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
@@ -276,9 +276,9 @@ foreach my $seqid (sort { (($a =~ /(\d+)$/)[0] || 0) <=> (($b =~ /(\d+)$/)[0] ||
 																						 config => $config
 	                                                                                   });
                 if ($opt_verbose) {
-                  dual_print( $log, "\nA proper hash:\n", $opt_verbose );
+                  dual_print( $log, "\nA proper hash:\n");
                   print_omniscient( { omniscient => $hash_omniscient_clean, output => $gffout } );
-                  dual_print( $log, "\n", $opt_verbose );
+                  dual_print( $log, "\n");
                 }
 
 	        ###################################################################################
@@ -294,7 +294,7 @@ foreach my $seqid (sort { (($a =~ /(\d+)$/)[0] || 0) <=> (($b =~ /(\d+)$/)[0] ||
 
 	            $gene_feature = $hash_omniscient_clean->{'level1'}{$primary_tag_key_level1}{$id_tag_key_level1};
 	            my @ListmrnaNoMatch;
-                dual_print( $log, "\n\nlevel1 feature:\n" . $gene_feature->gff_string . "\n\n", $opt_verbose );
+                dual_print( $log, "\n\nlevel1 feature:\n" . $gene_feature->gff_string . "\n\n");
 
 	            ################
 	            # == LEVEL 2
@@ -305,7 +305,7 @@ foreach my $seqid (sort { (($a =~ /(\d+)$/)[0] || 0) <=> (($b =~ /(\d+)$/)[0] ||
 
 	              if ( exists_keys($hash_omniscient_clean, ('level2',$primary_tag_key_level2,$id_tag_key_level1) ) ){
 	                foreach my $feature_level2 ( @{$hash_omniscient_clean->{'level2'}{$primary_tag_key_level2}{$id_tag_key_level1}}) {
-                      dual_print( $log, "level2 feature:\n" . $feature_level2->gff_string . "\n", $opt_verbose );
+                      dual_print( $log, "level2 feature:\n" . $feature_level2->gff_string . "\n");
 
 	                  my $percentMatch=0;
 
@@ -363,7 +363,7 @@ foreach my $seqid (sort { (($a =~ /(\d+)$/)[0] || 0) <=> (($b =~ /(\d+)$/)[0] ||
 
 	                  #compute the MATCH. A MATCH can be over 100% because we compute the size of the original feature l3 against the new feature l3. The new feature l3 (i.e exon) could have been strenghten to fit a new size/map of feature l2.
 	                  $percentMatch=($matchSize*100)/$totalSize;
-                      dual_print( $log, "$id_tag_key_level1 / $level2_ID  maps at $percentMatch percent.\n", $opt_verbose );
+                      dual_print( $log, "$id_tag_key_level1 / $level2_ID  maps at $percentMatch percent.\n");
 	                  #if($percentMatch > 100){
 	                  #  print $id_tag_key_level1."\n";exit;
 	                  #}
@@ -438,7 +438,7 @@ foreach my $seqid (sort { (($a =~ /(\d+)$/)[0] || 0) <=> (($b =~ /(\d+)$/)[0] ||
 	    if($nbMapTrueHere > 1 and $sucessMapL0 > 1){
 	      if( $sucessMapL1OusideScope > 1){
             $bothCase++;
-            dual_print( $log, "Both case:\nNb multi map seq diff=$sucessMapL0\nNb multi map same seq =$sucessMapL1OusideScope\n", $opt_verbose );
+            dual_print( $log, "Both case:\nNb multi map seq diff=$sucessMapL0\nNb multi map same seq =$sucessMapL1OusideScope\n");
 	        $nb_total_multiMap_seqdif_bothcase+=$sucessMapL0;
 	        $nb_total_multiMap_sameseq_bothcase+=$sucessMapL1OusideScope;
 	        $nb_multiMap_sameseq--;
@@ -452,14 +452,14 @@ foreach my $seqid (sort { (($a =~ /(\d+)$/)[0] || 0) <=> (($b =~ /(\d+)$/)[0] ||
 	  }
 	}
 }
-dual_print( $log, "Calcul of mapped percentage length finished !\n", $opt_verbose );
+dual_print( $log, "Calcul of mapped percentage length finished !\n");
 
 
 ######################
 # Check if nothing mapped
 my $nbKey = keys %mappedPercentPerGene;
 if ($nbKey == 0){
- dual_print( $log, "No succefully mapped feature found!\n", $opt_verbose );
+ dual_print( $log, "No succefully mapped feature found!\n");
 }
 
 ########
@@ -493,7 +493,7 @@ $messageEnd.= "\n";
 
 #print info
 print $outReport $messageEnd if $opt_output;
-dual_print( $log, $messageEnd, $opt_verbose );
+dual_print( $log, $messageEnd);
 
 #############
 #PLOT
@@ -551,13 +551,13 @@ if ($opt_plot){
         if ($opt_output) {
           print $outReport $messagePlot;
         }
-        else{ dual_print( $log, $messagePlot, $opt_verbose ); }
+        else{ dual_print( $log, $messagePlot); }
 
   	# Delete temporary file
   	#unlink "$pathPlotFile";
 }
 #END
-dual_print( $log, "We finished !! Bye Bye.\n", $opt_verbose );
+dual_print( $log, "We finished !! Bye Bye.\n");
 close $log if $log;
 
 #######################################################################################################################
@@ -581,7 +581,7 @@ close $log if $log;
 sub compute_total_size{
   my ($hash_omniscient, $l1_original_id, $feature_l3)=@_;
 
-            dual_print( $log, $l1_original_id . " = l1_original_id\n", $opt_verbose );
+            dual_print( $log, $l1_original_id . " = l1_original_id\n");
 
 		  my $l2_transcipt_id = lc($feature_l3->_tag_value('transcript_id'));
 		  my $total_size=0;

--- a/bin/agat_sp_list_short_introns.pl
+++ b/bin/agat_sp_list_short_introns.pl
@@ -45,7 +45,7 @@ my $fh = prepare_fileout($opt_output);
   my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $opt_file,
                                                                    config => $config
                                                               });
-  dual_print( $log, "Parsing Finished\n\n", $verbose );
+  dual_print( $log, "Parsing Finished\n\n");
   ### END Parse GFF input #
   #########################
 

--- a/bin/agat_sp_load_function_from_protein_align.pl
+++ b/bin/agat_sp_load_function_from_protein_align.pl
@@ -135,7 +135,7 @@ if(defined($sort_method_by_species) ){
   else{
     $sort_method_by_species = _taxid_ref_sorted();
   }
-  dual_print( $log, "Priority in this order will be used for selecting the referential protein form matching proteins:\n", $opt_verbose );
+  dual_print( $log, "Priority in this order will be used for selecting the referential protein form matching proteins:\n");
   foreach my $priority (sort { $a <=> $b } keys %{$sort_method_by_species}){
     _print( $priority." - ".$sort_method_by_species->{$priority}."\n",0);
   }
@@ -148,13 +148,13 @@ if ($priority_opt ne "pe" and $priority_opt ne "sp"){
 
 #Manage method
 if ($method_opt eq "replace"){
-  dual_print( $log, "We will add or replace the product and Name values when a protein maps properly.\n", $opt_verbose );
+  dual_print( $log, "We will add or replace the product and Name values when a protein maps properly.\n");
 }
 elsif($method_opt eq "add"){
-  dual_print( $log, "We will add the lfp_product and lfp_name values when a protein maps properly.\n", $opt_verbose );
+  dual_print( $log, "We will add the lfp_product and lfp_name values when a protein maps properly.\n");
 }
 elsif($method_opt eq "complete"){
-  dual_print( $log, "We will add the product and Name values when a protein maps properly and no product and/or Name value exists.\n", $opt_verbose );
+  dual_print( $log, "We will add the product and Name values when a protein maps properly and no product and/or Name value exists.\n");
 }
 else{
   die "Method option must be replace, add or complete. Please check the help for more information. (replace by default)\n";
@@ -633,7 +633,7 @@ sub _get_species{
     $abb = substr $clipped, $egal-2, 2;
     $clipped = substr $clipped, $egal+1;
   }
-  if($egal == -1){ dual_print($log, "No species name found in this fasta header: $self\n", $opt_verbose);return $species;}
+  if($egal == -1){ dual_print($log, "No species name found in this fasta header: $self\n");return $species;}
   $egal = index($clipped, '=');
   if($egal != -1){
     $species  =  substr $clipped, 0, $egal-2;
@@ -665,7 +665,7 @@ sub _get_gn{
     $abb = substr $clipped, $egal-2, 2;
     $clipped = substr $clipped, $egal+1;
   }
-  if($egal == -1){ dual_print($log, "No gene name found in this fasta header: $self\n", $opt_verbose);return $geneName;}
+  if($egal == -1){ dual_print($log, "No gene name found in this fasta header: $self\n");return $geneName;}
   $egal = index($clipped, '=');
   if($egal != -1){
     $geneName  =  substr $clipped, 0, $egal-2;
@@ -698,7 +698,7 @@ sub _get_pe{
     $abb = substr $clipped, $egal-2, 2;
     $clipped = substr $clipped, $egal+1;
   }
-  if($egal == -1){ dual_print($log, "No pe found in this fasta header: $self\n", $opt_verbose); return $pe; }
+  if($egal == -1){ dual_print($log, "No pe found in this fasta header: $self\n"); return $pe; }
   $egal = index($clipped, '=');
   if($egal != -1){
     $pe  =  substr $clipped, 0, $egal-2;
@@ -731,7 +731,7 @@ sub _get_sv{
     $abb = substr $clipped, $egal-2, 2;
     $clipped = substr $clipped, $egal+1;
   }
-  if($egal == -1){ dual_print($log, "No sv found in this fasta header: $self\n", $opt_verbose); return $sv; }
+  if($egal == -1){ dual_print($log, "No sv found in this fasta header: $self\n"); return $sv; }
   $egal = index($clipped, '=');
   if($egal != -1){
     $sv  =  substr $clipped, 0, $egal-2;
@@ -759,11 +759,11 @@ sub  _get_sequence{
     $descritpion = (split(/\s+/, $db->header($seq_id_original), 2))[1]; #take header and remove the first element wihch is the seq_id_original
 
     if($sequence eq ""){
-      dual_print( $log, "Problem ! no sequence extracted for - $seq_id_correct !\n", $opt_verbose );  exit;
+      dual_print( $log, "Problem ! no sequence extracted for - $seq_id_correct !\n");  exit;
     }
   }
   else{
-    dual_print( $log, "Problem ! protein ID $seq_id_correct not found into the protein fasta file!\n", $opt_verbose );
+    dual_print( $log, "Problem ! protein ID $seq_id_correct not found into the protein fasta file!\n");
   }
 
   return length($sequence), $seq_id_correct, $descritpion;
@@ -847,7 +847,7 @@ sub check_gene_overlap_gffAlign{
             # CALCUL ONTO THE WHOLE GENE MODEL #
             my @list_tag_l3=('exon');
             if(! exists_keys( $hash_omniscient, ('level3','exon'))){
-              dual_print( $log, "No exon found into the annoation file for feature $gene_id, we will use all the other l3 features\n", $opt_verbose );
+              dual_print( $log, "No exon found into the annoation file for feature $gene_id, we will use all the other l3 features\n");
               foreach my $tag_l3 (keys %{$hash_omniscient->{'level3'}}){
                 push @list_tag_l3,$tag_l3;
               }
@@ -960,7 +960,7 @@ sub check_gene_overlap_gffAlign{
               @list_res = ($gene_id2, $w_overlap12_abs, $w_overlap21_abs, $overlap12_abs, $overlap21_abs, $w_overlap_JD_abs, $overlap_JD_abs , $proteinName, $descritpion);
               }
             catch{
-              dual_print( $log, "We cannot check the real protein length, let's continue without this one: $prot_tag\n", $opt_verbose );
+              dual_print( $log, "We cannot check the real protein length, let's continue without this one: $prot_tag\n");
               #2 -> 1 whole sequence
               #$w_overlap21 = sprintf "%.1f", ($w_overlap*100/$lenght2);
               #$w_overlap21_abs = sprintf "%.1f", ($w_abs_overlap*100/$lenght2);
@@ -986,7 +986,7 @@ sub get_absolute_match{
 
   # We first need to check that the GAP feature is present among the protein attributes
   if(! $feature->has_tag('Gap')){
-    dual_print( $log, "I cannot calculate the absolute match because the tag Gap is absent !\n", $opt_verbose );
+    dual_print( $log, "I cannot calculate the absolute match because the tag Gap is absent !\n");
   }
   else{
 
@@ -1118,7 +1118,7 @@ sub  calcul_match_gap{
           $nuc_polish -= $gap;
         }
         else{
-          dual_print( $log, "Cannot interpret this CIGAR substring: $gap !\n", $opt_verbose );
+          dual_print( $log, "Cannot interpret this CIGAR substring: $gap !\n");
         }
   }
 
@@ -1148,7 +1148,7 @@ sub nuc_gap_val{
     $nuc = substr $gap, 1;
   }
   else{
-    dual_print( $log, "Cannot interpret this CIGAR substring: $gap !\n", $opt_verbose );
+    dual_print( $log, "Cannot interpret this CIGAR substring: $gap !\n");
   }
 
   return $nuc;
@@ -1156,7 +1156,7 @@ sub nuc_gap_val{
 
 sub _print{
   my ($mesage, $optionType) = @_;
-  dual_print( $log, $mesage, $opt_verbose );
+  dual_print( $log, $mesage);
   if ( defined $optionType ) {
       $outputTab[$optionType]->print($mesage);
   }

--- a/bin/agat_sp_manage_IDs.pl
+++ b/bin/agat_sp_manage_IDs.pl
@@ -46,7 +46,7 @@ my $gffout = prepare_gffout( $config, $outfile );
 # Manage $primaryTag
 my %ptagList;
 if ( !@opt_tag ) {
-    dual_print( $log, "We will work on attributes from all features\n", $verbose );
+    dual_print( $log, "We will work on attributes from all features\n");
     $ptagList{'level1'}++;
     $ptagList{'level2'}++;
     $ptagList{'level3'}++;
@@ -55,13 +55,13 @@ else {
     foreach my $tag (@opt_tag) {
         next if $tag eq "";
         if ( $tag eq "all" ) {
-            dual_print( $log, "We will work on attributes from all features\n", $verbose );
+            dual_print( $log, "We will work on attributes from all features\n");
             $ptagList{'level1'}++;
             $ptagList{'level2'}++;
             $ptagList{'level3'}++;
         }
         else {
-            dual_print( $log, "We will work on attributes from all the $tag features\n", $verbose );
+            dual_print( $log, "We will work on attributes from all the $tag features\n");
             $ptagList{ lc($tag) }++;
         }
     }
@@ -79,7 +79,7 @@ my @l3_out_priority = ("tss", "exon", "cds", "tts");
 my ( $hash_omniscient, $hash_mRNAGeneLink ) = slurp_gff3_file_JD({ input => $opt_gff,
                                                                    config => $config
                                                                });
-dual_print( $log, "GFF3 file parsed\n", $verbose );
+dual_print( $log, "GFF3 file parsed\n");
 
 # get spreadfeatire in case of collective option set
 my $spreadfeatures = $hash_omniscient->{'other'}{'level'}{'spread'};
@@ -229,28 +229,28 @@ sub  manage_attributes{
   else{
     $prefix = $opt_prefix;
   }
-  dual_print( $log, "prefix $prefix \n", $verbose );
+  dual_print( $log, "prefix $prefix \n");
 
   #  ----- deal with value independent or not of the feature type--------
   my $tag = $opt_type_dependent ? $primary_tag : 'all';
-  dual_print( $log, "tag: $tag\n", $verbose );
-  dual_print( $log, "primary_tag: $primary_tag\n", $verbose );
+  dual_print( $log, "tag: $tag\n");
+  dual_print( $log, "primary_tag: $primary_tag\n");
 
   if ($opt_tair){
     if ($level eq 'level1') {
       my $ID_number = get_id_number($tag, $level);
       $ID_number = add_ensembl_id_number_prefix($feature, $ID_number) if ($opt_ensembl);
       $result="$prefix$ID_number";
-      dual_print( $log, "tair l1: $result\n", $verbose );
+      dual_print( $log, "tair l1: $result\n");
     }
     if($level eq 'level2'){
       $result = $parent_id.".".$opt_tair_suffix; # add .1, .2,etc to level features
-        dual_print( $log, "tair l2: $result\n", $verbose );
+        dual_print( $log, "tair l2: $result\n");
     }
     elsif ($level eq 'level3'){
       my $ID_number = get_id_number("$parent_id$tag", $level);
       $result = $parent_id."-"."$primary_tag$ID_number";
-      dual_print( $log, "tair l3: $result\n", $verbose );
+      dual_print( $log, "tair l3: $result\n");
     }
 
   }

--- a/bin/agat_sp_manage_UTRs.pl
+++ b/bin/agat_sp_manage_UTRs.pl
@@ -39,7 +39,7 @@ my $log;
 if ( my $log_name = $config->{log_path} ) {
   open( $log, '>', $log_name ) or die "Can not open $log_name for printing: $!";
 }
-dual_print( $log, $header, $opt_verbose );
+dual_print( $log, $header);
 
 my $opt_utr3 = ($mode && $mode eq 'three') ? 1 : 0;
 my $opt_utr5 = ($mode && $mode eq 'five') ? 1 : 0;
@@ -155,7 +155,7 @@ my $ostreamUTRdiscarded = prepare_gffout($config, $ostreamUTRdiscarded_file);
 my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $opt_reffile,
                                                                  config => $config
                                                               });
-dual_print($log, "Parsing Finished\n\n", $opt_verbose);
+dual_print($log, "Parsing Finished\n\n");
 ### END Parse GFF input #
 #########################
 

--- a/bin/agat_sp_manage_attributes.pl
+++ b/bin/agat_sp_manage_attributes.pl
@@ -38,21 +38,21 @@ my $gffout = prepare_gffout( $config, $outfile );
 # Manage $primaryTag
 my @ptagList;
 if ( !$primaryTag or $primaryTag eq "all" ) {
-    dual_print( $log, "We will work on attributes from all features\n", $verbose );
+    dual_print( $log, "We will work on attributes from all features\n");
     push( @ptagList, "all" );
 }
 elsif ( $primaryTag =~ /^level[123]$/ ) {
-    dual_print( $log, "We will work on attributes from all the $primaryTag features\n", $verbose );
+    dual_print( $log, "We will work on attributes from all the $primaryTag features\n");
     push( @ptagList, $primaryTag );
 }
 else {
     @ptagList = split( /,/, $primaryTag );
     foreach my $tag (@ptagList) {
         if ( $tag =~ /^level[123]$/ ) {
-            dual_print( $log, "We will work on attributes from all the $tag features\n", $verbose );
+            dual_print( $log, "We will work on attributes from all the $tag features\n");
         }
         else {
-            dual_print( $log, "We will work on attributes from $tag feature.\n", $verbose );
+            dual_print( $log, "We will work on attributes from $tag feature.\n");
         }
     }
 }
@@ -65,10 +65,10 @@ if ($attributes){
 
   if ($attributes eq "all_attributes"){
     if($add){
-      dual_print( $log, "You cannot use the all_attributes value with the add option. Please change the parameters !\n", $verbose );
+      dual_print( $log, "You cannot use the all_attributes value with the add option. Please change the parameters !\n");
       exit;
     }
-    dual_print( $log, "All attributes will be removed except ID and Parent attributes !\n", $verbose );
+    dual_print( $log, "All attributes will be removed except ID and Parent attributes !\n");
     $attListOk{"all_attributes"}++;
   }
   else{
@@ -80,33 +80,33 @@ if ($attributes){
       if($#attList == 0){ # Attribute alone
         #check for ID attribute
         if(lc($attList[0]) eq "id" and ! $add){
-            dual_print( $log, "It's forbidden to remove the ID attribute in a gff3 file !\n", $verbose );
+            dual_print( $log, "It's forbidden to remove the ID attribute in a gff3 file !\n");
             exit;
         }
         #check for Parent attribute
         if(lc($attList[0]) eq "parent" and ! $add){
           foreach my $tag (@ptagList){
             if($tag ne "gene" and $tag ne "level1"){
-              dual_print( $log, "It's forbidden to remove the $attList[0] attribute to a $tag feature in a gff3 file !\n", $verbose );
+              dual_print( $log, "It's forbidden to remove the $attList[0] attribute to a $tag feature in a gff3 file !\n");
               exit;
             }
           }
         }
         $attListOk{$attList[0]}="null";
         if($add){
-          dual_print( $log, "$attList[0] attribute will be added. The value will be empty.\n", $verbose );
+          dual_print( $log, "$attList[0] attribute will be added. The value will be empty.\n");
         }
         else{
-          dual_print( $log, "$attList[0] attribute will be removed.\n", $verbose );
+          dual_print( $log, "$attList[0] attribute will be removed.\n");
         }
       }
       else{ # Attribute will be replaced/copied with a new tag name
         $attListOk{$attList[0]}=$attList[1];
-        dual_print( $log, "$attList[0] attribute will be replaced by $attList[1].\n", $verbose );
+        dual_print( $log, "$attList[0] attribute will be replaced by $attList[1].\n");
       }
     }
   }
-  dual_print( $log, "\n", $verbose );
+  dual_print( $log, "\n");
 }
 
 
@@ -120,7 +120,7 @@ if ($attributes){
 my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $gff,
                                                                  config => $config
                                                               });
-dual_print( $log, "GFF3 file parsed\n", $verbose );
+dual_print( $log, "GFF3 file parsed\n");
 
 
 foreach my $tag_l1 (keys %{$hash_omniscient->{'level1'}}){

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -107,7 +107,7 @@ my $log;
 if ( my $log_name = $config->{log_path} ) {
     open( $log, '>', $log_name ) or die "Can not open $log_name for printing: $!";
 }
-dual_print( $log, $header, $opt_verbose );
+dual_print( $log, $header);
 
 my $streamBlast = IO::File->new();
 my $streamInter = IO::File->new();
@@ -183,7 +183,7 @@ if ($opt_nameU) {
 # Display
 $ostreamReport->print($stringPrint);
 if ($opt_output) {
-  dual_print($log, "[" . strftime("%H:%M:%S", localtime) . "] $stringPrint\n", $opt_verbose);
+  dual_print($log, "[" . strftime("%H:%M:%S", localtime) . "] $stringPrint\n");
 } # When ostreamReport is a file we have to also display on screen
 
                   #          +------------------------------------------------------+
@@ -197,12 +197,12 @@ if ($opt_output) {
 my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $opt_reffile,
                                                                  config => $config
                                                                 });
-dual_print($log, "[" . strftime("%H:%M:%S", localtime) . "] Parsing Finished\n", $opt_verbose);
+dual_print($log, "[" . strftime("%H:%M:%S", localtime) . "] Parsing Finished\n");
 ### END Parse GFF input #
 #########################
 
 #Print directly what has been read
-dual_print($log, "[" . strftime("%H:%M:%S", localtime) . "] Compute statistics\n", $opt_verbose);
+dual_print($log, "[" . strftime("%H:%M:%S", localtime) . "] Compute statistics\n");
 print_omniscient_statistics(
   {
     input => $hash_omniscient,
@@ -220,7 +220,7 @@ my %allIDs;
 
 if (defined $opt_BlastFile) {
   # read fasta file and save info in memory
-  dual_print($log, "[" . strftime("%H:%M:%S", localtime) . "] Look at the fasta database\n", $opt_verbose);
+  dual_print($log, "[" . strftime("%H:%M:%S", localtime) . "] Look at the fasta database\n");
   $db = Bio::DB::Fasta->new($opt_dataBase);
 
   # JN: Begin parse fasta
@@ -243,10 +243,10 @@ if (defined $opt_BlastFile) {
     }
   } # JN: End parse fasta
 
-  dual_print($log, "[" . strftime("%H:%M:%S", localtime) . "] Parsing Finished\n", $opt_verbose);
+  dual_print($log, "[" . strftime("%H:%M:%S", localtime) . "] Parsing Finished\n");
 
   # parse blast output
-  dual_print( $log, "Reading features from $opt_BlastFile...\n", $opt_verbose );
+  dual_print( $log, "Reading features from $opt_BlastFile...\n");
   parse_blast($streamBlast, $opt_blastEvalue, $hash_mRNAGeneLink);
 }
 
@@ -273,7 +273,7 @@ if (defined $opt_InterproFile) {
 ###########################
 # change FUNCTIONAL information if asked for
 if ($opt_BlastFile || $opt_InterproFile ) {
-  dual_print($log, "[" . strftime("%H:%M:%S", localtime) . "] load FUNCTIONAL information\n", $opt_verbose);
+  dual_print($log, "[" . strftime("%H:%M:%S", localtime) . "] load FUNCTIONAL information\n");
 
   #################
   # == LEVEL 1 == #
@@ -416,7 +416,7 @@ if ($opt_BlastFile || $opt_InterproFile ) {
 ###########################
 # change names if asked for
 if ($opt_nameU || $opt_name ) { #|| $opt_BlastFile || $opt_InterproFile) {
-  dual_print($log, "[" . strftime("%H:%M:%S", localtime) . "] load new IDs\n", $opt_verbose);
+  dual_print($log, "[" . strftime("%H:%M:%S", localtime) . "] load new IDs\n");
 
   my %hash_sortBySeq;
   foreach my $tag_level1 ( keys %{$hash_omniscient->{'level1'}}) {
@@ -630,9 +630,9 @@ $ostreamReport->print("$stringPrint");
 ####################
 # PRINT IN FILES
 ####################
-dual_print($log, "[" . strftime("%H:%M:%S", localtime) . "] Writing result...\n", $opt_verbose);
+dual_print($log, "[" . strftime("%H:%M:%S", localtime) . "] Writing result...\n");
 print_omniscient( {omniscient => $hash_omniscient, output => $ostreamGFF} );
-dual_print($log, "[" . strftime("%H:%M:%S", localtime) . "] End of script.\n", $opt_verbose);
+dual_print($log, "[" . strftime("%H:%M:%S", localtime) . "] End of script.\n");
 
       #########################
       ######### END ###########
@@ -903,15 +903,15 @@ sub parse_blast {
     #Save uniprot id of the best match
    
     $mRNAUniprotIDFromBlast{$l2} = $candidates{$l2}[2];
-    dual_print( $log, "save protein ID for $l2 : " . $candidates{$l2}[2] . "\n", $opt_verbose );
+    dual_print( $log, "save protein ID for $l2 : " . $candidates{$l2}[2] . "\n");
     
     #Save evalu
     $blast_evalue{$l2} = $candidates{$l2}[1];
-    dual_print( $log, "save blast evalue for $l2 : " . $candidates{$l2}[1] . "\n", $opt_verbose );
+    dual_print( $log, "save blast evalue for $l2 : " . $candidates{$l2}[1] . "\n");
 
     # Parse header
     my $header = $candidates{$l2}[0];
-    dual_print( $log, "header: " . $header . "\n", $opt_verbose );
+    dual_print( $log, "header: " . $header . "\n");
 
     if ($header =~ m/(^[^\s]+)\s(.+?(?= \w{2}=))(.+)/) {
       my $protID = $1;
@@ -920,7 +920,7 @@ sub parse_blast {
       $theRest =~ s/\n//g;
       $theRest =~ s/\r//g;
       my $nameGene = undef;
-      dual_print( $log, "description: " . $description . "\n", $opt_verbose );
+      dual_print( $log, "description: " . $description . "\n");
       push ( @{ $mRNAproduct{$l2} }, $description );
 
       #deal with the rest
@@ -929,7 +929,7 @@ sub parse_blast {
       while ($theRest) {
         ($theRest, $tuple) = stringCatcher($theRest);
         my ($type, $value) = split /=/, $tuple;
-        dual_print( $log, "$protID: type:$type --- value:$value\n", $opt_verbose );
+        dual_print( $log, "$protID: type:$type --- value:$value\n");
         $hash_rest{lc($type)} = $value;
       }
 
@@ -1015,7 +1015,7 @@ sub stringCatcher {
 # method to parse Interpro file
 sub parse_interpro_tsv {
   my($file_in, $fileName) = @_;
-  dual_print($log, "Reading features from $fileName...\n", $opt_verbose);
+  dual_print($log, "Reading features from $fileName...\n");
 
   while( my $line = <$file_in>) {
 
@@ -1027,7 +1027,7 @@ sub parse_interpro_tsv {
     my $db_name = $values[3];
     my $db_value = $values[4];
     my $db_tuple = $db_name.":".$db_value;
-    dual_print($log, "Specific dB: " . $db_tuple . "\n", $opt_verbose);
+    dual_print($log, "Specific dB: " . $db_tuple . "\n");
 
     if (! grep( /^\Q$db_tuple\E$/, @{$functionData{$db_name}{$mRNAID}} )) { #to avoid duplicate
       $TotalTerm{$db_name}++;
@@ -1044,7 +1044,7 @@ sub parse_interpro_tsv {
       my $interpro_value = $values[11];
       $interpro_value =~ s/\n//g;
       my $interpro_tuple = "InterPro:".$interpro_value;
-      dual_print($log, "interpro dB: " . $interpro_tuple . "\n", $opt_verbose);
+      dual_print($log, "interpro dB: " . $interpro_tuple . "\n");
       next if $interpro_value eq "-"; #fix 147
 
       if (! grep( /^\Q$interpro_tuple\E$/, @{$functionData{$db_name}{$mRNAID}} )) { #to avoid duplicate
@@ -1064,7 +1064,7 @@ sub parse_interpro_tsv {
       $go_flat_list =~ s/\n//g;
       my @go_list = split(/\|/, $go_flat_list); #cut at character |
       foreach my $go_tuple (@go_list) {
-        dual_print($log, "GO term: " . $go_tuple . "\n", $opt_verbose);
+        dual_print($log, "GO term: " . $go_tuple . "\n");
         next if $go_tuple eq "-"; #fix kira
         
         if (! grep( /^\Q$go_tuple\E$/, @{$functionData{$db_name}{$mRNAID}} )) { #to avoid duplicate
@@ -1087,7 +1087,7 @@ sub parse_interpro_tsv {
       foreach my $pathway_tuple (@pathway_list) {
         my @tuple = split(/:/, $pathway_tuple); #cut at character :
         my $db_name = $tuple[0];
-        dual_print($log, "pathway info: " . $pathway_tuple . "\n", $opt_verbose);
+        dual_print($log, "pathway info: " . $pathway_tuple . "\n");
         next if ($pathway_tuple eq "-"); # avoid empty pathway tuple
         if (! grep( /^\Q$pathway_tuple\E$/, @{$functionData{$db_name}{$mRNAID}} ) ) { # to avoid duplicate
           $TotalTerm{$db_name}++;

--- a/bin/agat_sp_manage_introns.pl
+++ b/bin/agat_sp_manage_introns.pl
@@ -30,7 +30,7 @@ my $log;
 if ( my $log_name = $config->{log_path} ) {
     open( $log, '>', $log_name ) or die "Can not open $log_name for printing: $!";
 }
-dual_print( $log, $header, $opt_verbose );
+dual_print( $log, $header);
 
 # #######################
 # # START Manage Option #
@@ -105,19 +105,19 @@ if($opt_plot){
 my %introns;
 foreach my $file (@opt_files){
 
-  dual_print($log, "Reading $file\n", $opt_verbose);
+  dual_print($log, "Reading $file\n");
 
   ######################
   ### Parse GFF input #
   my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $file,
                                                                    config => $config
                                                               });
-  dual_print($log, "Parsing Finished\n\n", $opt_verbose);
+  dual_print($log, "Parsing Finished\n\n");
   ### END Parse GFF input #
   #########################
 
   #print statistics
-        dual_print($log, "Compute statistics\n", $opt_verbose);
+        dual_print($log, "Compute statistics\n");
 	print_omniscient_statistics({
             input   => $hash_omniscient,
             output  => $ostreamReport,

--- a/bin/agat_sp_merge_annotations.pl
+++ b/bin/agat_sp_merge_annotations.pl
@@ -23,7 +23,7 @@ my $log;
 if ( my $log_name = $config->{log_path} ) {
     open( $log, '>', $log_name ) or die "Can not open $log_name for printing: $!";
 }
-dual_print( $log, $header, $opt_verbose );
+dual_print( $log, $header);
 
 my @expanded_files;
 foreach my $file_or_dir (@opt_files) {
@@ -55,7 +55,7 @@ my $file1 = shift @opt_files;
 my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $file1,
                                                                  config => $config
                                                               });
-dual_print($log, "$file1 GFF3 file parsed\n", $opt_verbose);
+dual_print($log, "$file1 GFF3 file parsed\n");
 info_omniscient($hash_omniscient, $log, $opt_verbose);
 
 #Add the features of the other file in the first omniscient. It takes care of name to not have duplicates
@@ -63,22 +63,22 @@ foreach my $next_file (@opt_files){
   my ($hash_omniscient2, $hash_mRNAGeneLink2) = slurp_gff3_file_JD({ input => $next_file,
 	                                                                   config => $config
                                                                   });
-  dual_print($log, "$next_file GFF3 file parsed\n", $opt_verbose);
+  dual_print($log, "$next_file GFF3 file parsed\n");
   info_omniscient($hash_omniscient2, $log, $opt_verbose);
 
   #merge annotation is taking care of Uniq name. Does not look if mRNA are identic or so one, it will be handle later.
   merge_omniscients($hash_omniscient, $hash_omniscient2);
-  dual_print($log, "\nTotal raw data of files together:\n", $opt_verbose);
+  dual_print($log, "\nTotal raw data of files together:\n");
   info_omniscient($hash_omniscient, $log, $opt_verbose);
 }
 
 # Now all the feature are in the same omniscient
 # We have to check the omniscient to merge overlaping genes together. Identical isoforms will be removed
-dual_print($log, "\nNow merging overlaping loci, and removing identical isoforms:\n", $opt_verbose);
+dual_print($log, "\nNow merging overlaping loci, and removing identical isoforms:\n");
 merge_overlap_loci(undef, $hash_omniscient, $hash_mRNAGeneLink, undef);
 
 
-dual_print($log, "\nfinal result:\n", $opt_verbose);
+dual_print($log, "\nfinal result:\n");
 info_omniscient($hash_omniscient, $log, $opt_verbose);
 
 ########

--- a/bin/agat_sp_move_attributes_within_records.pl
+++ b/bin/agat_sp_move_attributes_within_records.pl
@@ -36,7 +36,7 @@ my $log;
 if ( my $log_name = $config->{log_path} ) {
     open( $log, '>', $log_name ) or die "Can not open $log_name for printing: $!";
 }
-dual_print( $log, $header, $opt_verbose );
+dual_print( $log, $header);
 
 ###############
 # Manage Output
@@ -105,7 +105,7 @@ my @attListOk;
 if ($attributes){
 
   if ($attributes eq "all_attributes"){
-    dual_print($log, "All attributes will be used !\n", $opt_verbose);
+    dual_print($log, "All attributes will be used !\n");
     $attHashOk{"all_attributes"}++;
   }
   else{
@@ -117,14 +117,14 @@ if ($attributes){
       }
     }
   }
-  dual_print($log, "\n", $opt_verbose);
+  dual_print($log, "\n");
 }
 
 # start with some interesting information
 my $stringPrint = strftime "%m/%d/%Y at %Hh%Mm%Ss", localtime;
 $stringPrint .= "\nusage: $0 @copyARGV\n";
 $stringPrint .= "The attributes @attListOk from the following feature types: $print_feature_string_copy will be copy pasted to the following feature types: $print_feature_string_paste.\n";
-dual_print($log, $stringPrint, $opt_verbose);
+dual_print($log, $stringPrint);
 
                           #######################
 # >>>>>>>>>>>>>>>>>>>>>>>>#        MAIN         #<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
@@ -135,7 +135,7 @@ my %all_cases = ('l1' => 0, 'l2' => 0, 'l3' => 0, 'all' => 0);
 my ($hash_omniscient, $hash_mRNAGeneLink) =  slurp_gff3_file_JD({ input => $opt_gff,
                                                                   config => $config
                                                                 });
-dual_print($log, "Parsing Finished\n", $opt_verbose);
+dual_print($log, "Parsing Finished\n");
 ### END Parse GFF input #
 #########################
 # sort by seq id

--- a/bin/agat_sp_prokka_fix_fragmented_gene_annotations.pl
+++ b/bin/agat_sp_prokka_fix_fragmented_gene_annotations.pl
@@ -88,7 +88,7 @@ my $log;
 if ( my $log_name = $config->{log_path} ) {
     open( $log, '>', $log_name ) or die "Can not open $log_name for printing: $!";
 }
-dual_print($log, $header, $verbose);
+dual_print($log, $header);
 
 # Check codon table
 $codonTable = get_proper_codon_table($codonTable, $log, $verbose);
@@ -144,7 +144,7 @@ $hamap_size = lc($hamap_size);
 my ($hash_omniscient, $hash_mRNAGeneLink) =slurp_gff3_file_JD({ input => $gff,
                                                                 config => $config
                                                               });
-dual_print($log, "GFF3 file parsed\n", $verbose);
+dual_print($log, "GFF3 file parsed\n");
 
 
 ####################
@@ -154,7 +154,7 @@ my $db_fasta = Bio::DB::Fasta->new($file_fasta);
 my %all_db_fasta_IDs;
 my @ids_db_fasta     = $db_fasta->get_all_primary_ids;
 foreach my $id (@ids_db_fasta ){$all_db_fasta_IDs{lc($id)}=$id;}
-dual_print($log, "Fasta file parsed\n", $verbose);
+dual_print($log, "Fasta file parsed\n");
 
 
 my $db_db = Bio::DB::Fasta->new($file_db);
@@ -162,7 +162,7 @@ my $db_db = Bio::DB::Fasta->new($file_db);
 my %all_db_db_IDs;
 my @ids_db_db     = $db_db->get_all_primary_ids;
 foreach my $id (@ids_db_db ){$all_db_db_IDs{lc($id)}=$id;}
-dual_print($log, "db file parsed\n", $verbose);
+dual_print($log, "db file parsed\n");
 
 ####################
 
@@ -413,7 +413,7 @@ $stringprint .= "\nWhen a FRAGS is detected you shoud think about few things...\
 								"In a case of pseudogene, if the pseudogene is not recent, other mutations should be accumulated in the sequence after the first premature stop codon...\n";
 $stringprint .=  "\nBye Bye.\n";
 
-dual_print($log, $stringprint, $verbose);
+dual_print($log, $stringprint);
 print $report $stringprint;
 
 
@@ -440,17 +440,17 @@ sub check_protein_size_congruency{
 	$total_putative_gene_fixed_before += @$listGeneToMerge;
 	$total_putative_gene_fixed_after ++;
 
-        dual_print($log, "\nBased on their names and the fact they are conitguous, those ".@$listGeneToMerge." genes might be merged: @$listGeneNameToMerge \n", $verbose);
+        dual_print($log, "\nBased on their names and the fact they are conitguous, those ".@$listGeneToMerge." genes might be merged: @$listGeneNameToMerge \n");
   retrieve_expected_protein_length($obj_case);
 
 	my $expected_protein_length = $obj_case->{expected_length};
 	if ($expected_protein_length){
-                dual_print($log, "Average of the expected length = $expected_protein_length \n", $verbose);
+                dual_print($log, "Average of the expected length = $expected_protein_length \n");
 
 	 	#add 10 percent to expected protein $seq_lengt
 	 	my $expected_protein_length_plus10 = int (($expected_protein_length * 110) / 100);
 		$obj_case->{expected_length_10} = $expected_protein_length_plus10;
-                dual_print($log, "Average of the expected length + 20 % = $expected_protein_length_plus10 \n", $verbose);
+                dual_print($log, "Average of the expected length + 20 % = $expected_protein_length_plus10 \n");
 
 		# need to get the oervlap to remove from the calculated length
 		my $aa_overlap = get_overlap($obj_case);
@@ -462,10 +462,10 @@ sub check_protein_size_congruency{
 	 	}
 		$total_current_size -= $aa_overlap; # remove all overlap parts
 		$obj_case->{current_aa_length_together} = $total_current_size;
-                dual_print($log, "current length adding all genes together (and removing overlaping part): $total_current_size\n", $verbose);
+                dual_print($log, "current length adding all genes together (and removing overlaping part): $total_current_size\n");
 
 	 	if ($total_current_size < $expected_protein_length_plus10){
-                        dual_print($log, "$total_current_size < $expected_protein_length_plus10 => Let's merge them. (The length of the appended proteins is shorter than the size of the protein use for the inference)\n\n", $verbose);
+                        dual_print($log, "$total_current_size < $expected_protein_length_plus10 => Let's merge them. (The length of the appended proteins is shorter than the size of the protein use for the inference)\n\n");
 			$congruent_size++;
 			$size_congruency = 1;
 		}
@@ -474,7 +474,7 @@ sub check_protein_size_congruency{
 		}
 	}
 	else{
-                dual_print($log, "No expected size found - skip the case\n", $verbose);
+                dual_print($log, "No expected size found - skip the case\n");
 	}
  return $size_congruency;
 }
@@ -499,10 +499,10 @@ sub merge_case{
 		$gff_shift{$gene_feature1->seq_id}{$value_insert_position}=$value_insert_size; #keep track of shifts
 		my $sequence = $seqObj->seq();
 
-                dual_print($log, "add N x $value_insert_size at position $value_insert_position\n", $verbose);
-                dual_print($log, "piece of sequence before: ".substr($sequence, $value_insert_before + $value_insert_position - 10, 20)."\n", $verbose);
+                dual_print($log, "add N x $value_insert_size at position $value_insert_position\n");
+                dual_print($log, "piece of sequence before: ".substr($sequence, $value_insert_before + $value_insert_position - 10, 20)."\n");
                 substr($sequence, $value_insert_before + $value_insert_position-1, 1) = "N" x ($value_insert_size+1);
-                dual_print($log, "piece of sequence after: ".substr($sequence, $value_insert_before + $value_insert_position - 10, 20)."\n", $verbose);
+                dual_print($log, "piece of sequence after: ".substr($sequence, $value_insert_before + $value_insert_position - 10, 20)."\n");
 		$seqObj->seq($sequence);
 
 		# Should I add Pseudo attribure?
@@ -561,16 +561,16 @@ sub check_long_orf_if_can_be_merged{
 		my $gene_feature1 = shift @listGene;
 		my $gene_feature2 = $listGene[0];
 		my $intergenic = 1;
-                dual_print($log, $gene_feature1->gff_string()."\n", $verbose);
-                dual_print($log, $gene_feature2->gff_string()."\n", $verbose);
+                dual_print($log, $gene_feature1->gff_string()."\n");
+                dual_print($log, $gene_feature2->gff_string()."\n");
                 if($gene_feature1->end > $gene_feature2->start){
-                        dual_print($log, "No intergenic region!\n", $verbose);
+                        dual_print($log, "No intergenic region!\n");
                         $intergenic=undef;
 
                 }
                 else{
                         my $intergenic_region = [$gene_feature1->end,$gene_feature2->start];
-                        dual_print($log, "intergenic_region = @$intergenic_region\n", $verbose);
+                        dual_print($log, "intergenic_region = @$intergenic_region\n");
                 }
 
 		my $ID_correct = $all_db_fasta_IDs{lc($gene_feature1->seq_id)};
@@ -605,9 +605,9 @@ sub check_long_orf_if_can_be_merged{
 				# --- this overlaping part will be used as intergenec region to shift frame
 
 				my $overlap_part = $gene_feature1->end - $gene_feature2->start + 1;
-                                dual_print($log, "overlap_part $overlap_part\n", $verbose);
+                                dual_print($log, "overlap_part $overlap_part\n");
                                 my $to_shrink = 3 + ( 3 - ($overlap_part % 3) );
-                                dual_print($log, "to_shrink (last codon plus offset needed to be in frame:) $to_shrink\n", $verbose);
+                                dual_print($log, "to_shrink (last codon plus offset needed to be in frame:) $to_shrink\n");
 				my $subseq1 = $db_fasta->seq($ID_correct, $gene_feature1->start, ($gene_feature2->start - $to_shrink - 1 ));
 				$subseq1_cds_obj = Bio::Seq->new(-seq => $subseq1, -alphabet => 'dna' );
 				$subseq1_cds_obj = $subseq1_cds_obj->revcom();
@@ -658,9 +658,9 @@ sub check_long_orf_if_can_be_merged{
 			}
 			else{
 				my $overlap_part = $gene_feature1->end - $gene_feature2->start + 1;
-                                dual_print($log, "overlap_part $overlap_part\n", $verbose);
+                                dual_print($log, "overlap_part $overlap_part\n");
                                 my $to_shrink = 3 + (  3 - ( $overlap_part % 3 ) ) ;
-                                dual_print($log, "to_shrink (last codon plus offset needed to be in frame:) $to_shrink\n", $verbose);
+                                dual_print($log, "to_shrink (last codon plus offset needed to be in frame:) $to_shrink\n");
 				my $subseq2 = $db_fasta->seq($ID_correct, $gene_feature1->end + $to_shrink + 1, $gene_feature2->end );
 				$subseq2_cds_obj = Bio::Seq->new(-seq => $subseq2, -alphabet => 'dna' );
 			}
@@ -673,11 +673,11 @@ sub check_long_orf_if_can_be_merged{
 		if ($gene_feature1->strand == -1 or $gene_feature1->strand eq "-"){
 			my $found = 0;
 			my $prot_second=$subseq1_prot_obj;
-                        dual_print($log, "Minus strand swithching seq1 and seq2\n", $verbose);
-                        dual_print($log, "full seq1: ".$subseq2_prot_obj_full->seq."\n", $verbose);
-                        dual_print($log, "subseq1: ".$subseq2_prot_obj->seq."\n", $verbose);
-                        dual_print($log, "full seq2: ".$subseq1_prot_obj_full->seq."\n", $verbose);
-                        dual_print($log, "subseq2: ".$subseq1_prot_obj->seq."\n", $verbose);
+                        dual_print($log, "Minus strand swithching seq1 and seq2\n");
+                        dual_print($log, "full seq1: ".$subseq2_prot_obj_full->seq."\n");
+                        dual_print($log, "subseq1: ".$subseq2_prot_obj->seq."\n");
+                        dual_print($log, "full seq2: ".$subseq1_prot_obj_full->seq."\n");
+                        dual_print($log, "subseq2: ".$subseq1_prot_obj->seq."\n");
 
 			#getting part1 for merging
 			if( exists $all_db_fasta_IDs{lc($gene_feature1->seq_id)}){
@@ -688,9 +688,9 @@ sub check_long_orf_if_can_be_merged{
 				my $cds_obj1 = Bio::Seq->new(-seq => $seq1, -alphabet => 'dna' );
 				$cds_obj1 = $cds_obj1->revcom();
 				my $prot_obj1 = $cds_obj1->translate(-codontable_id => $codonTable) ;
-                                dual_print($log, "Test frame 1 : ".$prot_obj1->seq."\n", $verbose);
+                                dual_print($log, "Test frame 1 : ".$prot_obj1->seq."\n");
                                 if (index($prot_obj1->seq, $prot_second->seq) != -1) {
-                                        dual_print($log, "frame 1 contains protein2\nIs the codon stop from the first gene real? Does the codon code for a stop codon? Is there a substition? Is it a pseudogene?\n", $verbose);
+                                        dual_print($log, "frame 1 contains protein2\nIs the codon stop from the first gene real? Does the codon code for a stop codon? Is there a substition? Is it a pseudogene?\n");
 					$found++;
 					$case_frame1++;
 					$merged++ if ($pseudo);
@@ -702,9 +702,9 @@ sub check_long_orf_if_can_be_merged{
 				my $cds_obj2 = Bio::Seq->new(-seq => $seq2, -alphabet => 'dna' );
 				$cds_obj2 = $cds_obj2->revcom();
 				my $prot_obj2 = $cds_obj2->translate(-codontable_id => $codonTable) ;
-                                dual_print($log, "Test frame 2 : ".$prot_obj2->seq."\n", $verbose);
+                                dual_print($log, "Test frame 2 : ".$prot_obj2->seq."\n");
                                 if (index($prot_obj2->seq, $prot_second->seq) != -1) {
-                                        dual_print($log, "frame 2 contains protein2\n", $verbose);
+                                        dual_print($log, "frame 2 contains protein2\n");
 					push @{$obj_case->{insert_size}}, 1;
 					push @{$obj_case->{total_insert_before}}, $total_insert_before ;
 					$total_insert_before += 1;
@@ -720,9 +720,9 @@ sub check_long_orf_if_can_be_merged{
 				my $cds_obj3 = Bio::Seq->new(-seq => $seq3, -alphabet => 'dna' );
 				$cds_obj3 = $cds_obj3->revcom();
 				my $prot_obj3 = $cds_obj3->translate(-codontable_id => $codonTable) ;
-                                dual_print($log, "Test frame 3 : ".$prot_obj3->seq."\n", $verbose);
+                                dual_print($log, "Test frame 3 : ".$prot_obj3->seq."\n");
                                 if (index($prot_obj3->seq, $prot_second->seq) != -1) {
-                                        dual_print($log, "frame 3 contains protein2\n", $verbose);
+                                        dual_print($log, "frame 3 contains protein2\n");
 					push @{$obj_case->{insert_size}}, 2;
 					push @{$obj_case->{total_insert_before}}, $total_insert_before;
 					$total_insert_before += 2;
@@ -734,7 +734,7 @@ sub check_long_orf_if_can_be_merged{
 				}
 			}
 			else{
-                                dual_print($log, "ERROR ".$gene_feature1->seq_id." not found among the db!\n", $verbose);
+                                dual_print($log, "ERROR ".$gene_feature1->seq_id." not found among the db!\n");
 			}
 			if (! $found){
                                 my $msg = "subseq2 not found in any frame. There is a problem when preparing subseq2\n";
@@ -742,17 +742,17 @@ sub check_long_orf_if_can_be_merged{
                                 warn $msg if $verbose;
 			}
 			elsif($found>1){
-                                dual_print($log, "interesting, subseq2 found in $found frames\n", $verbose);
+                                dual_print($log, "interesting, subseq2 found in $found frames\n");
 			}
 		}
 		# ---- strand + ----
 		else{
 			my $found = 0;
 			my $prot_second=$subseq2_prot_obj;
-                        dual_print($log, "full seq1: ".$subseq1_prot_obj_full->seq."\n", $verbose);
-                        dual_print($log, "subseq1: ".$subseq1_prot_obj->seq."\n", $verbose);
-                        dual_print($log, "full seq2: ".$subseq2_prot_obj_full->seq."\n", $verbose);
-                        dual_print($log, "subseq2: ".$subseq2_prot_obj->seq."\n", $verbose);
+                        dual_print($log, "full seq1: ".$subseq1_prot_obj_full->seq."\n");
+                        dual_print($log, "subseq1: ".$subseq1_prot_obj->seq."\n");
+                        dual_print($log, "full seq2: ".$subseq2_prot_obj_full->seq."\n");
+                        dual_print($log, "subseq2: ".$subseq2_prot_obj->seq."\n");
 
 			#getting part1 for merging
 			if( exists $all_db_fasta_IDs{lc($gene_feature1->seq_id)}){
@@ -762,9 +762,9 @@ sub check_long_orf_if_can_be_merged{
 				my $seq1 = $seq."N".$db_fasta->seq($ID_correct, $gene_feature1->end + 1, $gene_feature2->end);
 				my $cds_obj1 = Bio::Seq->new(-seq => $seq1, -alphabet => 'dna' );
 				my $prot_obj1 = $cds_obj1->translate(-codontable_id => $codonTable) ;
-                                dual_print($log, "Test frame 1 : ".$prot_obj1->seq."\n", $verbose);
+                                dual_print($log, "Test frame 1 : ".$prot_obj1->seq."\n");
                                 if (index($prot_obj1->seq, $prot_second->seq) != -1) {
-                                        dual_print($log, "frame 1 contains protein2\nIs the codon stop from the first gene real? Does the codon code for a stop codon? Is there a substition? Is it a pseudogene?\n", $verbose);
+                                        dual_print($log, "frame 1 contains protein2\nIs the codon stop from the first gene real? Does the codon code for a stop codon? Is there a substition? Is it a pseudogene?\n");
 					$found++;
 					$case_frame1++;
 					$merged++ if ($pseudo);
@@ -775,9 +775,9 @@ sub check_long_orf_if_can_be_merged{
 				my $seq2 = $seq."NN".$db_fasta->seq($ID_correct, $gene_feature1->end + 1, $gene_feature2->end);
 				my $cds_obj2 = Bio::Seq->new(-seq => $seq2, -alphabet => 'dna' );
 				my $prot_obj2 = $cds_obj2->translate(-codontable_id => $codonTable) ;
-                                dual_print($log, "frame 2 : ".$prot_obj2->seq."\n", $verbose);
+                                dual_print($log, "frame 2 : ".$prot_obj2->seq."\n");
                                 if (index($prot_obj2->seq, $prot_second->seq) != -1) {
-                                        dual_print($log, "frame 2 contains protein2\n", $verbose);
+                                        dual_print($log, "frame 2 contains protein2\n");
 					push @{$obj_case->{insert_size}}, 1;
 					push @{$obj_case->{total_insert_before}}, $total_insert_before;
 					$total_insert_before += 1;
@@ -792,9 +792,9 @@ sub check_long_orf_if_can_be_merged{
 				my $seq3 = $seq."NNN".$db_fasta->seq($ID_correct, $gene_feature1->end + 1, $gene_feature2->end);
 				my $cds_obj3 = Bio::Seq->new(-seq => $seq3, -alphabet => 'dna' );
 				my $prot_obj3 = $cds_obj3->translate(-codontable_id => $codonTable) ;
-                                dual_print($log, "frame 3 : ".$prot_obj3->seq."\n", $verbose);
+                                dual_print($log, "frame 3 : ".$prot_obj3->seq."\n");
                                 if (index($prot_obj3->seq, $prot_second->seq) != -1) {
-                                        dual_print($log, "frame 3 contains protein2\n", $verbose);
+                                        dual_print($log, "frame 3 contains protein2\n");
 					push @{$obj_case->{insert_size}}, 2;
 					push @{$obj_case->{total_insert_before}}, $total_insert_before;
 					$total_insert_before += 2;
@@ -810,11 +810,11 @@ sub check_long_orf_if_can_be_merged{
                                 warn $msg if $verbose;
 				}
 				elsif($found>1){
-                                        dual_print($log, "interesting, subseq2 found in $found frames\n", $verbose);
+                                        dual_print($log, "interesting, subseq2 found in $found frames\n");
 				}
 			}
 			else{
-                                dual_print($log, "ERROR ".$gene_feature1->seq_id." not found among the db!\n", $verbose);
+                                dual_print($log, "ERROR ".$gene_feature1->seq_id." not found among the db!\n");
 			}
 		}
 	}
@@ -835,11 +835,11 @@ sub get_overlap {
 
 		if($gene_feature1->end > $gene_feature2->start){
 			my $overlap_region = $gene_feature1->end - $gene_feature2->start + 1;
-                        dual_print($log, "overlap_region nt = $overlap_region\n", $verbose);
+                        dual_print($log, "overlap_region nt = $overlap_region\n");
 			$overlap += ($overlap_region * 2); # overlap touch both gene
 		}
 		else{
-                        dual_print($log, "No overlap_region region!\n", $verbose);
+                        dual_print($log, "No overlap_region region!\n");
 			$overlap+=0;
 		}
 	}
@@ -862,7 +862,7 @@ sub retrieve_expected_protein_length{
 		$obj_sub_gene->{current_dna_length} = $gene_feature->end - $gene_feature->start + 1;
 		$obj_sub_gene->{current_aa_length} = $gene_size;
 
-                dual_print($log, $gene_feature->_tag_value('Name')." has a AA size of: $gene_size\n", $verbose);
+                dual_print($log, $gene_feature->_tag_value('Name')." has a AA size of: $gene_size\n");
 
 		if ($gene_feature->has_tag("inference")){
 			my @inference_atts = $gene_feature->get_tag_values("inference");
@@ -891,22 +891,22 @@ sub retrieve_expected_protein_length{
 		my $prot_name = $obj_sub_gene->{inference_value};
 
 		if (lc($obj_sub_gene->{inference_db}) eq "uniprotkb"){
-                        dual_print($log, "Inference made with Uniprot, looking for protein size: $prot_name\n", $verbose);
+                        dual_print($log, "Inference made with Uniprot, looking for protein size: $prot_name\n");
 			if( exists $all_db_db_IDs{lc($prot_name)}){
 				my $protID_correct = $all_db_db_IDs{lc($prot_name)};
 				$obj_sub_gene->{inference_aa_length} = $db_db->length( $protID_correct );
 				$obj_sub_gene->{inference_aa_seq} = $db_db->seq($protID_correct);
 			}
 			else{
-                                dual_print($log, "ERROR $prot_name not found among the db!\n", $verbose);
+                                dual_print($log, "ERROR $prot_name not found among the db!\n");
 			}
 		}
 		elsif (lc($obj_sub_gene->{inference_db}) eq "hamap"){
-                        dual_print($log, "Inference made with HAMAP, looking for protein size using internet: $prot_name\n", $verbose);
+                        dual_print($log, "Inference made with HAMAP, looking for protein size using internet: $prot_name\n");
 			fetcher_HAMAP($obj_sub_gene) if (! $skip_hamap);
 		}
 		else{
-                        dual_print($log, "Inference made with ".$obj_sub_gene->{inference_db}.", not yet implemented\n", $verbose);
+                        dual_print($log, "Inference made with ".$obj_sub_gene->{inference_db}.", not yet implemented\n");
 		}
 
 		#I have a length, let's check if we can merge the case
@@ -914,7 +914,7 @@ sub retrieve_expected_protein_length{
 			push @{$obj_case->{list_aa_size}}, $obj_sub_gene->{inference_aa_length};
 			$total_size += $obj_sub_gene->{inference_aa_length};
 			$nb_prot++;
-                        dual_print($log, "AA length found ".$obj_sub_gene->{inference_aa_length}." \n", $verbose);
+                        dual_print($log, "AA length found ".$obj_sub_gene->{inference_aa_length}." \n");
 		}
 	}
 	$obj_case->{expected_length} = int($total_size/$nb_prot) if $nb_prot;
@@ -936,7 +936,7 @@ sub fetcher_HAMAP {
 				my $string = $response->decoded_content;
 				#print $string."\n";
 				if ( $string =~ /.*<td>(.*)amino acids<\/td>.*/){
-                                        dual_print($log, "size range: $1\n", $verbose);
+                                        dual_print($log, "size range: $1\n");
 					my @data = split /-/, $1 ;
 
 					if($hamap_size eq "low"){
@@ -955,12 +955,12 @@ sub fetcher_HAMAP {
 
 				}
 				else{
-                                        dual_print($log, "No size found for $id\n", $verbose);
+                                        dual_print($log, "No size found for $id\n");
 				}
 			$obj_sub_gene->{inference_aa_length} = $size;
 		}
 		else {
-                        dual_print($log, $response->status_line."\n", $verbose);
+                        dual_print($log, $response->status_line."\n");
                         die;
 		}
 }

--- a/bin/agat_sp_sensitivity_specificity.pl
+++ b/bin/agat_sp_sensitivity_specificity.pl
@@ -35,20 +35,20 @@ my $report = prepare_fileout($outfile);
 
 ######################
 ### Parse GFF input #
-dual_print( $log, "Parsing $gff1\n", $verbose );
+dual_print( $log, "Parsing $gff1\n");
 my ($omniscient1, $hash_mRNAGeneLink1) = slurp_gff3_file_JD({ input => $gff1,
                                                               config => $config
                                                               });
-dual_print( $log, "\n\nParsing $gff2\n", $verbose );
+dual_print( $log, "\n\nParsing $gff2\n");
 my ($omniscient2, $hash_mRNAGeneLink2) = slurp_gff3_file_JD({ input => $gff2,
                                                               config => $config
                                                               });
-dual_print( $log, "-- Files parsed --\n", $verbose );
+dual_print( $log, "-- Files parsed --\n");
 
 
 my $sortBySeq1 = gather_and_sort_l1_location_by_seq_id_and_strand_chimere($omniscient1);
 my $sortBySeq2 = gather_and_sort_l1_location_by_seq_id_and_strand_chimere($omniscient2);
-dual_print( $log, "GFF3 files sorted\n", $verbose );
+dual_print( $log, "GFF3 files sorted\n");
 
 #get top feature first
 my $top_features = get_feature_type_by_agat_value($omniscient1, 'level1', 'topfeature');
@@ -148,7 +148,7 @@ foreach my $sortBySeq ($sortBySeq1, $sortBySeq2){
 # Will merge same location types that overlap
 #use Data::Dumper; print "\n\n\n all locations1 sored: ".Dumper($flattened_locations1) ;
 #use Data::Dumper; print "\n\n\n all locations2 sored: ".Dumper($flattened_locations2) ;
-dual_print( $log, "Now flattening the locations\n", $verbose );
+dual_print( $log, "Now flattening the locations\n");
 foreach my $flattened_locations ( $flattened_locations1, $flattened_locations2 ){
   foreach my $locusID (  keys %{$flattened_locations} ){
     foreach my $chimere_type ( keys %{$flattened_locations->{$locusID}}){
@@ -160,11 +160,11 @@ foreach my $flattened_locations ( $flattened_locations1, $flattened_locations2 )
           $all{$chimere_type}{$level}{$type}{'FP'}=0;
             $all{$chimere_type}{$level}{$type}{'TP'}=0;
 
-            dual_print( $log, "investigate $type\n", $verbose );
+            dual_print( $log, "investigate $type\n");
           my @newlocations;
           my $previous_location = undef;
           foreach my $location ( sort {$a->[0] <=> $b->[0]} @{$flattened_locations->{$locusID}{$chimere_type}{$level}{$type}} ){
-              dual_print( $log, "investigate @$location\n", $verbose );
+              dual_print( $log, "investigate @$location\n");
             # first round
             if (! $previous_location){
                push @newlocations, $location;
@@ -205,65 +205,65 @@ foreach my $flattened_locations ( $flattened_locations1, $flattened_locations2 )
 # ------------------------------------------------------------------------------
 #use Data::Dumper; print "\n\n\n flattened_locations1: ".Dumper($flattened_locations1) ;
 #use Data::Dumper; print "\n\n\n flattened_locations2: ".Dumper($flattened_locations2) ;
-dual_print( $log, "COMPARE FLATENED LOCATIONS\n", $verbose );
+dual_print( $log, "COMPARE FLATENED LOCATIONS\n");
 foreach my $locusID ( sort  keys %{$flattened_locations1} ){
   foreach my $chimere_type ( sort keys %{$flattened_locations1->{$locusID}} ){
     foreach my $level ( sort keys %{$flattened_locations1->{$locusID}{$chimere_type}} ){
       foreach my $type ( sort keys %{$flattened_locations1->{$locusID}{$chimere_type}{$level}} ){
 
-        dual_print( $log, "\n========================================================\nGENERAL loop over $locusID $chimere_type $level <<$type>>\n", $verbose );
+        dual_print( $log, "\n========================================================\nGENERAL loop over $locusID $chimere_type $level <<$type>>\n");
         if ( exists_keys ($flattened_locations1, ($locusID,$chimere_type,$level,$type) ) ){ # We have to remove the locations2 to check at the end the FP that are remaining (only prenent in annotationB)
 
           if ($verbose) {
-            dual_print( $log, "list of location1 $level $type: ", $verbose );
+            dual_print( $log, "list of location1 $level $type: ");
             foreach my $array ( @{$flattened_locations1->{$locusID}{$chimere_type}{$level}{$type}} ){
-              dual_print( $log, "@{$array} - ", $verbose );
+              dual_print( $log, "@{$array} - ");
             }
-            dual_print( $log, "\n", $verbose );
+            dual_print( $log, "\n");
           }
           while ( my $location1 = shift  @{$flattened_locations1->{$locusID}{$chimere_type}{$level}{$type}} ){ # here the location are supposed to be sorted
-            dual_print( $log, "location1 investigated:  @$location1\n", $verbose );
+            dual_print( $log, "location1 investigated:  @$location1\n");
 
             # keep track last locationA
             my $last_locationA = undef;
             $last_locationA = 1 if (scalar @{$flattened_locations1->{$locusID}{$chimere_type}{$level}{$type}} == 0);
-            dual_print( $log, "Lets go for last LocationA !!\n", $verbose ) if $last_locationA;
+            dual_print( $log, "Lets go for last LocationA !!\n") if $last_locationA;
 
             if ( exists_keys ($flattened_locations2, ($locusID,$chimere_type,$level,$type) ) and
                 scalar @{$flattened_locations2->{$locusID}{$chimere_type}{$level}{$type}} != 0 ){ # and
 
               while ( scalar @{$flattened_locations2->{$locusID}{$chimere_type}{$level}{$type}} != 0 ){
                 if ($verbose) {
-                  dual_print( $log, " list of location2 $level $type: ", $verbose );
+                  dual_print( $log, " list of location2 $level $type: ");
                   foreach my $array ( @{$flattened_locations2->{$locusID}{$chimere_type}{$level}{$type}} ){
-                    dual_print( $log, "@{$array} - ", $verbose );
+                    dual_print( $log, "@{$array} - ");
                   }
-                  dual_print( $log, "\n", $verbose );
+                  dual_print( $log, "\n");
                 }
 
                 my $location2 = $flattened_locations2->{$locusID}{$chimere_type}{$level}{$type}->[0];
-                dual_print( $log, " location2 investigated:  @$location2\n", $verbose );
-                dual_print( $log, " Original TP: ".$all{$chimere_type}{$level}{$type}{'TP'}."\n", $verbose );
-                dual_print( $log, " Original FN: ".$all{$chimere_type}{$level}{$type}{'FN'}."\n", $verbose );
-                dual_print( $log, " Original FP: ".$all{$chimere_type}{$level}{$type}{'FP'}."\n", $verbose );
+                dual_print( $log, " location2 investigated:  @$location2\n");
+                dual_print( $log, " Original TP: ".$all{$chimere_type}{$level}{$type}{'TP'}."\n");
+                dual_print( $log, " Original FN: ".$all{$chimere_type}{$level}{$type}{'FN'}."\n");
+                dual_print( $log, " Original FP: ".$all{$chimere_type}{$level}{$type}{'FP'}."\n");
 
                 # keep track last locationB
                 my $last_locationB = undef;
                 $last_locationB = 1 if (scalar @{$flattened_locations2->{$locusID}{$chimere_type}{$level}{$type}} == 1);
-                dual_print( $log, " Lets go for last LocationB !!\n", $verbose ) if $last_locationB;
+                dual_print( $log, " Lets go for last LocationB !!\n") if $last_locationB;
 
                 # ===================== CASE 1 =====================
                 #  location A                         ----------------
                 #  location B  ---------------
                 if ($location2->[1] < $location1->[0]){
                   my $FP = $location2->[1] - $location2->[0] + 1; #size
-                  dual_print( $log, " +FP => $FP\n", $verbose );
+                  dual_print( $log, " +FP => $FP\n");
                   $all{$chimere_type}{$level}{$type}{'FP'} += $FP;
 
-                  dual_print( $log, "End1 TP: ".$all{$chimere_type}{$level}{$type}{'TP'}."\n", $verbose );
-                  dual_print( $log, "End1 FN: ".$all{$chimere_type}{$level}{$type}{'FN'}."\n", $verbose );
-                  dual_print( $log, "End1 FP: ".$all{$chimere_type}{$level}{$type}{'FP'}."\n", $verbose );
-                  dual_print( $log, " Case1 - Next location2!\n\n", $verbose );
+                  dual_print( $log, "End1 TP: ".$all{$chimere_type}{$level}{$type}{'TP'}."\n");
+                  dual_print( $log, "End1 FN: ".$all{$chimere_type}{$level}{$type}{'FN'}."\n");
+                  dual_print( $log, "End1 FP: ".$all{$chimere_type}{$level}{$type}{'FP'}."\n");
+                  dual_print( $log, " Case1 - Next location2!\n\n");
                   my $tothrow = shift  @{$flattened_locations2->{$locusID}{$chimere_type}{$level}{$type}};# Throw location B
                 }
 
@@ -272,9 +272,9 @@ foreach my $locusID ( sort  keys %{$flattened_locations1} ){
                 #      ------------ OVERLAP -----------
                 ## # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
                 elsif( ($location1->[0] <= $location2->[1]) and ($location1->[1] >= $location2->[0])){
-                  dual_print( $log, " location @$location1 and @$location2 overlap !!!!\n", $verbose );
+                  dual_print( $log, " location @$location1 and @$location2 overlap !!!!\n");
                   my ($FN, $FP, $TP) = get_snsp_for_overlaps ($location1, $location2);
-                  dual_print( $log, " FN=$FN, FP=$FP, TP=$TP\n", $verbose );
+                  dual_print( $log, " FN=$FN, FP=$FP, TP=$TP\n");
 
 
                   my $locationB_remain = 0 ;
@@ -295,18 +295,18 @@ foreach my $locusID ( sort  keys %{$flattened_locations1} ){
                   #  location A          -------------
                   #  location B  -----------   --  ------------
 
-                  dual_print( $log, "locationA_remain $locationA_remain \n", $verbose );
-                  dual_print( $log, "locationB_remain $locationB_remain \n", $verbose );
+                  dual_print( $log, "locationA_remain $locationA_remain \n");
+                  dual_print( $log, "locationB_remain $locationB_remain \n");
 
                   if ($locationA_remain and !$last_locationA and !$last_locationB){
                     # TP must always be added
                     $all{$chimere_type}{$level}{$type}{'TP'} += $TP;
                     $all{$chimere_type}{$level}{$type}{'FN'} -= $TP;
                     $all{$chimere_type}{$level}{$type}{'FP'} += $FP;
-                    dual_print( $log, " TP: ADDING ".$TP."\n", $verbose );
-                    dual_print( $log, " FN: removing ".$TP."\n", $verbose );
-                    dual_print( $log, " FP: ADDING ".$FP."\n", $verbose );
-                    dual_print( $log, " Case2 A - Next location B \n", $verbose );
+                    dual_print( $log, " TP: ADDING ".$TP."\n");
+                    dual_print( $log, " FN: removing ".$TP."\n");
+                    dual_print( $log, " FP: ADDING ".$FP."\n");
+                    dual_print( $log, " Case2 A - Next location B \n");
                     my $tothrow = shift  @{$flattened_locations2->{$locusID}{$chimere_type}{$level}{$type}};# Throw location B
                   }
 
@@ -316,10 +316,10 @@ foreach my $locusID ( sort  keys %{$flattened_locations1} ){
                     $all{$chimere_type}{$level}{$type}{'FN'} += $FN;
                     $all{$chimere_type}{$level}{$type}{'FP'} -= $TP;
 
-                    dual_print( $log, " TP: ADDING ".$TP."\n", $verbose );
-                    dual_print( $log, " FN: ADDING ".$FN."\n", $verbose );
-                    dual_print( $log, " FP: removing ".$TP."\n", $verbose );
-                    dual_print( $log, " Case2 B - Next location A\n", $verbose );
+                    dual_print( $log, " TP: ADDING ".$TP."\n");
+                    dual_print( $log, " FN: ADDING ".$FN."\n");
+                    dual_print( $log, " FP: removing ".$TP."\n");
+                    dual_print( $log, " Case2 B - Next location A\n");
                     last;
                   }
 
@@ -327,24 +327,24 @@ foreach my $locusID ( sort  keys %{$flattened_locations1} ){
                     $all{$chimere_type}{$level}{$type}{'FN'} += $FN;
                     $all{$chimere_type}{$level}{$type}{'FP'} += $FP;
                     $all{$chimere_type}{$level}{$type}{'TP'} += $TP;
-                    dual_print( $log, " TP: ADDING ".$TP."\n", $verbose );
-                    dual_print( $log, " FN: ADDING ".$FN."\n", $verbose );
-                    dual_print( $log, " FP: ADDING ".$FP."\n", $verbose );
-                    dual_print( $log, " Case2 C ------\n", $verbose );
-                    dual_print( $log, " End TP: ".$all{$chimere_type}{$level}{$type}{'TP'}."\n", $verbose );
-                    dual_print( $log, " End FN: ".$all{$chimere_type}{$level}{$type}{'FN'}."\n", $verbose );
-                    dual_print( $log, " End FP: ".$all{$chimere_type}{$level}{$type}{'FP'}."\n\n", $verbose );
+                    dual_print( $log, " TP: ADDING ".$TP."\n");
+                    dual_print( $log, " FN: ADDING ".$FN."\n");
+                    dual_print( $log, " FP: ADDING ".$FP."\n");
+                    dual_print( $log, " Case2 C ------\n");
+                    dual_print( $log, " End TP: ".$all{$chimere_type}{$level}{$type}{'TP'}."\n");
+                    dual_print( $log, " End FN: ".$all{$chimere_type}{$level}{$type}{'FN'}."\n");
+                    dual_print( $log, " End FP: ".$all{$chimere_type}{$level}{$type}{'FP'}."\n\n");
 
                       if( $last_locationB and !$last_locationA){
-                        dual_print( $log, " Case2 C2 - Remove last location B\n", $verbose );
+                        dual_print( $log, " Case2 C2 - Remove last location B\n");
                         my $tothrow = shift  @{$flattened_locations2->{$locusID}{$chimere_type}{$level}{$type}};# Throw location B
                       }
                       elsif ($last_locationA and !$last_locationB){
-                        dual_print( $log, " Case2 C3 - No more location A - LAST\n", $verbose );
+                        dual_print( $log, " Case2 C3 - No more location A - LAST\n");
                         last;
                       }
                       elsif ($last_locationA and $last_locationB){
-                        dual_print( $log, " Case2 C4 - No more locationA neither locationB. Removing locationB and LAST.\n", $verbose );
+                        dual_print( $log, " Case2 C4 - No more locationA neither locationB. Removing locationB and LAST.\n");
                         my $tothrow = shift  @{$flattened_locations2->{$locusID}{$chimere_type}{$level}{$type}};# Throw location B
                         last;
                       }
@@ -353,7 +353,7 @@ foreach my $locusID ( sort  keys %{$flattened_locations1} ){
                       #  location B  -------------- <
                       # No more locationA
                       elsif(!$locationA_remain and !$locationB_remain){
-                        dual_print( $log, " Clean cut !!! Removing LocationB and next Location A\n", $verbose );
+                        dual_print( $log, " Clean cut !!! Removing LocationB and next Location A\n");
                         my $tothrow = shift  @{$flattened_locations2->{$locusID}{$chimere_type}{$level}{$type}};# Throw location B
                         last; # next locationA
                       }
@@ -364,16 +364,16 @@ foreach my $locusID ( sort  keys %{$flattened_locations1} ){
                 #  location A  -------------------------
                 #  location B                                     -------------------------
                 else{
-                  dual_print( $log, " last because location2 after\n", $verbose );
+                  dual_print( $log, " last because location2 after\n");
 
                   my $FN = $location1->[1] - $location1->[0] + 1; #size
                   $all{$chimere_type}{$level}{$type}{'FN'} += $FN;
-                  dual_print( $log, " Take into account the current locationA! +FN: $FN;\n", $verbose );
+                  dual_print( $log, " Take into account the current locationA! +FN: $FN;\n");
 
-                  dual_print( $log, " End2 TP: ".$all{$chimere_type}{$level}{$type}{'TP'}."\n", $verbose );
-                  dual_print( $log, " End2 FN: ".$all{$chimere_type}{$level}{$type}{'FN'}."\n", $verbose );
-                  dual_print( $log, " End2 FP: ".$all{$chimere_type}{$level}{$type}{'FP'}."\n", $verbose );
-                  dual_print( $log, " Case3 - Next location A \n\n", $verbose );
+                  dual_print( $log, " End2 TP: ".$all{$chimere_type}{$level}{$type}{'TP'}."\n");
+                  dual_print( $log, " End2 FN: ".$all{$chimere_type}{$level}{$type}{'FN'}."\n");
+                  dual_print( $log, " End2 FP: ".$all{$chimere_type}{$level}{$type}{'FP'}."\n");
+                  dual_print( $log, " Case3 - Next location A \n\n");
                   last; # next locationA
                 }
               }# END WHILE until location B is after A
@@ -383,20 +383,20 @@ foreach my $locusID ( sort  keys %{$flattened_locations1} ){
             # The list of locationB is empty now
             else{
               my $FN += $location1->[1] - $location1->[0] + 1; #size
-              dual_print( $log, " LocationA only => +FN:$FN\n", $verbose );
+              dual_print( $log, " LocationA only => +FN:$FN\n");
               $all{$chimere_type}{$level}{$type}{'FN'} += $FN;
-              dual_print( $log, " Case4 - Next location A \n\n", $verbose );
+              dual_print( $log, " Case4 - Next location A \n\n");
             }
           }
         }
 
         # No such $type in annotationB, so it is specific to annotationA
         else{
-          dual_print( $log, "Specific to annotationA  => FN\n", $verbose );
+          dual_print( $log, "Specific to annotationA  => FN\n");
           my $FN=0;
           foreach my $location ( @{$flattened_locations1->{$locusID}{$chimere_type}{$level}{$type}} ){ # here the location are supposed to be sorted
             $FN += $location->[1] - $location->[0] + 1; #size
-            dual_print( $log, " Case5 - Next location A \n", $verbose );
+            dual_print( $log, " Case5 - Next location A \n");
           }
           $all{$chimere_type}{$level}{$type}{'FN'} += $FN;
         }
@@ -415,7 +415,7 @@ foreach my $locusID (  keys %{$flattened_locations2} ){
         if ( exists_keys ($flattened_locations2, ($locusID,$chimere_type,$level,$type) ) ){ # We have to remove the locations2 to check at the end the FP that are remaining (only prenent in annotationB)
           while ( my $location2 = shift @{$flattened_locations2->{$locusID}{$chimere_type}{$level}{$type}} ){ # here the location are supposed to be sorted
             my $FP = $location2->[1] - $location2->[0] + 1; #size
-            dual_print( $log, "remaining $chimere_type $level $type - location: ".$location2->[0]." ".$location2->[1]."  -  +FP $FP\n", $verbose );
+            dual_print( $log, "remaining $chimere_type $level $type - location: ".$location2->[0]." ".$location2->[1]."  -  +FP $FP\n");
             $all{$chimere_type}{$level}{$type}{'FP'} += $FP;
           }
         }
@@ -437,7 +437,7 @@ foreach my $chimere_type ( keys %all ){
         my $FN=$all{$chimere_type}{$level}{$type}{'FN'};
         my $FP=$all{$chimere_type}{$level}{$type}{'FP'};
         my $TP=$all{$chimere_type}{$level}{$type}{'TP'};
-        dual_print( $log, "chimere_type:$chimere_type level:$level type/$type TP:$TP FN:$FN FP:$FP\n", $verbose );
+        dual_print( $log, "chimere_type:$chimere_type level:$level type/$type TP:$TP FN:$FN FP:$FP\n");
         if($TP){
           $sensitivity{$chimere_type}{$level}{$type} = sprintf("%.2f", $TP / ($TP + $FN) );
           $specificity{$chimere_type}{$level}{$type} = sprintf("%.2f", $TP / ($TP + $FP) );
@@ -487,8 +487,8 @@ $string_to_print .= "\n";
 if ($outfile){
   print $report $string_to_print;
 }
-dual_print( $log, $string_to_print, $verbose );
-dual_print( $log, "Bye Bye.\n", $verbose );
+dual_print( $log, $string_to_print);
+dual_print( $log, "Bye Bye.\n");
 #######################################################################################################################
         ####################
          #     METHODS    #

--- a/bin/agat_sp_separate_by_record_type.pl
+++ b/bin/agat_sp_separate_by_record_type.pl
@@ -27,7 +27,7 @@ if ( my $log_name = $config->{log_path} ) {
 # Manage output file #
 
 if (! $opt_output) {
-  dual_print($log, "Default output name: split_result\n", $verbose);
+  dual_print($log, "Default output name: split_result\n");
   $opt_output="split_result";
 }
 
@@ -46,7 +46,7 @@ mkdir $opt_output;
 my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $opt_gfffile,
                                                                  config => $config
                                                               });
-dual_print($log, "GFF3 file parsed\n", $verbose);
+dual_print($log, "GFF3 file parsed\n");
 
 
 my $topfeatures = get_feature_type_by_agat_value($hash_omniscient, 'level1', 'topfeature');
@@ -157,7 +157,7 @@ foreach my $key (keys %handlers){
 
 my $end_run = time();
 my $run_time = $end_run - $start_run;
-dual_print($log, "Job done in $run_time seconds\n", $verbose);
+dual_print($log, "Job done in $run_time seconds\n");
 
 close $log if $log;
 __END__

--- a/bin/agat_sp_statistics.pl
+++ b/bin/agat_sp_statistics.pl
@@ -91,18 +91,18 @@ if($opt_plot){
 
 ######################
 ### Parse GFF input #
-dual_print( $log, "Reading file $gff\n", $opt_verbose );
+dual_print( $log, "Reading file $gff\n");
 my ($hash_omniscient, $hash_mRNAGeneLink) =  slurp_gff3_file_JD({
                                                                input => $gff,
                                                                config => $config
                                                                });
-dual_print( $log, "Parsing Finished\n", $opt_verbose );
+dual_print( $log, "Parsing Finished\n");
 ### END Parse GFF input #
 #########################
 
 ##############
 # STATISTICS #
-dual_print( $log, "Compute statistics\n", $opt_verbose );
+dual_print( $log, "Compute statistics\n");
 print_omniscient_statistics ({ input   => $hash_omniscient,
 															 genome  => $opt_genomeSize,
                                percentile => $opt_percentile,
@@ -116,7 +116,7 @@ print_omniscient_statistics ({ input   => $hash_omniscient,
 # END STATISTICS #
 ##################
 
-dual_print( $log, "Bye Bye.\n", $opt_verbose );
+dual_print( $log, "Bye Bye.\n");
 
 __END__
 

--- a/bin/agat_sp_webApollo_compliant.pl
+++ b/bin/agat_sp_webApollo_compliant.pl
@@ -34,7 +34,7 @@ my $gffout = prepare_gffout($config, $opt_output);
 my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $opt_gfffile,
                                                                  config => $config
                                                               });
-dual_print( $log, "GFF3 file parsed\n", $verbose );
+dual_print( $log, "GFF3 file parsed\n");
 
 ########
 # Transform thing needed for webapollo.
@@ -46,7 +46,7 @@ print_omniscient( {omniscient => $hash_omniscient, output => $gffout} );
 
 my $end_run = time();
 my $run_time = $end_run - $start_run;
-dual_print( $log, "Job done in $run_time seconds\n", $verbose );
+dual_print( $log, "Job done in $run_time seconds\n");
 __END__
 
 =head1 NAME

--- a/bin/agat_sq_add_attributes_from_tsv.pl
+++ b/bin/agat_sq_add_attributes_from_tsv.pl
@@ -36,7 +36,7 @@ my $gffout = prepare_gffout($config, $outputFile);
 # Manage GFF Input
 my $format = $config->{force_gff_input_version};
 if(! $format ){ $format = select_gff_format($input_gff); }
-dual_print($log, "Reading $input_gff using format GFF$format\n", $config->{verbose});
+dual_print($log, "Reading $input_gff using format GFF$format\n");
 my $gff_in = AGAT::BioperlGFF->new(-file => $input_gff, -gff_version => $format);
 
 # Manage tsv input
@@ -65,7 +65,7 @@ while (<INPUT>) {
 
 	if ($line == 1){
 		$nb_header = scalar @splitline;
-             dual_print($log, "$nb_header headers\n", $config->{verbose});
+             dual_print($log, "$nb_header headers\n");
 		my $cpt = 0;
 		foreach my $header_title (@splitline){
 			$header{$cpt++} = $header_title;
@@ -73,7 +73,7 @@ while (<INPUT>) {
 	}
 	else{
 		my $nb_column = scalar @splitline;
-             if($nb_column != $nb_header) { dual_print($log, "Number of header ($nb_header) different to number of columm ($nb_column) line $line\n", $config->{verbose}); }
+             if($nb_column != $nb_header) { dual_print($log, "Number of header ($nb_header) different to number of columm ($nb_column) line $line\n"); }
 		for(my $i = 1; $i <= $#splitline; $i++){
 			$tsv{lc($splitline[0])}{$header{$i}} = $splitline[$i];
 		}
@@ -91,17 +91,17 @@ while (my $feature = $gff_in->next_feature() ) {
 				if($feature->has_tag($att)){
 					my @originalvalues = $feature->get_tag_values($att);
 					if (grep( /$tsv{$id}{$att}/, @originalvalues)){
-                                           dual_print($log, "Value $tsv{$id}{$att} already exists for attribute $att in feature with ID $id\n", $config->{verbose});
+                                           dual_print($log, "Value $tsv{$id}{$att} already exists for attribute $att in feature with ID $id\n");
 					}
 					#add attribute
 					else{
-                                           dual_print($log, "Attribute $att exists for feature with ID $id, we add the new value $tsv{$id}{$att} to it.\n", $config->{verbose});
+                                           dual_print($log, "Attribute $att exists for feature with ID $id, we add the new value $tsv{$id}{$att} to it.\n");
 						$feature->add_tag_value($att, $tsv{$id}{$att});
 					}
 				}
 				# new attribute
 				else{
-                                   dual_print($log, "New attribute $att with value $tsv{$id}{$att} added for feature with ID $id.\n", $config->{verbose});
+                                   dual_print($log, "New attribute $att with value $tsv{$id}{$att} added for feature with ID $id.\n");
 					$feature->add_tag_value($att, $tsv{$id}{$att});
 				}
 			}
@@ -112,7 +112,7 @@ while (my $feature = $gff_in->next_feature() ) {
 
 my $end_run = time();
 my $run_time = $end_run - $start_run;
-dual_print($log, "Job done in $run_time seconds\n", $config->{verbose});
+dual_print($log, "Job done in $run_time seconds\n");
 
 close $log if $log;
 

--- a/bin/agat_sq_add_hash_tag.pl
+++ b/bin/agat_sq_add_hash_tag.pl
@@ -42,7 +42,7 @@ my $startP=time;
 my $nbLine=`wc -l < $inputFile`;
 $nbLine =~ s/ //g;
 chomp $nbLine;
-dual_print($log, "$nbLine line to process...\n", $config->{verbose});
+dual_print($log, "$nbLine line to process...\n");
 
 my $line_cpt=0;
 my $count=0;
@@ -85,7 +85,7 @@ while (my $feature = $ref_in->next_feature() ) {
   if ((30 - (time - $startP)) < 0) {
     my $done = ($line_cpt*100)/$nbLine;
     $done = sprintf ('%.0f', $done);
-        dual_print($log, "\rProgression : $done % processed.\n", $config->{verbose});
+        dual_print($log, "\rProgression : $done % processed.\n");
     $startP= time;
   }
 }
@@ -95,12 +95,12 @@ while (my $feature = $ref_in->next_feature() ) {
 $count++;
 
 if($count > 0){
-  dual_print($log, "$count line added !\n", $config->{verbose});
+  dual_print($log, "$count line added !\n");
 }
-else{dual_print($log, "No line added !\n", $config->{verbose});}
+else{dual_print($log, "No line added !\n");}
 my $end_run = time();
 my $run_time = $end_run - $start_run;
-dual_print($log, "Job done in $run_time seconds\n", $config->{verbose});
+dual_print($log, "Job done in $run_time seconds\n");
 
 close $log if $log;
 

--- a/bin/agat_sq_add_locus_tag.pl
+++ b/bin/agat_sq_add_locus_tag.pl
@@ -50,21 +50,21 @@ my $hash_levels= get_levels_info();
 my $hash_level1 = $hash_levels->{'other'}{'level'}{'level1'};
 
 if(! $primaryTag){
-  dual_print($log, "We will work on attributes from all Level1 features.\n", $config->{verbose});
+  dual_print($log, "We will work on attributes from all Level1 features.\n");
   push(@ptagList, "all");
 }
 else{
    @ptagList= split(/,/, $primaryTag);
    foreach my $tag (@ptagList){
       if ( exists_keys ( $hash_level1, ( lc($tag) ) ) ){
-        dual_print($log, "We will work on attributes from <$tag> feature.\n", $config->{verbose});
+        dual_print($log, "We will work on attributes from <$tag> feature.\n");
       }
       else{
-        dual_print($log, "<$tag> feature is not a level1 feature. Current accepted value are:\n", $config->{verbose});
+        dual_print($log, "<$tag> feature is not a level1 feature. Current accepted value are:\n");
         foreach my $key ( keys %{$hash_level1}){
-          dual_print($log, $key." ", $config->{verbose});
+          dual_print($log, $key." ");
         }
-        dual_print($log, "\n", $config->{verbose});
+        dual_print($log, "\n");
         exit;
       }
    }
@@ -75,7 +75,7 @@ my $startP=time;
 my $nbLine=`wc -l < $inputFile`;
 $nbLine =~ s/ //g;
 chomp $nbLine;
-dual_print($log, "$nbLine line to process...\n", $config->{verbose});
+dual_print($log, "$nbLine line to process...\n");
 
 my $line_cpt=0;
 my $locus=undef;
@@ -95,9 +95,9 @@ while (my $feature = $ref_in->next_feature() ) {
           $locus = $feature->_tag_value($tag_in);
         }
         else{
-          dual_print($log, "No attribute $tag_in for the following feature:\n".$feature->gff_string()."\n", $config->{verbose});
+          dual_print($log, "No attribute $tag_in for the following feature:\n".$feature->gff_string()."\n");
           $locus = $locus_tag.$locus_cpt;$locus_cpt++;
-          dual_print($log, "We will use the created locus_tag value: $locus instead to name the locus!\n", $config->{verbose});
+          dual_print($log, "We will use the created locus_tag value: $locus instead to name the locus!\n");
         }
       }
       else{
@@ -125,7 +125,7 @@ while (my $feature = $ref_in->next_feature() ) {
   if ((30 - (time - $startP)) < 0) {
     my $done = ($line_cpt*100)/$nbLine;
     $done = sprintf ('%.0f', $done);
-        dual_print($log, "\rProgression : $done % processed.\n", $config->{verbose});
+        dual_print($log, "\rProgression : $done % processed.\n");
     $startP= time;
   }
 }
@@ -134,7 +134,7 @@ while (my $feature = $ref_in->next_feature() ) {
 ##Last round
 my $end_run = time();
 my $run_time = $end_run - $start_run;
-dual_print($log, "Job done in $run_time seconds\n", $config->{verbose});
+dual_print($log, "Job done in $run_time seconds\n");
 
 
 #######################################################################################################################

--- a/bin/agat_sq_count_attributes.pl
+++ b/bin/agat_sq_count_attributes.pl
@@ -30,7 +30,7 @@ if ( my $log_name = $config->{log_path} ) {
 
 # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>     MAIN     <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
-dual_print( $log, "Looking to $attribute attribute.\n", $verbose );
+dual_print( $log, "Looking to $attribute attribute.\n");
 
 # Manage input gff file
 my $format = $config->{force_gff_input_version};
@@ -42,7 +42,7 @@ my $startP=time;
 my $nbLine=`wc -l < $gff`;
 $nbLine =~ s/ //g;
 chomp $nbLine;
-dual_print( $log, "$nbLine line to process...\n", $verbose );
+dual_print( $log, "$nbLine line to process...\n");
 
 my $line_cpt=0;
 my %hash_values;
@@ -61,7 +61,7 @@ while (my $feature = $ref_in->next_feature() ) {
   if ((30 - (time - $startP)) < 0) {
     my $done = ($line_cpt*100)/$nbLine;
     $done = sprintf ('%.0f', $done);
-        dual_print( $log, "\rProgression : $done % processed.\n", $verbose );
+        dual_print( $log, "\rProgression : $done % processed.\n");
     $startP= time;
   }
 }
@@ -73,9 +73,9 @@ my $run_time = $end_run - $start_run;
 
 my $result = scalar keys %hash_values;
 
-dual_print( $log, "$line_cpt features read. Among them, $nb_attributes has the $attribute attribute.\n", $verbose );
-dual_print( $log, "There is $result unique value within $attribute attribute\n", $verbose );
-dual_print( $log, "Job done in $run_time seconds\n", $verbose );
+dual_print( $log, "$line_cpt features read. Among them, $nb_attributes has the $attribute attribute.\n");
+dual_print( $log, "There is $result unique value within $attribute attribute\n");
+dual_print( $log, "Job done in $run_time seconds\n");
 
 __END__
 

--- a/bin/agat_sq_filter_feature_from_fasta.pl
+++ b/bin/agat_sq_filter_feature_from_fasta.pl
@@ -39,7 +39,7 @@ my $gffout = prepare_gffout($config, $outfile);
 #### read fasta
 my $nbFastaSeq=0;
 my $db = Bio::DB::Fasta->new($opt_fastafile);
-dual_print($log, "Fasta file parsed\n", $opt_verbose);
+dual_print($log, "Fasta file parsed\n");
 
 # get all seq id from fasta and convert to hash
 my @ids      = $db->get_all_primary_ids;
@@ -67,16 +67,14 @@ while (my $feature = $ref_in->next_feature() ) {
   }
 }
 
-dual_print($log, "We removed $cpt_removed annotations.\n", $opt_verbose);
+dual_print($log, "We removed $cpt_removed annotations.\n");
 my $nbSeqWithAnnotation = scalar keys %seqNameSeen;
 dual_print(
     $log,
-    "We kept $cpt_kept annotations that are linked to $nbSeqWithAnnotation sequences.\n",
-    $opt_verbose
-);
+    "We kept $cpt_kept annotations that are linked to $nbSeqWithAnnotation sequences.\n");
 my $end_run = time();
 my $run_time = $end_run - $start_run;
-dual_print($log, "Job done in $run_time seconds\n", $opt_verbose);
+dual_print($log, "Job done in $run_time seconds\n");
 
 __END__
 

--- a/bin/agat_sq_list_attributes.pl
+++ b/bin/agat_sq_list_attributes.pl
@@ -33,13 +33,13 @@ if ( my $log_name = $config->{log_path} ) {
 # Manage $primaryTag
 my @ptagList;
 if(! $primaryTag or $primaryTag eq "all"){
-  dual_print($log, "We will work on attributes from all features\n", $opt_verbose);
+  dual_print($log, "We will work on attributes from all features\n");
   push(@ptagList, "all");
 }
 else{
    @ptagList= split(/,/, $primaryTag);
    foreach my $tag (@ptagList){
-     dual_print($log, "We will work on attributes from $tag feature.\n", $opt_verbose);
+     dual_print($log, "We will work on attributes from $tag feature.\n");
    }
 }
 
@@ -63,7 +63,7 @@ my $startP=time;
 my $nbLine=`wc -l < $gff`;
 $nbLine =~ s/ //g;
 chomp $nbLine;
-dual_print($log, "$nbLine line to process...\n", $opt_verbose);
+dual_print($log, "$nbLine line to process...\n");
 warn "Input file $gff is empty\n" if $opt_verbose && $nbLine == 0;
 
 my $geneName=undef;
@@ -78,7 +78,7 @@ while (my $feature = $ref_in->next_feature() ) {
   if ((30 - (time - $startP)) < 0) {
     my $done = ($line_cpt*100)/$nbLine;
     $done = sprintf ('%.0f', $done);
-        dual_print($log, "\rProgression : $done % processed.\n", $opt_verbose);
+        dual_print($log, "\rProgression : $done % processed.\n");
     $startP= time;
   }
 }
@@ -109,7 +109,7 @@ foreach my $attribute ( sort keys %all_attributes){
 ##Last round
 my $end_run = time();
 my $run_time = $end_run - $start_run;
-dual_print($log, "\nJob done in $run_time seconds\n", $opt_verbose);
+dual_print($log, "\nJob done in $run_time seconds\n");
 
 close $log if $log;
 

--- a/bin/agat_sq_manage_IDs.pl
+++ b/bin/agat_sq_manage_IDs.pl
@@ -43,7 +43,7 @@ my $startP=time;
 my $nbLine=`wc -l < $inputFile`;
 $nbLine =~ s/ //g;
 chomp $nbLine;
-dual_print( $log, "$nbLine line to process...\n", $config->{verbose} );
+dual_print( $log, "$nbLine line to process...\n");
 
 my $line_cpt=0;
 my %hash_IDs;
@@ -69,7 +69,7 @@ while (my $feature = $ref_in->next_feature() ) {
   if ((30 - (time - $startP)) < 0) {
     my $done = ($line_cpt*100)/$nbLine;
     $done = sprintf ('%.0f', $done);
-        dual_print( $log, "\rProgression : $done % processed.\n", $config->{verbose} );
+        dual_print( $log, "\rProgression : $done % processed.\n");
     $startP= time;
   }
 }
@@ -77,7 +77,7 @@ while (my $feature = $ref_in->next_feature() ) {
 ##Last round
 my $end_run = time();
 my $run_time = $end_run - $start_run;
-dual_print( $log, "Job done in $run_time seconds\n", $config->{verbose} );
+dual_print( $log, "Job done in $run_time seconds\n");
 
 
 

--- a/bin/agat_sq_manage_attributes.pl
+++ b/bin/agat_sq_manage_attributes.pl
@@ -64,26 +64,26 @@ my $gffout = prepare_gffout( $config, $outfile );
 # deal with strategy input
 $strategy=lc($strategy);
 if( ($strategy ne "equal") and ($strategy ne "match") ){
-  dual_print($log, "Strategy must be <equal> or <match>. Wrong value provided: <$strategy>\n", $config->{verbose});
+  dual_print($log, "Strategy must be <equal> or <match>. Wrong value provided: <$strategy>\n");
   exit;
 }
 
 # Manage $primaryTag
 my @ptagList;
 if(! $primaryTag or $primaryTag eq "all"){
-  dual_print($log, "We will work on attributes from all features\n", $config->{verbose});
+  dual_print($log, "We will work on attributes from all features\n");
   push(@ptagList, "all");
 }elsif($primaryTag =~/^level[123]$/){
-  dual_print($log, "We will work on attributes from all the $primaryTag features\n", $config->{verbose});
+  dual_print($log, "We will work on attributes from all the $primaryTag features\n");
   push(@ptagList, $primaryTag);
 }else{
    @ptagList= split(/,/, $primaryTag);
    foreach my $tag (@ptagList){
       if($tag =~/^level[123]$/){
-        dual_print($log, "We will work on attributes from all the $tag features\n", $config->{verbose});
+        dual_print($log, "We will work on attributes from all the $tag features\n");
       }
       else{
-       dual_print($log, "We will work on attributes from $tag feature.\n", $config->{verbose});
+       dual_print($log, "We will work on attributes from $tag feature.\n");
       }
    }
 }
@@ -96,10 +96,10 @@ if ($attributes){
 
   if ($attributes eq "all_attributes"){
     if($add){
-      dual_print($log, "You cannot use the all_attributes value with the add option. Please change the parameters !\n", $config->{verbose});
+      dual_print($log, "You cannot use the all_attributes value with the add option. Please change the parameters !\n");
       exit;
     }
-    dual_print($log, "All attributes will be removed except ID and Parent attributes !\n", $config->{verbose});
+    dual_print($log, "All attributes will be removed except ID and Parent attributes !\n");
     $attListOk{"all_attributes"}++;
   }
   else{
@@ -110,36 +110,36 @@ if ($attributes){
       my @attList= split(/\//, $attributeTuple);
       if($#attList == 0){ # Attribute alone
         #check for ID attribute
-        if(lc($attList[0]) eq "id" and ! $add){dual_print($log, "It's forbidden to remove the ID attribute in a gff3 file !\n", $config->{verbose}); exit;}
+        if(lc($attList[0]) eq "id" and ! $add){dual_print($log, "It's forbidden to remove the ID attribute in a gff3 file !\n"); exit;}
         #check for Parent attribute
         if(lc($attList[0]) eq "parent" and ! $add){
           foreach my $tag (@ptagList){
             if($tag ne "gene" and $tag ne "level1"){
-              dual_print($log, "It's forbidden to remove the $attList[0] attribute to a $tag feature in a gff3 file !\n", $config->{verbose});
+              dual_print($log, "It's forbidden to remove the $attList[0] attribute to a $tag feature in a gff3 file !\n");
               exit;
             }
           }
         }
         $attListOk{$attList[0]}="null";
         if($add){
-          dual_print($log, "$attList[0] attribute will be added. The value will be empty.\n", $config->{verbose});
+          dual_print($log, "$attList[0] attribute will be added. The value will be empty.\n");
         }
         else{
           if($value){
-              dual_print($log, "$attList[0] attribute will be removed if it has the value:$value.\n", $config->{verbose});
+              dual_print($log, "$attList[0] attribute will be removed if it has the value:$value.\n");
           }
           else{
-            dual_print($log, "$attList[0] attribute will be removed.\n", $config->{verbose});
+            dual_print($log, "$attList[0] attribute will be removed.\n");
           }
         }
       }
       else{ # Attribute will be replaced/copied with a new tag name
         $attListOk{$attList[0]}=$attList[1];
-        dual_print($log, "$attList[0] attribute will be replaced by $attList[1].\n", $config->{verbose});
+        dual_print($log, "$attList[0] attribute will be replaced by $attList[1].\n");
       }
     }
   }
-  dual_print($log, "\n", $config->{verbose});
+  dual_print($log, "\n");
 }
 
 my $hash_info= get_levels_info();
@@ -161,7 +161,7 @@ my $startP=time;
 my $nbLine=`wc -l < $gff`;
 $nbLine =~ s/ //g;
 chomp $nbLine;
-dual_print($log, "$nbLine line to process...\n", $config->{verbose});
+dual_print($log, "$nbLine line to process...\n");
 
 my $line_cpt=0;
 my %hash_IDs;
@@ -178,7 +178,7 @@ while (my $feature = $ref_in->next_feature() ) {
   if ((30 - (time - $startP)) < 0) {
     my $done = ($line_cpt*100)/$nbLine;
     $done = sprintf ('%.0f', $done);
-        dual_print($log, "\rProgression : $done % processed.\n", $config->{verbose});
+        dual_print($log, "\rProgression : $done % processed.\n");
     $startP= time;
   }
 }
@@ -188,15 +188,15 @@ my $end_run = time();
 my $run_time = $end_run - $start_run;
 
 if($add){
-  dual_print($log, "$cpt_case attribute added\n", $config->{verbose});
+  dual_print($log, "$cpt_case attribute added\n");
 }
 elsif($cp){
-  dual_print($log, "$cpt_case attribute copied\n", $config->{verbose});
+  dual_print($log, "$cpt_case attribute copied\n");
 
 }else{
-  dual_print($log, "$cpt_case attribute removed\n", $config->{verbose});
+  dual_print($log, "$cpt_case attribute removed\n");
 }
-dual_print($log, "Job done in $run_time seconds\n", $config->{verbose});
+dual_print($log, "Job done in $run_time seconds\n");
 
 
 #######################################################################################################################

--- a/bin/agat_sq_mask.pl
+++ b/bin/agat_sq_mask.pl
@@ -50,17 +50,17 @@ if ( my $log_name = $config->{log_path} ) {
 my $ostream = prepare_fileout($opt_output);
 
 if ( defined $opt_HardMask ) {
-    dual_print( $log, "You choose to Hard Mask the genome.\n", $opt_verbose );
+    dual_print( $log, "You choose to Hard Mask the genome.\n");
     if ( $opt_HardMask eq '' ) {
         $hardMaskChar = 'n';
     }
     else {
         $hardMaskChar = $opt_HardMask;
     }
-    dual_print( $log, "Charcater uses for Mask: $hardMaskChar\n", $opt_verbose );
+    dual_print( $log, "Charcater uses for Mask: $hardMaskChar\n");
 }
 if ($opt_SoftMask) {
-    dual_print( $log, "You choose to Soft Mask the genome.\n", $opt_verbose );
+    dual_print( $log, "You choose to Soft Mask the genome.\n");
 }
 ##### MAIN ####
 
@@ -73,7 +73,7 @@ if(! $format ){ $format = select_gff_format($opt_gfffile); }
 my $gff_in = AGAT::BioperlGFF->new(-file => $opt_gfffile, -gff_version => $format);
 
 
-dual_print($log, "Reading features from $opt_gfffile...\n", $opt_verbose);
+dual_print($log, "Reading features from $opt_gfffile...\n");
   while (my $feature = $gff_in->next_feature()) {
     my $seqname=$feature->seq_id();
     my $start=$feature->start();
@@ -82,7 +82,7 @@ dual_print($log, "Reading features from $opt_gfffile...\n", $opt_verbose);
     $nbLineRead++;
    }
 $gff_in->close();
-dual_print($log, "$nbLineRead lines read\n", $opt_verbose);
+dual_print($log, "$nbLineRead lines read\n");
 warn "Input file $opt_gfffile is empty\n" if $opt_verbose && $nbLineRead == 0;
 
 #### read fasta
@@ -111,11 +111,11 @@ while ($_=$inFasta->next_seq()) {
     $nbFastaSeq++;
 }
 $inFasta->close();
-dual_print($log, "$nbFastaSeq fasta sequences read.\n", $opt_verbose);
-dual_print($log, "$nucl_masked nucleotides masked.\n", $opt_verbose);
+dual_print($log, "$nbFastaSeq fasta sequences read.\n");
+dual_print($log, "$nucl_masked nucleotides masked.\n");
 my $end_run = time();
 my $run_time = $end_run - $start_run;
-dual_print($log, "Job done in $run_time seconds\n", $opt_verbose);
+dual_print($log, "Job done in $run_time seconds\n");
 __END__
 
 =head1 NAME

--- a/bin/agat_sq_remove_redundant_entries.pl
+++ b/bin/agat_sq_remove_redundant_entries.pl
@@ -38,7 +38,7 @@ my $startP=time;
 my $nbLine=`wc -l < $inputFile`;
 $nbLine =~ s/ //g;
 chomp $nbLine;
-dual_print($log, "$nbLine line to process...\n", $opt_verbose);
+dual_print($log, "$nbLine line to process...\n");
 warn "Input file $inputFile is empty\n" if $opt_verbose && $nbLine == 0;
 my $line_cpt=0;
 
@@ -74,18 +74,18 @@ while (my $feature = $ref_in->next_feature() ) {
   if ((30 - (time - $startP)) < 0) {
     my $done = ($line_cpt*100)/$nbLine;
     $done = sprintf ('%.0f', $done);
-        dual_print($log, "Progression : $done % processed.\n", $opt_verbose);
+        dual_print($log, "Progression : $done % processed.\n");
     $startP= time;
   }
 }
 
 if($count > 0){
-  dual_print($log, "$count entries removed !\n", $opt_verbose);
+  dual_print($log, "$count entries removed !\n");
 }
-else{dual_print($log, "No entry removed !\n", $opt_verbose);}
+else{dual_print($log, "No entry removed !\n");}
 my $end_run = time();
 my $run_time = $end_run - $start_run;
-dual_print($log, "Job done in $run_time seconds\n", $opt_verbose);
+dual_print($log, "Job done in $run_time seconds\n");
 
 __END__
 

--- a/bin/agat_sq_rename_seqid.pl
+++ b/bin/agat_sq_rename_seqid.pl
@@ -76,7 +76,7 @@ while (my $feature = $gff_in->next_feature() ) {
 
 my $end_run = time();
 my $run_time = $end_run - $start_run;
-dual_print( $log, "Job done in $run_time seconds\n", $config->{verbose} );
+dual_print( $log, "Job done in $run_time seconds\n");
 
 __END__
 

--- a/bin/agat_sq_repeats_analyzer.pl
+++ b/bin/agat_sq_repeats_analyzer.pl
@@ -55,7 +55,7 @@ my $genomeSize=undef;
           $genomeSize += length($string);
         }
     }
-    dual_print($log, sprintf("%-45s%d%s", 'Total sequence length', $genomeSize, "\n"), $opt_verbose);
+    dual_print($log, sprintf("%-45s%d%s", 'Total sequence length', $genomeSize, "\n"));
   }
 
 #time to calcul progression
@@ -64,7 +64,7 @@ my $type_bp;
 my %check; #track the repeat already annotated to not. Allow to skip already read repeats
 
 foreach my $file (@inputFile){
-  dual_print($log, "Reading $file\n", $opt_verbose);
+  dual_print($log, "Reading $file\n");
   my $format = $config->{force_gff_input_version};
   if(! $format ){ $format = select_gff_format($file); }
   my $ref_in = AGAT::BioperlGFF->new(-file => $file, -gff_version => $format);
@@ -73,7 +73,7 @@ foreach my $file (@inputFile){
   my $nbLine=`wc -l < $file`;
   $nbLine =~ s/ //g;
   chomp $nbLine;
-  dual_print($log, "$nbLine line to process...\n", $opt_verbose);
+  dual_print($log, "$nbLine line to process...\n");
   warn "Input file $file is empty\n" if $opt_verbose && $nbLine == 0;
   my $line_cpt=0;
 
@@ -98,11 +98,11 @@ foreach my $file (@inputFile){
     if ((30 - (time - $startP)) < 0) {
       my $done = ($line_cpt*100)/$nbLine;
       $done = sprintf ('%.0f', $done);
-      dual_print($log, "\rProgress : $done %", $opt_verbose);
+      dual_print($log, "\rProgress : $done %");
       $startP= time;
     }
   }
-  dual_print($log, "\rProgress : 100 %\n", $opt_verbose);
+  dual_print($log, "\rProgress : 100 %\n");
 }
 
 my $totalNumber=0;
@@ -152,7 +152,7 @@ else{
 
 my $end_run = time();
 my $run_time = $end_run - $start_run;
-dual_print($log, "Job done in $run_time seconds\n", $opt_verbose);
+dual_print($log, "Job done in $run_time seconds\n");
 
 __END__
 

--- a/bin/agat_sq_reverse_complement.pl
+++ b/bin/agat_sq_reverse_complement.pl
@@ -53,7 +53,7 @@ while(my $seqObj = $seqio->next_seq) {
 #### read fasta again for DB
 my $nbFastaSeq=0;
 my $db = Bio::DB::Fasta->new($opt_fastafile);
-dual_print($log, "Fasta file parsed\n", $opt_verbose);
+dual_print($log, "Fasta file parsed\n");
 
 # get all seq id from fasta and convert to hash
 my @ids      = $db->get_all_primary_ids;
@@ -115,14 +115,14 @@ my $nb_error = 0;
 $nb_error  =  keys %{$info{"error"}};
 
 
-dual_print($log, "Annotations on $nb_flip sequences have been reverse complemented.\n", $opt_verbose);
-dual_print($log, "Annotations on $nb_intact sequences have been kept intact (Sequences absent from the fasta file but present in the gff.\n", $opt_verbose);
+dual_print($log, "Annotations on $nb_flip sequences have been reverse complemented.\n");
+dual_print($log, "Annotations on $nb_intact sequences have been kept intact (Sequences absent from the fasta file but present in the gff.\n");
 warn "$nb_error sequences from the fasta file were absent from the gff.\n" if $opt_verbose && $nb_error;
-dual_print($log, "$nb_error sequences from the fasta file were absent from the gff.\n", $opt_verbose);
+dual_print($log, "$nb_error sequences from the fasta file were absent from the gff.\n");
 
 my $end_run = time();
 my $run_time = $end_run - $start_run;
-dual_print($log, "Job done in $run_time seconds\n", $opt_verbose);
+dual_print($log, "Job done in $run_time seconds\n");
 
 close $log if $log;
 

--- a/bin/agat_sq_rfam_analyzer.pl
+++ b/bin/agat_sq_rfam_analyzer.pl
@@ -40,7 +40,7 @@ my $genomeSize=undef;
           $genomeSize += length($string);
         }
     }
-  dual_print($log, sprintf("%-45s%d%s", "Total sequence length", $genomeSize, "\n"), $opt_verbose);
+  dual_print($log, sprintf("%-45s%d%s", "Total sequence length", $genomeSize, "\n"));
   }
 
 #time to calcul progression
@@ -50,7 +50,7 @@ my %check; #track the repeat already annotated to not. Allow to skip already rea
 
 foreach my $file (@inputFile){
   # Manage input gff file
-  dual_print($log, "Reading $file\n", $opt_verbose);
+  dual_print($log, "Reading $file\n");
   my $format = $config->{force_gff_input_version};
   if(! $format ){ $format = select_gff_format($file); }
   my $ref_in = AGAT::BioperlGFF->new(-file => $file, -gff_version => $format);
@@ -59,7 +59,7 @@ foreach my $file (@inputFile){
   my $nbLine=`wc -l < $file`;
   $nbLine =~ s/ //g;
   chomp $nbLine;
-  dual_print($log, "$nbLine line to process...\n", $opt_verbose);
+  dual_print($log, "$nbLine line to process...\n");
   my $line_cpt=0;
 
   local $| = 1; # Or use IO::Handle; STDOUT->autoflush; Use to print progression bar
@@ -90,11 +90,11 @@ foreach my $file (@inputFile){
     if ((30 - (time - $startP)) < 0) {
       my $done = ($line_cpt*100)/$nbLine;
       $done = sprintf ('%.0f', $done);
-          dual_print($log, "\rProgress : $done %", $opt_verbose);
+          dual_print($log, "\rProgress : $done %");
       $startP= time;
     }
   }
-  dual_print($log, "\rProgress : 100 %\n", $opt_verbose);
+  dual_print($log, "\rProgress : 100 %\n");
 }
 
 my $totalNumber=0;
@@ -144,7 +144,7 @@ else{
 
   my $end_run = time();
   my $run_time = $end_run - $start_run;
-  dual_print($log, "Job done in $run_time seconds\n", $opt_verbose);
+  dual_print($log, "Job done in $run_time seconds\n");
 
 close $log if $log;
 

--- a/bin/agat_sq_split.pl
+++ b/bin/agat_sq_split.pl
@@ -37,19 +37,18 @@ if ( -d $opt_output ) {
 } else {
     my ( $path, $ext );
     ( $opt_output, $path, $ext ) = fileparse( $opt_output, qr/\.[^.]*$/ );
-    dual_print( $log, "Creating the $opt_output folder\n", $opt_verbose );
+    dual_print( $log, "Creating the $opt_output folder\n");
     mkdir $opt_output;
 }
 
 dual_print( $log,
-    "I will split the file into files containing $interval group of feature. The top feature of the group of feature is currently defined by <$feature_type>.\n",
-    $opt_verbose );
+    "I will split the file into files containing $interval group of feature. The top feature of the group of feature is currently defined by <$feature_type>.\n");
 
 my $startP = time;
 my $nbLine = `wc -l < $opt_gff`;
 $nbLine =~ s/ //g;
 chomp $nbLine;
-dual_print( $log, "$nbLine line to process...\n", $opt_verbose );
+dual_print( $log, "$nbLine line to process...\n");
 my $line_cpt = 0;
 
 my $count_feature = 0;
@@ -76,7 +75,7 @@ while ( my $feature = $ref_in->next_feature() ) {
     if ( ( 30 - ( time - $startP ) ) < 0 ) {
         my $done = ( $line_cpt * 100 ) / $nbLine;
         $done = sprintf( '%.0f', $done );
-        dual_print( $log, "\rProgression : $done % processed.\n", $opt_verbose );
+        dual_print( $log, "\rProgression : $done % processed.\n");
         $startP = time;
     }
 }
@@ -84,7 +83,7 @@ close $gffout;
 
 my $end_run  = time();
 my $run_time = $end_run - $start_run;
-dual_print( $log, "Job done in $run_time seconds\n", $opt_verbose );
+dual_print( $log, "Job done in $run_time seconds\n");
 
 __END__
 

--- a/bin/agat_sq_stat_basic.pl
+++ b/bin/agat_sq_stat_basic.pl
@@ -42,7 +42,7 @@ my $genomeSize=undef;
           $genomeSize += length($string);
         }
     }
-  dual_print($log, sprintf("%-45s%d%s", "Total sequence length", $genomeSize, "\n"), $opt_verbose);
+  dual_print($log, sprintf("%-45s%d%s", "Total sequence length", $genomeSize, "\n"));
   }
 
 #time to calcul progression
@@ -52,7 +52,7 @@ my %check; #track the repeat already annotated to not. Allow to skip already rea
 
 foreach my $file (@inputFile){
 # Manage input gff file
-  dual_print($log, "Reading $file\n", $opt_verbose);
+  dual_print($log, "Reading $file\n");
 	my $format = $config->{force_gff_input_version};
 	if(! $format ){ $format = select_gff_format($file); }
   my $ref_in = AGAT::BioperlGFF->new(-file => $file, -gff_version => $format);
@@ -61,7 +61,7 @@ foreach my $file (@inputFile){
   my $nbLine=`wc -l < $file`;
   $nbLine =~ s/ //g;
   chomp $nbLine;
-  dual_print($log, "$nbLine line to process...\n", $opt_verbose);
+  dual_print($log, "$nbLine line to process...\n");
   my $line_cpt=0;
 
   local $| = 1; # Or use IO::Handle; STDOUT->autoflush; Use to print progression bar
@@ -89,11 +89,11 @@ foreach my $file (@inputFile){
     if ((30 - (time - $startP)) < 0) {
       my $done = ($line_cpt*100)/$nbLine;
       $done = sprintf ('%.0f', $done);
-          dual_print($log, "\rProgress : $done %", $opt_verbose);
+          dual_print($log, "\rProgress : $done %");
       $startP= time;
     }
   }
-  dual_print($log, "\rProgress : 100 %\n", $opt_verbose);
+  dual_print($log, "\rProgress : 100 %\n");
 }
 
 my $totalNumber=0;
@@ -138,7 +138,7 @@ else{
 
 my $end_run = time();
 my $run_time = $end_run - $start_run;
-dual_print($log, "Job done in $run_time seconds\n", $opt_verbose);
+dual_print($log, "Job done in $run_time seconds\n");
 
 close $log if $log;
 

--- a/lib/AGAT/Utilities.pm
+++ b/lib/AGAT/Utilities.pm
@@ -300,23 +300,13 @@ sub print_time{
 # @input: 3 => fh, string, integer
 # @output 0 => None
 sub dual_print{
-        my ($fh, $string, $verbose) = @_;
-        if(! defined($verbose)){
-                if(defined $AGAT::AGAT::CONFIG->{verbose}){
-                        $verbose = $AGAT::AGAT::CONFIG->{verbose};
-                }
-                else{
-                        $verbose = 1; # default verbosity
-                }
-        }
-
-        if($verbose > 0 ){ #only 0 is quiet mode
+        my ($fh, $string, $min) = @_;
+        my $verbose = defined $AGAT::AGAT::CONFIG->{verbose} ? $AGAT::AGAT::CONFIG->{verbose} : 1;
+        $min = 1 unless defined $min;
+        if ($min > 0 && $verbose >= $min) {
                 print $string;
         }
-        # print in log in any provided
-        if($fh){
-                print $fh $string;
-        }
+        print $fh $string if $fh;
 }
 
 # @Purpose: transform a String with separator into hash


### PR DESCRIPTION
## Summary
- simplify `dual_print` to use configuration verbosity and optional minimum level
- drop redundant verbosity arguments from agat scripts

## Testing
- `prove -lr t/smoke` *(fails: Cannot detect source of 't/smoke')*
- `make test` *(fails: Result: FAIL)*

------
https://chatgpt.com/codex/tasks/task_e_68acd1233f40832a9d8ddca94f260fdd