### PR TITLE
Ensure verbosity level for specific diagnostic logs

### DIFF
--- a/bin/agat_sp_compare_two_annotations.pl
+++ b/bin/agat_sp_compare_two_annotations.pl
@@ -73,7 +73,7 @@ my %overlap_info; # <= Will contain the overlap information
 # ------------------------------------------------------------------------------
 # ---------------------------- COLLECT ALL LOCATIONS ---------------------------
 # ------------------------------------------------------------------------------
-dual_print( $log, "COLLECT LOCATIONS\n");
+dual_print( $log, "COLLECT LOCATIONS\n", 2 );
 my $bucket_locations1 = {};
 my $bucket_locations2 = {};
 my $cpt = 0;
@@ -148,7 +148,7 @@ foreach my $sortBySeq ($sortBySeq1, $sortBySeq2){
 # ------------------------- FLATTEN OVERLAPPING LOCATIONS ----------------------
 # ------------------------------------------------------------------------------
 # Will merge same location types that overlap
-dual_print( $log, "FLATTEN LOCATIONS\n");
+dual_print( $log, "FLATTEN LOCATIONS\n", 2 );
 my $flattened_locations_clean;
 my $flattened_locations1_clean = {};
 my $flattened_locations2_clean = {};
@@ -277,7 +277,7 @@ foreach my $locusID ( sort  keys %{$flattened_locations2_clean} ){
 # ------------------------------------------------------------------------------
 
 # When already checked the location is removed from flattened_locationsX_clean_sorted hash
-dual_print( $log, "COMPARE LOCATIONS\n");
+dual_print( $log, "COMPARE LOCATIONS\n", 2 );
 my %seen1;
 my %seen2;
 foreach my $locusID ( sort  keys %{$flattened_locations1_clean_sorted} ){
@@ -431,7 +431,7 @@ foreach my $locusID ( sort  keys %{$flattened_locations1_clean_sorted} ){
 
 # ---- NOw deal with what is remaining in annotationA
 # Gather False positive => seq only annotated in annotationB, or type of feature annotated only in annotationB that was missing in annotatoin A
-dual_print( $log, "\nLook now what is specific to annotationA \n");
+dual_print( $log, "\nLook now what is specific to annotationA \n", 2 );
 foreach my $locusID (  keys %{$flattened_locations1_clean_sorted} ){
   foreach my $chimere_type ( keys %{$flattened_locations1_clean_sorted->{$locusID}}){
     foreach my $locations1 ( @{$flattened_locations1_clean_sorted->{$locusID}{$chimere_type}} ){
@@ -443,7 +443,7 @@ foreach my $locusID (  keys %{$flattened_locations1_clean_sorted} ){
 
 # ---- NOw deal with what is remaining in annotationB-
 # Gather False positive => seq only annotated in annotationB, or type of feature annotated only in annotationB that was missing in annotatoin A
-dual_print( $log, "\nLook now what is specific to annotationB \n");
+dual_print( $log, "\nLook now what is specific to annotationB \n", 2 );
 foreach my $locusID (  keys %{$flattened_locations2_clean_sorted} ){
   foreach my $chimere_type ( keys %{$flattened_locations2_clean_sorted->{$locusID}}){
     foreach my $locations2 ( @{$flattened_locations2_clean_sorted->{$locusID}{$chimere_type}} ){
@@ -570,7 +570,7 @@ dual_print( $log, "Bye Bye.\n");
  # return t1 is location overlap
 sub remove_loc_by_id{
 	my($list_location, $locusID, $chimere_type, $id)=@_;
-    dual_print( $log, "Remove $id from locations \n");
+    dual_print( $log, "Remove $id from locations \n", 2 );
 	my @new_list;
 	foreach my $locations ( @{$list_location->{$locusID}{$chimere_type}} ){
 		if ( lc($locations->[0][3]) ne lc($id) ) {

--- a/bin/agat_sp_filter_by_ORF_size.pl
+++ b/bin/agat_sp_filter_by_ORF_size.pl
@@ -133,7 +133,7 @@ foreach my $primary_tag_l1 (keys %{$hash_omniscient->{'level1'}}){ # primary_tag
         if( $there_is_cds ){
           # All transcript discarded
           if( @l2_to_keep == 0){
-            dual_print( $log, "Case all L2 discarded \n");
+              dual_print( $log, "Case all L2 discarded \n", 2 );
             $number_gene_discarded++;
             $number_gene_affected++;
             # move L3
@@ -151,7 +151,7 @@ foreach my $primary_tag_l1 (keys %{$hash_omniscient->{'level1'}}){ # primary_tag
           }
           # Only part of the isoforms have been discarded
           elsif ( @l2_to_discard > 0){
-            dual_print( $log, "Case some L2 discarded \n");
+              dual_print( $log, "Case some L2 discarded \n", 2 );
             $number_gene_affected++;
             # handle L3
             
@@ -183,12 +183,12 @@ foreach my $primary_tag_l1 (keys %{$hash_omniscient->{'level1'}}){ # primary_tag
         }
         # ---------- CASE there is no CDS -----------
         else{
-          dual_print( $log, "No cds for $gene_id_l1\n");
+          dual_print( $log, "No cds for $gene_id_l1\n", 2 );
         }
       }
       # ---------- CASE NO L2 -----------
       if($no_l2){ # case of l1 feature without child
-        dual_print( $log, "No child for $gene_id_l1\n");
+        dual_print( $log, "No child for $gene_id_l1\n", 2 );
       }
     }
   }

--- a/bin/agat_sp_filter_by_locus_distance.pl
+++ b/bin/agat_sp_filter_by_locus_distance.pl
@@ -93,7 +93,7 @@ foreach my $locusID ( sort keys %{$sortBySeq}){ # tag_l1 = gene or repeat etc...
           my $location2 = @{$sortBySeq->{$locusID}{$tag_l1}}[0];
           my $id2_l1 = $location2->[0];
           my $dist = $location2->[1] - $location->[2] + 1;
-          dual_print( $log, "distance $id_l1 - id2_l1 = $dist\n");
+          dual_print( $log, "distance $id_l1 - id2_l1 = $dist\n", 2 );
 
           ############################
           #deal with overlap
@@ -213,12 +213,12 @@ sub add_info{
 
   if($feature->has_tag('low_dist')){
     $feature->add_tag_value('low_dist', $value);
-    dual_print( $log, $feature->_tag_value('ID')." add $value\n");
+      dual_print( $log, $feature->_tag_value('ID')." add $value\n", 2 );
   }
   else{
     create_or_replace_tag($feature, 'low_dist', $value);
     $geneCounter_skip++;
-    dual_print( $log, $feature->_tag_value('ID')." create $value\n");
+      dual_print( $log, $feature->_tag_value('ID')." create $value\n", 2 );
   }
 
 }

--- a/bin/agat_sp_filter_incomplete_gene_coding_models.pl
+++ b/bin/agat_sp_filter_incomplete_gene_coding_models.pl
@@ -123,7 +123,7 @@ foreach my $primary_tag_key_level1 (keys %{$hash_omniscient->{'level1'}}){ # pri
               if (! $skip_start_check){
                 my $start_codon = $seqobj->subseq(1,3);
                 if(! $codonTable->is_start_codon( $start_codon )){
-                  dual_print( $log, "start= $start_codon  is not a valid start codon\n");
+                    dual_print( $log, "start= $start_codon  is not a valid start codon\n", 2 );
                   $start_missing="true";
                   if($add_flag){
                     create_or_replace_tag($level2_feature, 'incomplete', '1');
@@ -136,7 +136,7 @@ foreach my $primary_tag_key_level1 (keys %{$hash_omniscient->{'level1'}}){ # pri
                 my $stop_codon = $seqobj->subseq($seqlength - 2, $seqlength) ;
 
                 if(! $codonTable->is_ter_codon( $stop_codon )){
-                  dual_print( $log, "stop= $stop_codon is not a valid stop codon\n");
+                    dual_print( $log, "stop= $stop_codon is not a valid stop codon\n", 2 );
                   $stop_missing="true";
                   if($add_flag){
                     if($start_missing){
@@ -150,11 +150,11 @@ foreach my $primary_tag_key_level1 (keys %{$hash_omniscient->{'level1'}}){ # pri
               }
             }
             else{ #short CDS
-              dual_print( $log, "CDS too short ($length_CDS nt) we skip it\n");
+                dual_print( $log, "CDS too short ($length_CDS nt) we skip it\n", 2 );
             }
           }
           else{ #No CDS
-            dual_print( $log, "Not a coding rna (no CDS) we skip it\n");
+              dual_print( $log, "Not a coding rna (no CDS) we skip it\n", 2 );
           }
 
           if($start_missing or $stop_missing){
@@ -193,7 +193,7 @@ foreach my $primary_tag_key_level1 (keys %{$hash_omniscient->{'level1'}}){ # pri
     }
     #after checking all mRNA of a gene
     if($ncGene){
-      dual_print( $log, "This is a non coding gene (no cds to any of its RNAs)");
+        dual_print( $log, "This is a non coding gene (no cds to any of its RNAs)", 2 );
     }
   }
 }

--- a/bin/agat_sp_fix_features_locations_duplicated.pl
+++ b/bin/agat_sp_fix_features_locations_duplicated.pl
@@ -134,7 +134,7 @@ foreach my $seqid (sort keys %{$hash_sortBySeq}){ # loop over all the feature le
 
                           #Check their subfeature are  identicals
                           if(featuresList_identik(\@{$omniscient->{'level3'}{'exon'}{$id_l2_1}}, \@{$omniscient->{'level3'}{'exon'}{$id_l2_2}}, $verbose )){
-                            dual_print( $log, "case1: $id_l2_2 and $id_l2_1 have same exon list\n");
+                              dual_print( $log, "case1: $id_l2_2 and $id_l2_1 have same exon list\n", 2 );
 
                             my $size_cds1 =  cds_size($omniscient, $id_l2_1);
                             my $size_cds2 =  cds_size($omniscient, $id_l2_2);
@@ -285,7 +285,7 @@ foreach my $seqid (sort keys %{$hash_sortBySeq}){ # loop over all the feature le
                               }
                               # CDS and Exon does not overlap
                               else{
-                                dual_print( $log, "CDS and Exon does not overlap\n");
+                                  dual_print( $log, "CDS and Exon does not overlap\n", 2 );
 
                               }
                             }


### PR DESCRIPTION
## Summary
- set verbosity level 2 for select `dual_print` diagnostics in comparison, filtering, and fixing scripts

## Testing
- `prove -lr t/smoke` *(fails: Cannot detect source of 't/smoke')*
- `make test` *(fails: several script output mismatches)*


------
https://chatgpt.com/codex/tasks/task_e_68adaccb4078832a8d8014b92d35f540