### PR TITLE
refactor tests to use check_quiet_and_normal_run

### DIFF
--- a/t/agat.t
+++ b/t/agat.t
@@ -5,7 +5,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catdir catfile);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix); 
 use Test::More;
 
 my $script_prefix = script_prefix();

--- a/t/agat_convert_bed2gff.t
+++ b/t/agat_convert_bed2gff.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,12 +22,12 @@ my $script = $script_prefix . catfile($bin_dir, "agat_convert_bed2gff.pl");
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_convert_bed2gff_1.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    check_quiet_run(" $script --bed $input_folder/test.bed -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { bed => "$input_folder/test.bed" },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_convert_embl2gff.t
+++ b/t/agat_convert_embl2gff.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,12 +22,12 @@ my $script = $script_prefix . catfile($bin_dir, "agat_convert_embl2gff.pl");
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_convert_embl2gff_1.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    check_quiet_run(" $script --embl $input_folder/agat_convert_embl2gff_1.embl -o $outtmp --emblmygff3");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { embl => "$input_folder/agat_convert_embl2gff_1.embl", emblmygff3 => 1 },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_convert_genscan2gff.t
+++ b/t/agat_convert_genscan2gff.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,12 +22,12 @@ my $script = $script_prefix . catfile($bin_dir, "agat_convert_genscan2gff.pl");
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_convert_genscan2gff_1.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    check_quiet_run(" $script --genscan $input_folder/test.genscan -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { genscan => "$input_folder/test.genscan" },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_convert_mfannot2gff.t
+++ b/t/agat_convert_mfannot2gff.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,24 +22,22 @@ my $script = $script_prefix . catfile($bin_dir, "agat_convert_mfannot2gff.pl");
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_convert_mfannot2gff_1.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --mfannot $input_folder/test.mfannot -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { mfannot => "$input_folder/test.mfannot" },
+    "$result.stdout",
+    $result
+);
 
 
 $script = $script_prefix . catfile($bin_dir, "agat_convert_mfannot2gff.pl");
 $result = "$output_folder/agat_convert_mfannot2gff_2.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --mfannot $input_folder/test.mfannot2 -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { mfannot => "$input_folder/test.mfannot2" },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_convert_minimap2_bam2gff.t
+++ b/t/agat_convert_minimap2_bam2gff.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -21,13 +21,12 @@ my $script = $script_prefix . catfile($bin_dir, "agat_convert_minimap2_bam2gff.p
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_convert_minimap2_bam2gff_1.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script -i $input_folder/test_minimap2.sam -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { i => "$input_folder/test_minimap2.sam" },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_convert_sp_gff2bed.t
+++ b/t/agat_convert_sp_gff2bed.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,13 +22,12 @@ my $script = $script_prefix . catfile($bin_dir, "agat_convert_sp_gff2bed.pl");
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_convert_sp_gff2bed_1.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/1.gff" },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_convert_sp_gff2gtf.t
+++ b/t/agat_convert_sp_gff2gtf.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -23,43 +23,39 @@ my $script = $script_prefix . catfile($bin_dir, "agat_convert_sp_gff2gtf.pl");
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$convert_sp_gff2gtf_folder/agat_convert_sp_gff2gtf_1.gtf";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/1.gff --gtf_version 3 -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/1.gff", gtf_version => "3" },
+    "$result.stdout",
+    $result
+);
 
 
 $result = "$convert_sp_gff2gtf_folder/agat_convert_sp_gff2gtf_2.gtf";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $convert_sp_gff2gtf_folder/stop_start_an_exon.gff --gtf_version 3 -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$convert_sp_gff2gtf_folder/stop_start_an_exon.gff", gtf_version => "3" },
+    "$result.stdout",
+    $result
+);
 
 
 $result = "$convert_sp_gff2gtf_folder/agat_convert_sp_gff2gtf_3.gtf";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $convert_sp_gff2gtf_folder/stop_split_over_two_exons.gff --gtf_version 3 -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$convert_sp_gff2gtf_folder/stop_split_over_two_exons.gff", gtf_version => "3" },
+    "$result.stdout",
+    $result
+);
 
 
 $result = "$convert_sp_gff2gtf_folder/result_issue_245.gtf";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $convert_sp_gff2gtf_folder/issue_245.gff --gtf_version 3 -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$convert_sp_gff2gtf_folder/issue_245.gff", gtf_version => "3" },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_convert_sp_gff2tsv.t
+++ b/t/agat_convert_sp_gff2tsv.t
@@ -5,7 +5,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catdir catfile);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix); 
 use Test::More;
 
 my $script_prefix = script_prefix();

--- a/t/agat_convert_sp_gff2zff.t
+++ b/t/agat_convert_sp_gff2zff.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,13 +22,13 @@ my $script = $script_prefix . catfile($bin_dir, "agat_convert_sp_gff2zff.pl");
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_convert_sp_gff2zff_1.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/1.gff --fasta $input_folder/1.fa -o $outtmp");
-    check_diff( "$outprefix.ann", $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/1.gff", fasta => "$input_folder/1.fa" },
+    "$result.stdout",
+    $result,
+    '.ann'
+);
 
 
 

--- a/t/agat_convert_sp_gxf2gxf.t
+++ b/t/agat_convert_sp_gxf2gxf.t
@@ -5,7 +5,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catdir catfile);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix); 
 use Test::More;
 
 my $script_prefix = script_prefix();

--- a/t/agat_sp_Prokka_inferNameFromAttributes.t
+++ b/t/agat_sp_Prokka_inferNameFromAttributes.t
@@ -5,7 +5,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catdir catfile);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix); 
 use Test::More;
 
 my $script_prefix = script_prefix();

--- a/t/agat_sp_add_attribute_shortest_exon_size.t
+++ b/t/agat_sp_add_attribute_shortest_exon_size.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,13 +22,12 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sp_add_attribute_shortest_
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sp_add_attribute_shortest_exon_size.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/1.gff" },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_sp_add_attribute_shortest_intron_size.t
+++ b/t/agat_sp_add_attribute_shortest_intron_size.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,13 +22,12 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sp_add_attribute_shortest_
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sp_add_attribute_shortest_intron_size.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/1.gff" },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_sp_add_intergenic_regions.t
+++ b/t/agat_sp_add_intergenic_regions.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,13 +22,12 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sp_add_intergenic_regions.
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sp_add_intergenic_regions_1.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/1.gff" },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_sp_add_introns.t
+++ b/t/agat_sp_add_introns.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,13 +22,12 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sp_add_introns.pl");
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sp_add_introns_1.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/1.gff" },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_sp_add_splice_sites.t
+++ b/t/agat_sp_add_splice_sites.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,13 +22,12 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sp_add_splice_sites.pl");
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sp_add_splice_sites_1.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/0.gff -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/0.gff" },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_sp_add_start_and_stop.t
+++ b/t/agat_sp_add_start_and_stop.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,24 +22,22 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sp_add_start_and_stop.pl")
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sp_add_start_and_stop_1.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/agat_sp_add_start_and_stop.gff --fasta $input_folder/1.fa --ni -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/agat_sp_add_start_and_stop.gff", fasta => "$input_folder/1.fa", ni => 1 },
+    "$result.stdout",
+    $result
+);
 
 
 $script = $script_prefix . catfile($bin_dir, "agat_sp_add_start_and_stop.pl");
 $result = "$output_folder/agat_sp_add_start_and_stop_2.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/agat_sp_add_start_and_stop.gff --fasta $input_folder/1.fa -e --ni -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/agat_sp_add_start_and_stop.gff", fasta => "$input_folder/1.fa", e => 1, ni => 1 },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_sp_alignment_output_style.t
+++ b/t/agat_sp_alignment_output_style.t
@@ -5,7 +5,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catdir catfile);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix); 
 use Test::More;
 
 my $script_prefix = script_prefix();

--- a/t/agat_sp_clipN_seqExtremities_and_fixCoordinates.t
+++ b/t/agat_sp_clipN_seqExtremities_and_fixCoordinates.t
@@ -5,7 +5,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catdir catfile);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix); 
 use Test::More;
 
 my $script_prefix = script_prefix();

--- a/t/agat_sp_compare_two_BUSCOs.t
+++ b/t/agat_sp_compare_two_BUSCOs.t
@@ -5,7 +5,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catdir catfile);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix); 
 use Test::More;
 
 my $script_prefix = script_prefix();

--- a/t/agat_sp_compare_two_annotations.t
+++ b/t/agat_sp_compare_two_annotations.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -21,32 +21,35 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sp_compare_two_annotations
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sp_compare_two_annotations_1.txt";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    check_quiet_run(" $script --gff1 $input_folder/1.gff  --gff2 $input_folder/1.gff -o $outtmp");
-    check_diff( "$outtmp/report.txt", $result, "output $script", "-I '^usage:'" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff1 => "$input_folder/1.gff", gff2 => "$input_folder/1.gff" },
+    "$result.stdout",
+    $result,
+    '.gff/report.txt'
+);
 
 
 $script = $script_prefix . catfile($bin_dir, "agat_sp_compare_two_annotations.pl");
 $result = "$output_folder/agat_sp_compare_two_annotations_2.txt";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    check_quiet_run(" $script --gff1 $input_folder/agat_sp_compare_two_annotations/file1.gff  --gff2 $input_folder/agat_sp_compare_two_annotations/file2.gff -o $outtmp");
-    check_diff( "$outtmp/report.txt", $result, "output $script", "-I '^usage:'" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff1 => "$input_folder/agat_sp_compare_two_annotations/file1.gff", gff2 => "$input_folder/agat_sp_compare_two_annotations/file2.gff" },
+    "$result.stdout",
+    $result,
+    '.gff/report.txt'
+);
 
 
 $script = $script_prefix . catfile($bin_dir, "agat_sp_compare_two_annotations.pl");
 $result = "$output_folder/agat_sp_compare_two_annotations_3.txt";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    check_quiet_run(" $script --gff1 $input_folder/agat_sp_compare_two_annotations/file2.gff  --gff2 $input_folder/agat_sp_compare_two_annotations/file1.gff -o $outtmp");
-    check_diff( "$outtmp/report.txt", $result, "output $script", "-I '^usage:'" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff1 => "$input_folder/agat_sp_compare_two_annotations/file2.gff", gff2 => "$input_folder/agat_sp_compare_two_annotations/file1.gff" },
+    "$result.stdout",
+    $result,
+    '.gff/report.txt'
+);
 
 
 

--- a/t/agat_sp_complement_annotations.t
+++ b/t/agat_sp_complement_annotations.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -21,29 +21,24 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sp_complement_annotations.
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sp_complement_annotations_1.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(
-        " $script --ref "
-          . catfile( $Bin, 'gff', 'gff_syntax', 'in', '25_test.gff' )
-          . "  --add "
-          . catfile( $Bin, 'gff', 'gff_syntax', 'in', '9_test.gff' )
-          . " -o $outtmp"
-    );
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    {
+        ref => catfile( $Bin, 'gff', 'gff_syntax', 'in', '25_test.gff' ),
+        add => catfile( $Bin, 'gff', 'gff_syntax', 'in', '9_test.gff' ),
+    },
+    "$result.stdout",
+    $result
+);
 
 
 $result = "$output_folder/agat_sp_complement_annotations_2.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --ref $input_folder/agat_sp_complement_annotations/agat_sp_complement_annotations_ref.gff  --add $input_folder/agat_sp_complement_annotations/agat_sp_complement_annotations_add.gff -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { ref => "$input_folder/agat_sp_complement_annotations/agat_sp_complement_annotations_ref.gff", add => "$input_folder/agat_sp_complement_annotations/agat_sp_complement_annotations_add.gff" },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_sp_ensembl_output_style.t
+++ b/t/agat_sp_ensembl_output_style.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,13 +22,12 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sp_ensembl_output_style.pl
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sp_ensembl_output_style_1.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run("$script --gff $input_folder/0.gff -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/0.gff" },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_sp_extract_attributes.t
+++ b/t/agat_sp_extract_attributes.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,13 +22,13 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sp_extract_attributes.pl")
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sp_extract_attributes_1.txt";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/1.gff --att protein_id -o $outtmp");
-    check_diff( "${outprefix}_protein_id.gff", $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/1.gff", att => "protein_id" },
+    "$result.stdout",
+    $result,
+    '_protein_id.gff'
+);
 
 
 

--- a/t/agat_sp_extract_sequences.t
+++ b/t/agat_sp_extract_sequences.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,68 +22,62 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sp_extract_sequences.pl");
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$input_folder/agat_sp_extract_sequences/agat_sp_extract_sequences_1.fa";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/1.gff --fasta $input_folder/1.fa -o $outtmp");
-    check_diff( $outtmp, $result, "output $script test1" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/1.gff", fasta => "$input_folder/1.fa" },
+    "$result.stdout",
+    $result
+);
 
 
 $script = $script_prefix . catfile($bin_dir, "agat_sp_extract_sequences.pl");
 $result = "$input_folder/agat_sp_extract_sequences/agat_sp_extract_sequences_split.fa";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/1.gff --fasta $input_folder/1.fa --split -o $outtmp");
-    check_diff( $outtmp, $result, "output $script test2" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/1.gff", fasta => "$input_folder/1.fa", split => 1 },
+    "$result.stdout",
+    $result
+);
 
 
 $script = $script_prefix . catfile($bin_dir, "agat_sp_extract_sequences.pl");
 $result = "$input_folder/agat_sp_extract_sequences/agat_sp_extract_sequences_merge.fa";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/1.gff --fasta $input_folder/1.fa -t exon --merge -o $outtmp");
-    check_diff( $outtmp, $result, "output $script test3" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/1.gff", fasta => "$input_folder/1.fa", t => "exon", merge => 1 },
+    "$result.stdout",
+    $result
+);
 
 
 $script = $script_prefix . catfile($bin_dir, "agat_sp_extract_sequences.pl");
 $result = "$input_folder/agat_sp_extract_sequences/agat_sp_extract_sequences_full.fa";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/1.gff --fasta $input_folder/1.fa --full -o $outtmp");
-    check_diff( $outtmp, $result, "output $script test4" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/1.gff", fasta => "$input_folder/1.fa", full => 1 },
+    "$result.stdout",
+    $result
+);
 
 
 $script = $script_prefix . catfile($bin_dir, "agat_sp_extract_sequences.pl");
 $result = "$input_folder/agat_sp_extract_sequences/agat_sp_extract_sequences_attributes_kept.fa";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/1.gff --fasta $input_folder/1.fa --keep_attributes -o $outtmp");
-    check_diff( $outtmp, $result, "output $script test5" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/1.gff", fasta => "$input_folder/1.fa", keep_attributes => 1 },
+    "$result.stdout",
+    $result
+);
 
 
 $script = $script_prefix . catfile($bin_dir, "agat_sp_extract_sequences.pl");
 $result = "$input_folder/agat_sp_extract_sequences/agat_sp_extract_sequences_parent_attributes_kept.fa";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/1.gff --fasta $input_folder/1.fa --keep_parent_attributes -o $outtmp");
-    check_diff( $outtmp, $result, "output $script test6" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/1.gff", fasta => "$input_folder/1.fa", keep_parent_attributes => 1 },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_sp_filter_by_ORF_size.t
+++ b/t/agat_sp_filter_by_ORF_size.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -21,13 +21,13 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sp_filter_by_ORF_size.pl")
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sp_filter_by_ORF_size_sup100.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp");
-    check_diff( "${outprefix}_sup100.gff", $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/1.gff" },
+    "$result.stdout",
+    $result,
+    '_sup100.gff'
+);
 
 
 

--- a/t/agat_sp_filter_by_locus_distance.t
+++ b/t/agat_sp_filter_by_locus_distance.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -21,13 +21,12 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sp_filter_by_locus_distanc
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sp_filter_by_locus_distance_1.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/1.gff" },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_sp_filter_by_mrnaBlastValue.t
+++ b/t/agat_sp_filter_by_mrnaBlastValue.t
@@ -5,7 +5,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catdir catfile);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix); 
 use Test::More;
 
 my $script_prefix = script_prefix();

--- a/t/agat_sp_filter_feature_by_attribute_presence.t
+++ b/t/agat_sp_filter_feature_by_attribute_presence.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -21,13 +21,12 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sp_filter_feature_by_attri
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sp_filter_feature_by_attribute_presence_1.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp -a protein_id");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/1.gff" },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_sp_filter_feature_by_attribute_value.t
+++ b/t/agat_sp_filter_feature_by_attribute_value.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,13 +22,12 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sp_filter_feature_by_attri
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sp_filter_feature_by_attribute_value_1.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp --value Os01t0100100-01 -p level3 -a protein_id");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/1.gff" },
+    "$result.stdout",
+    $result
+);
 
 {
     my $dir = setup_tempdir();

--- a/t/agat_sp_filter_feature_from_keep_list.t
+++ b/t/agat_sp_filter_feature_from_keep_list.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,13 +22,12 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sp_filter_feature_from_kee
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sp_filter_feature_from_keep_list_1.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp --kl $input_folder/keep_list.txt");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/1.gff" },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_sp_filter_feature_from_kill_list.t
+++ b/t/agat_sp_filter_feature_from_kill_list.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,13 +22,12 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sp_filter_feature_from_kil
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sp_filter_feature_from_kill_list_1.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp --kl $input_folder/kill_list.txt");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/1.gff" },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_sp_filter_gene_by_intron_numbers.t
+++ b/t/agat_sp_filter_gene_by_intron_numbers.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,13 +22,12 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sp_filter_gene_by_intron_n
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sp_filter_gene_by_intron_numbers_1.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/1.gff" },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_sp_filter_gene_by_length.t
+++ b/t/agat_sp_filter_gene_by_length.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,13 +22,12 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sp_filter_gene_by_length.p
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sp_filter_gene_by_length_1.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/1.gff --size 1000 --test \"<\" -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/1.gff", size => "1000", test => "\"<\"" },
+    "$result.stdout",
+    $result
+);
 
 {
     my $dir = setup_tempdir();

--- a/t/agat_sp_filter_incomplete_gene_coding_models.t
+++ b/t/agat_sp_filter_incomplete_gene_coding_models.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -21,16 +21,16 @@ my $config = 'agat_config.yaml';
 my $script = $script_prefix . catfile($bin_dir, "agat_sp_filter_incomplete_gene_coding_models.pl");
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
-my $result = "$output_folder/agat_sp_filter_incomplete_gene_coding_models_1.gff";
-my $result2 = "$output_folder/agat_sp_filter_incomplete_gene_coding_models_incomplete_1.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/1.gff --fasta $input_folder/1.fa -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-    check_diff( $outprefix . "_incomplete.gff", $result2, "output $script" );
-}
+my $result  = "$output_folder/agat_sp_filter_incomplete_gene_coding_models_1.gff";
+my $result2 =
+  "$output_folder/agat_sp_filter_incomplete_gene_coding_models_incomplete_1.gff";
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/1.gff", fasta => "$input_folder/1.fa" },
+    "$result.stdout",
+    [ $result, $result2 ],
+    [ undef, '_incomplete.gff' ]
+);
 
 
 

--- a/t/agat_sp_filter_record_by_coordinates.t
+++ b/t/agat_sp_filter_record_by_coordinates.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,13 +22,13 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sp_filter_record_by_coordi
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sp_filter_record_by_coordinates_1.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/1.gff --tsv $input_folder/coordinates.tsv -o $outtmp");
-    check_diff( "$outtmp/remaining.gff3", $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/1.gff", tsv => "$input_folder/coordinates.tsv" },
+    "$result.stdout",
+    $result,
+    '.gff/remaining.gff3'
+);
 
 
 

--- a/t/agat_sp_fix_cds_phases.t
+++ b/t/agat_sp_fix_cds_phases.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,13 +22,12 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sp_fix_cds_phases.pl");
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sp_fix_cds_phases_1.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/1.gff --fasta $input_folder/1.fa -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/1.gff", fasta => "$input_folder/1.fa" },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_sp_fix_features_locations_duplicated.t
+++ b/t/agat_sp_fix_features_locations_duplicated.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -23,13 +23,12 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sp_fix_features_locations_
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sp_fix_features_locations_duplicated_1.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/agat_sp_fix_features_locations_duplicated/test.gff -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/agat_sp_fix_features_locations_duplicated/test.gff" },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_sp_fix_fusion.t
+++ b/t/agat_sp_fix_fusion.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,13 +22,13 @@ my $script = $script_prefix . catfile( $bin_dir, "agat_sp_fix_fusion.pl" );
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sp_fix_fusion_1.txt";
-{
-    my $dir = setup_tempdir();
-    my $outtmp    = catfile( $dir, 'tmp.gff' );
-    my $outprefix = catfile( $dir, 'tmp' );
-    check_quiet_run(" $script --gff $input_folder/1.gff --fasta $input_folder/1.fa -o $outtmp");
-    check_diff( "$outprefix-report.txt", $result, "output $script", "-b -I '^Job done in' -I '^usage:'" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/1.gff", fasta => "$input_folder/1.fa" },
+    "$result.stdout",
+    $result,
+    '-report.txt'
+);
 
 
 done_testing();

--- a/t/agat_sp_fix_longest_ORF.t
+++ b/t/agat_sp_fix_longest_ORF.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -25,6 +25,7 @@ my $result = "$output_folder/agat_sp_fix_longest_ORF_1.txt";
 check_quiet_and_normal_run(
     $script,
     { gff => "$input_folder/1.gff", fasta => "$input_folder/1.fa" },
+    "$result.stdout",
     $result,
     '-report.txt'
 );

--- a/t/agat_sp_fix_overlaping_genes.t
+++ b/t/agat_sp_fix_overlaping_genes.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,24 +22,22 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sp_fix_overlaping_genes.pl
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sp_fix_overlaping_genes_1.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/genes_overlap.gff -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/genes_overlap.gff" },
+    "$result.stdout",
+    $result
+);
 
 
 $script = $script_prefix . catfile($bin_dir, "agat_sp_fix_overlaping_genes.pl");
 $result = "$output_folder/agat_sp_fix_overlaping_genes_2.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/genes_overlap.gff -o $outtmp --merge");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/genes_overlap.gff", merge => 1 },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_sp_fix_small_exon_from_extremities.t
+++ b/t/agat_sp_fix_small_exon_from_extremities.t
@@ -5,7 +5,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catdir catfile);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix); 
 use Test::More;
 
 my $script_prefix = script_prefix();

--- a/t/agat_sp_flag_premature_stop_codons.t
+++ b/t/agat_sp_flag_premature_stop_codons.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,13 +22,12 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sp_flag_premature_stop_cod
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sp_flag_premature_stop_codons_1.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/prokka_fragmented_genes.gff --fasta $input_folder/prokka_cav_10DC88.fa -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/prokka_fragmented_genes.gff", fasta => "$input_folder/prokka_cav_10DC88.fa" },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_sp_flag_short_introns.t
+++ b/t/agat_sp_flag_short_introns.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,13 +22,12 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sp_flag_short_introns.pl")
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sp_flag_short_introns_1.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/agat_sp_flag_short_introns.gff -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/agat_sp_flag_short_introns.gff" },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_sp_flag_short_introns_ebi.t
+++ b/t/agat_sp_flag_short_introns_ebi.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,13 +22,12 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sp_flag_short_introns_ebi.
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sp_flag_short_introns_ebi_1.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/agat_sp_flag_short_introns_ebi.gff -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/agat_sp_flag_short_introns_ebi.gff" },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_sp_functional_statistics.t
+++ b/t/agat_sp_functional_statistics.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -21,17 +21,17 @@ my $config = 'agat_config.yaml';
 my $script = $script_prefix . catfile($bin_dir, "agat_sp_functional_statistics.pl");
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
-my $result = "$output_folder/agat_sp_functional_statistics_1.txt";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/function.gff -o $outtmp");
-    check_diff( "$outtmp/gene\@mrna/table_per_feature_type.txt", "$output_folder/agat_sp_functional_statistics/table_gene_mrna.txt", "output $script" );
-    check_diff( "$outtmp/repeat_region/table_per_feature_type.txt", "$output_folder/agat_sp_functional_statistics/table_repeat.txt", "output $script" );
-}
-
-
-
-
+my $result  = "$output_folder/agat_sp_functional_statistics_1.txt";
+my $result1 = "$output_folder/agat_sp_functional_statistics/table_gene_mrna.txt";
+my $result2 = "$output_folder/agat_sp_functional_statistics/table_repeat.txt";
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/function.gff" },
+    "$result.stdout",
+    [ $result1, $result2 ],
+    [
+        '.gff/gene@mrna/table_per_feature_type.txt',
+        '.gff/repeat_region/table_per_feature_type.txt',
+    ]
+);
 done_testing();

--- a/t/agat_sp_keep_longest_isoform.t
+++ b/t/agat_sp_keep_longest_isoform.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,23 +22,21 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sp_keep_longest_isoform.pl
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sp_keep_longest_isoform_1.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/1.gff" },
+    "$result.stdout",
+    $result
+);
 
 
 $result = "$output_folder/agat_sp_keep_longest_isoform_2.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/agat_sp_keep_longest_isoform_2.gff -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/agat_sp_keep_longest_isoform_2.gff" },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_sp_kraken_assess_liftover.t
+++ b/t/agat_sp_kraken_assess_liftover.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,13 +22,12 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sp_kraken_assess_liftover.
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sp_kraken_assess_liftover_1.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gtf $input_folder/test_kraken.gtf -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gtf => "$input_folder/test_kraken.gtf" },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_sp_list_short_introns.t
+++ b/t/agat_sp_list_short_introns.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,13 +22,12 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sp_list_short_introns.pl")
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sp_list_short_introns_1.txt";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/1.gff" },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_sp_load_function_from_protein_align.t
+++ b/t/agat_sp_load_function_from_protein_align.t
@@ -5,7 +5,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catdir catfile);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix); 
 use Test::More;
 
 my $script_prefix = script_prefix();

--- a/t/agat_sp_manage_IDs.t
+++ b/t/agat_sp_manage_IDs.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -21,12 +21,13 @@ my $config = 'agat_config.yaml';
 my $script = $script_prefix . catfile($bin_dir, "agat_sp_manage_IDs.pl");
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile( $dir, 'tmp.gff' );
-    ok( check_quiet_run(" $script --gff $input_folder/1.gff --ensembl -o $outtmp") == 0,
-        "output $script" );
-}
+my $result = "$output_folder/agat_sp_manage_IDs_1.gff";
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/1.gff", ensembl => 1 },
+    "$result.stdout",
+    $result
+);
 
 {
     my $dir = setup_tempdir();

--- a/t/agat_sp_manage_UTRs.t
+++ b/t/agat_sp_manage_UTRs.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,13 +22,13 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sp_manage_UTRs.pl");
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sp_manage_UTRs_1.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/1.gff -b -o $outtmp");
-    check_diff( "$outprefix/1_bothSides_under5.gff", $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/1.gff", b => 1 },
+    "$result.stdout",
+    $result,
+    '/1_bothSides_under5.gff'
+);
 
 
 

--- a/t/agat_sp_manage_attributes.t
+++ b/t/agat_sp_manage_attributes.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,13 +22,12 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sp_manage_attributes.pl");
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sp_manage_attributes_1.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/1.gff --att protein_id -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/1.gff", att => "protein_id" },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_sp_manage_functional_annotation.t
+++ b/t/agat_sp_manage_functional_annotation.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,13 +22,13 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sp_manage_functional_annot
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sp_manage_functional_annotation_1.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/agat_sp_manage_functional_annotation/02413F.gff --db $input_folder/agat_sp_manage_functional_annotation/uniprot_sprot_test.fasta -b $input_folder/agat_sp_manage_functional_annotation/02413F_blast.out -i $input_folder/agat_sp_manage_functional_annotation/02413F_interpro.tsv --clean_name -o $outtmp");
-    check_diff( "$outtmp/02413F.gff", $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/agat_sp_manage_functional_annotation/02413F.gff", db => "$input_folder/agat_sp_manage_functional_annotation/uniprot_sprot_test.fasta", b => "$input_folder/agat_sp_manage_functional_annotation/02413F_blast.out", i => "$input_folder/agat_sp_manage_functional_annotation/02413F_interpro.tsv", clean_name => 1 },
+    "$result.stdout",
+    $result,
+    '.gff/02413F.gff'
+);
 
 
 

--- a/t/agat_sp_manage_introns.t
+++ b/t/agat_sp_manage_introns.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,13 +22,13 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sp_manage_introns.pl");
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sp_manage_introns_1.txt";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp");
-    check_diff( "$outtmp/report.txt", $result, "output $script", "-b -I '^usage:'" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/1.gff" },
+    "$result.stdout",
+    $result,
+    '.gff/report.txt'
+);
 
 
 

--- a/t/agat_sp_merge_annotations.t
+++ b/t/agat_sp_merge_annotations.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,33 +22,30 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sp_merge_annotations.pl");
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sp_merge_annotations_1.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/agat_sp_merge_annotations/file1.gff  --gff $input_folder/agat_sp_merge_annotations/file2.gff -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/agat_sp_merge_annotations/file1.gff", gff => "$input_folder/agat_sp_merge_annotations/file2.gff" },
+    "$result.stdout",
+    $result
+);
 
 
 $result = "$output_folder/agat_sp_merge_annotations_2.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/agat_sp_merge_annotations/fileA.gff  --gff $input_folder/agat_sp_merge_annotations/fileB.gff -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/agat_sp_merge_annotations/fileA.gff", gff => "$input_folder/agat_sp_merge_annotations/fileB.gff" },
+    "$result.stdout",
+    $result
+);
 
 
 $result = "$output_folder/agat_sp_merge_annotations_3.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/agat_sp_merge_annotations/test457_A.gff  --gff $input_folder/agat_sp_merge_annotations/test457_B.gff -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/agat_sp_merge_annotations/test457_A.gff", gff => "$input_folder/agat_sp_merge_annotations/test457_B.gff" },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_sp_move_attributes_within_records.t
+++ b/t/agat_sp_move_attributes_within_records.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,13 +22,12 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sp_move_attributes_within_
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sp_move_attributes_within_records.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/agat_sp_move_attributes_within_records.gff --fp exon,CDS --fc mRNA -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/agat_sp_move_attributes_within_records.gff", fp => "exon,CDS", fc => "mRNA" },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_sp_prokka_fix_fragmented_gene_annotations.t
+++ b/t/agat_sp_prokka_fix_fragmented_gene_annotations.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -21,16 +21,21 @@ my $config = 'agat_config.yaml';
 my $script = $script_prefix . catfile($bin_dir, "agat_sp_prokka_fix_fragmented_gene_annotations.pl");
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
-my $result = "$output_folder/agat_sp_prokka_fix_fragmented_gene_annotations_1.gff";
+my $result  = "$output_folder/agat_sp_prokka_fix_fragmented_gene_annotations_1.gff";
 my $result2 = "$output_folder/agat_sp_prokka_fix_fragmented_gene_annotations_1.fa";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/prokka_cav_10DC88.gff --fasta $input_folder/prokka_cav_10DC88.fa --db $input_folder/prokka_bacteria_sprot.fa --skip_hamap --frags -o $outtmp");
-    check_diff( "$outtmp/prokka_cav_10DC88.gff", $result, "output $script" );
-    check_diff( "$outtmp/prokka_cav_10DC88.fa", $result2, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    {
+        gff   => "$input_folder/prokka_cav_10DC88.gff",
+        fasta => "$input_folder/prokka_cav_10DC88.fa",
+        db    => "$input_folder/prokka_bacteria_sprot.fa",
+        skip_hamap => 1,
+        frags      => 1
+    },
+    "$result.stdout",
+    [ $result, $result2 ],
+    [ '.gff/prokka_cav_10DC88.gff', '.gff/prokka_cav_10DC88.fa' ]
+);
 
 
 

--- a/t/agat_sp_sensitivity_specificity.t
+++ b/t/agat_sp_sensitivity_specificity.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,52 +22,52 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sp_sensitivity_specificity
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sp_sensitivity_specificity_1.txt";
-{
-    my $dir = setup_tempdir();
-    my $outtmp   = catfile( $dir, 'tmp.gff' );
-    check_quiet_run(" $script --gff1 $input_folder/1.gff --gff2 $input_folder/1.gff -o $outtmp");
-    check_diff( $outtmp, $result, "output $script", "-I '^usage:'" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff1 => "$input_folder/1.gff", gff2 => "$input_folder/1.gff" },
+    "$result.stdout",
+    $result
+);
 
 
 $script = $script_prefix . catfile($bin_dir, "agat_sp_sensitivity_specificity.pl");
 $result = "$output_folder/agat_sp_sensitivity_specificity_2.txt";
-{
-    my $dir = setup_tempdir();
-    my $outtmp   = catfile( $dir, 'tmp.gff' );
-    check_quiet_run(" $script --gff1 $input_folder/agat_sp_sensitivity_specificity/ref0.gff3 --gff2 $input_folder/agat_sp_sensitivity_specificity/query0.gff3 -o $outtmp");
-    check_diff( $outtmp, $result, "output $script", "-I '^usage:'" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff1 => "$input_folder/agat_sp_sensitivity_specificity/ref0.gff3", gff2 => "$input_folder/agat_sp_sensitivity_specificity/query0.gff3" },
+    "$result.stdout",
+    $result
+);
 
 
 $script = $script_prefix . catfile($bin_dir, "agat_sp_sensitivity_specificity.pl");
 $result = "$output_folder/agat_sp_sensitivity_specificity_3.txt";
-{
-    my $dir = setup_tempdir();
-    my $outtmp   = catfile( $dir, 'tmp.gff' );
-    check_quiet_run(" $script --gff1 $input_folder/agat_sp_sensitivity_specificity/ref1.gff3 --gff2 $input_folder/agat_sp_sensitivity_specificity/query1.gff3 -o $outtmp");
-    check_diff( $outtmp, $result, "output $script", "-I '^usage:'" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff1 => "$input_folder/agat_sp_sensitivity_specificity/ref1.gff3", gff2 => "$input_folder/agat_sp_sensitivity_specificity/query1.gff3" },
+    "$result.stdout",
+    $result
+);
 
 
 $script = $script_prefix . catfile($bin_dir, "agat_sp_sensitivity_specificity.pl");
 $result = "$output_folder/agat_sp_sensitivity_specificity_4.txt";
-{
-    my $dir = setup_tempdir();
-    my $outtmp   = catfile( $dir, 'tmp.gff' );
-    check_quiet_run(" $script --gff1 $input_folder/agat_sp_sensitivity_specificity/ref2.gff3 --gff2 $input_folder/agat_sp_sensitivity_specificity/query2.gff3 -o $outtmp");
-    check_diff( $outtmp, $result, "output $script", "-I '^usage:'" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff1 => "$input_folder/agat_sp_sensitivity_specificity/ref2.gff3", gff2 => "$input_folder/agat_sp_sensitivity_specificity/query2.gff3" },
+    "$result.stdout",
+    $result
+);
 
 
 $script = $script_prefix . catfile($bin_dir, "agat_sp_sensitivity_specificity.pl");
 $result = "$output_folder/agat_sp_sensitivity_specificity_5.txt";
-{
-    my $dir = setup_tempdir();
-    my $outtmp   = catfile( $dir, 'tmp.gff' );
-    check_quiet_run(" $script --gff1 $input_folder/agat_sp_sensitivity_specificity/ref3.gff3 --gff2 $input_folder/agat_sp_sensitivity_specificity/query3.gff3 -o $outtmp");
-    check_diff( $outtmp, $result, "output $script", "-I '^usage:'" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff1 => "$input_folder/agat_sp_sensitivity_specificity/ref3.gff3", gff2 => "$input_folder/agat_sp_sensitivity_specificity/query3.gff3" },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_sp_separate_by_record_type.t
+++ b/t/agat_sp_separate_by_record_type.t
@@ -5,7 +5,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catdir catfile);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix); 
 use Test::More;
 
 my $script_prefix = script_prefix();

--- a/t/agat_sp_split_by_level2_feature.t
+++ b/t/agat_sp_split_by_level2_feature.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,13 +22,13 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sp_separate_by_record_type
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sp_separate_by_record_type_1.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp");
-    check_diff( "$outtmp/trna.gff", $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/1.gff" },
+    "$result.stdout",
+    $result,
+    '.gff/trna.gff'
+);
 
 
 

--- a/t/agat_sp_statistics.t
+++ b/t/agat_sp_statistics.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,13 +22,12 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sp_statistics.pl");
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sp_statistics_1.txt";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp -r");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/1.gff" },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_sp_to_tabulated.t
+++ b/t/agat_sp_to_tabulated.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,13 +22,12 @@ my $script = $script_prefix . catfile($bin_dir, "agat_convert_sp_gff2tsv.pl");
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_convert_sp_gff2tsv_1.tsv";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/1.gff" },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_sp_webApollo_compliant.t
+++ b/t/agat_sp_webApollo_compliant.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,13 +22,12 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sp_webApollo_compliant.pl"
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sp_webApollo_compliant_1.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/1.gff" },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_sq_add_attributes_from_tsv.t
+++ b/t/agat_sq_add_attributes_from_tsv.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,13 +22,12 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sq_add_attributes_from_tsv
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sq_add_attributes_from_tsv_1.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/agat_sq_add_attributes_from_tsv.gff --tsv $input_folder/agat_sq_add_attributes_from_tsv.tsv -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/agat_sq_add_attributes_from_tsv.gff", tsv => "$input_folder/agat_sq_add_attributes_from_tsv.tsv" },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_sq_add_hash_tag.t
+++ b/t/agat_sq_add_hash_tag.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,13 +22,12 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sq_add_hash_tag.pl");
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sq_add_hash_tag_1.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/1.gff -i 2 -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/1.gff", i => "2" },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_sq_add_locus_tag.t
+++ b/t/agat_sq_add_locus_tag.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,13 +22,12 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sq_add_locus_tag.pl");
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sq_add_locus_tag_1.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/1.gff" },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_sq_count_attributes.t
+++ b/t/agat_sq_count_attributes.t
@@ -5,7 +5,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catdir catfile);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix); 
 use Test::More;
 
 my $script_prefix = script_prefix();

--- a/t/agat_sq_filter_feature_from_fasta.t
+++ b/t/agat_sq_filter_feature_from_fasta.t
@@ -5,7 +5,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catdir catfile);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix); 
 use Test::More;
 
 my $script_prefix = script_prefix();

--- a/t/agat_sq_list_attributes.t
+++ b/t/agat_sq_list_attributes.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,13 +22,12 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sq_list_attributes.pl");
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sq_list_attributes_1.txt";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp");
-    check_diff( $outtmp, $result, "output $script", "-b -I '^Job done in'" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/1.gff" },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_sq_manage_IDs.t
+++ b/t/agat_sq_manage_IDs.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,13 +22,12 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sq_manage_IDs.pl");
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sq_manage_IDs_1.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/1.gff" },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_sq_manage_attributes.t
+++ b/t/agat_sq_manage_attributes.t
@@ -5,7 +5,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catdir catfile);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix); 
 use Test::More;
 
 my $script_prefix = script_prefix();

--- a/t/agat_sq_mask.t
+++ b/t/agat_sq_mask.t
@@ -5,7 +5,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catdir catfile);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix); 
 use Test::More;
 
 my $script_prefix = script_prefix();

--- a/t/agat_sq_remove_redundant_entries.t
+++ b/t/agat_sq_remove_redundant_entries.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,13 +22,12 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sq_remove_redundant_entrie
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sq_remove_redundant_entries_1.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/1.gff" },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_sq_rename_seqid.t
+++ b/t/agat_sq_rename_seqid.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,13 +22,12 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sq_rename_seqid.pl");
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sq_rename_seqid_1.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/agat_sq_rename_seqid/rename_seqid.gff --tsv $input_folder/agat_sq_rename_seqid/rename_table.tsv -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/agat_sq_rename_seqid/rename_seqid.gff", tsv => "$input_folder/agat_sq_rename_seqid/rename_table.tsv" },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_sq_repeats_analyzer.t
+++ b/t/agat_sq_repeats_analyzer.t
@@ -5,7 +5,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catdir catfile);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix); 
 use Test::More;
 
 my $script_prefix = script_prefix();

--- a/t/agat_sq_reverse_complement.t
+++ b/t/agat_sq_reverse_complement.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,13 +22,12 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sq_reverse_complement.pl")
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sq_reverse_complement_1.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/1.gff --fasta  $input_folder/1.fa -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/1.gff", fasta => "$input_folder/1.fa" },
+    "$result.stdout",
+    $result
+);
 
 
 

--- a/t/agat_sq_rfam_analyzer.t
+++ b/t/agat_sq_rfam_analyzer.t
@@ -5,7 +5,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catdir catfile);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix); 
 use Test::More;
 
 my $script_prefix = script_prefix();

--- a/t/agat_sq_split.t
+++ b/t/agat_sq_split.t
@@ -5,7 +5,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catdir catfile);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir script_prefix);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix); 
 use Test::More;
 
 my $script_prefix = script_prefix();

--- a/t/agat_sq_stat_basic.t
+++ b/t/agat_sq_stat_basic.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(abs_path);
-use AGAT::TestUtilities qw(setup_tempdir check_diff script_prefix check_quiet_run);
+use AGAT::TestUtilities qw(setup_tempdir script_prefix check_quiet_and_normal_run); 
 use Test::More;
 
 my $script_prefix = script_prefix();
@@ -22,13 +22,12 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sq_stat_basic.pl");
 { my $dir = setup_tempdir(); ok(system("$script -h 1>\/dev\/null") == 0, "help $script"); }
 
 my $result = "$output_folder/agat_sq_stat_basic_1.gff";
-{
-    my $dir = setup_tempdir();
-    my $outtmp = catfile($dir, 'tmp.gff');
-    my $outprefix = catfile($dir, 'tmp');
-    check_quiet_run(" $script --gff $input_folder/1.gff -o $outtmp");
-    check_diff( $outtmp, $result, "output $script" );
-}
+check_quiet_and_normal_run(
+    $script,
+    { gff => "$input_folder/1.gff" },
+    "$result.stdout",
+    $result
+);
 
 
 


### PR DESCRIPTION
## Summary
- decouple quiet and normal checks in `check_quiet_and_normal_run`, comparing console output separately
- adjust all `t/agat*.t` scripts to supply expected stdout fixtures

## Testing
- `prove -lr t/smoke` *(fails: Cannot detect source of 't/smoke')*
- `.agents/with-perl-local.sh make test` *(fails: Can't locate local/lib.pm)*

------
https://chatgpt.com/codex/tasks/task_e_68ad7d270b38832abd6a0ddd7ffb880e