### PR TITLE
Allow multiple option occurrences in test utilities

### DIFF
--- a/t/agat_sp_merge_annotations.t
+++ b/t/agat_sp_merge_annotations.t
@@ -24,7 +24,10 @@ my $script = $script_prefix . catfile($bin_dir, "agat_sp_merge_annotations.pl");
 my $result = "$output_folder/agat_sp_merge_annotations_1.gff";
 check_quiet_and_normal_run(
     $script,
-    { gff => "$input_folder/agat_sp_merge_annotations/file1.gff", gff => "$input_folder/agat_sp_merge_annotations/file2.gff" },
+    [
+        { gff => "$input_folder/agat_sp_merge_annotations/file1.gff" },
+        { gff => "$input_folder/agat_sp_merge_annotations/file2.gff" },
+    ],
     "$result.stdout",
     $result
 );
@@ -33,7 +36,10 @@ check_quiet_and_normal_run(
 $result = "$output_folder/agat_sp_merge_annotations_2.gff";
 check_quiet_and_normal_run(
     $script,
-    { gff => "$input_folder/agat_sp_merge_annotations/fileA.gff", gff => "$input_folder/agat_sp_merge_annotations/fileB.gff" },
+    [
+        { gff => "$input_folder/agat_sp_merge_annotations/fileA.gff" },
+        { gff => "$input_folder/agat_sp_merge_annotations/fileB.gff" },
+    ],
     "$result.stdout",
     $result
 );
@@ -42,7 +48,10 @@ check_quiet_and_normal_run(
 $result = "$output_folder/agat_sp_merge_annotations_3.gff";
 check_quiet_and_normal_run(
     $script,
-    { gff => "$input_folder/agat_sp_merge_annotations/test457_A.gff", gff => "$input_folder/agat_sp_merge_annotations/test457_B.gff" },
+    [
+        { gff => "$input_folder/agat_sp_merge_annotations/test457_A.gff" },
+        { gff => "$input_folder/agat_sp_merge_annotations/test457_B.gff" },
+    ],
     "$result.stdout",
     $result
 );

--- a/t/lib/AGAT/TestUtilities.pm
+++ b/t/lib/AGAT/TestUtilities.pm
@@ -72,27 +72,40 @@ sub _sh_escape {
 }
 
 sub _build_cmd {
-    my ( $script, $args_hr, $outtmp ) = @_;
+    my ( $script, $args_in, $outtmp ) = @_;
     my @parts = ($script);
-    my %args  = %{ $args_hr // {} };
 
-    delete @args{qw/o output/};    # enforce our -o
-    for my $k ( sort keys %args ) {
-        my $v    = $args{$k};
-        my $flag = ( length($k) == 1 ) ? "-$k" : "--$k";    # allow single-letter flags
-        if ( !defined $v || $v eq '' || $v eq 1 ) {          # valueless option
-            push @parts, $flag;
-        }
-        else {
-            push @parts, $flag, _sh_escape($v);
+    # allow a hashref or an arrayref of hashrefs so that the same option
+    # (e.g. --gff) can be supplied multiple times
+    my @args_sets;
+    if ( ref $args_in eq 'ARRAY' ) {
+        @args_sets = @$args_in;
+    }
+    else {
+        @args_sets = ($args_in // {});
+    }
+
+    for my $args_hr (@args_sets) {
+        my %args = %{ $args_hr // {} };
+        delete @args{qw/o output/};    # enforce our -o
+        for my $k ( sort keys %args ) {
+            my $v    = $args{$k};
+            my $flag = ( length($k) == 1 ) ? "-$k" : "--$k";    # allow single-letter flags
+            if ( !defined $v || $v eq '' || $v eq 1 ) {          # valueless option
+                push @parts, $flag;
+            }
+            else {
+                push @parts, $flag, _sh_escape($v);
+            }
         }
     }
+
     push @parts, "-o", _sh_escape($outtmp);
     return join( ' ', @parts );
 }
 
 sub check_quiet_and_normal_run {
-    my ( $script, $args_hr, $stdout_expected, $results, $out_suffixes ) = @_;
+    my ( $script, $args, $stdout_expected, $results, $out_suffixes ) = @_;
     die "need script"           unless defined $script;
     die "need expected stdout"   unless defined $stdout_expected;
 
@@ -111,14 +124,14 @@ sub check_quiet_and_normal_run {
     # run in quiet mode first
     my $dir    = setup_tempdir();
     my $outtmp = File::Spec->catfile( $dir, 'tmp.gff' );
-    my $cmd    = _build_cmd( $script, $args_hr, $outtmp );
+    my $cmd    = _build_cmd( $script, $args, $outtmp );
     ok( check_quiet_run($cmd) == 0, "quiet run $script" );
 
     # normal mode
     $dir       = setup_tempdir();
     $outtmp    = File::Spec->catfile( $dir, 'tmp.gff' );
     my $outprefix = File::Spec->catfile( $dir, 'tmp' );
-    $cmd       = _build_cmd( $script, $args_hr, $outtmp );
+    $cmd       = _build_cmd( $script, $args, $outtmp );
     check_console_output( $cmd, $stdout_expected );
 
     for my $i ( 0 .. $#results ) {


### PR DESCRIPTION
## Summary
- permit TestUtilities::_build_cmd to accept an array of argument hashes so the same flag can be provided multiple times
- support array style args in check_quiet_and_normal_run
- update merge annotations test to supply two --gff inputs

## Testing
- `.agents/with-perl-local.sh make test` *(fails: output mismatch and missing config in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ae042bf4cc832a91fe9aa371044693