### PR TITLE
Sort loop keys for deterministic output

### DIFF
--- a/bin/agat_sp_prokka_fix_fragmented_gene_annotations.pl
+++ b/bin/agat_sp_prokka_fix_fragmented_gene_annotations.pl
@@ -281,7 +281,7 @@ foreach my $seqid (sort { (($a =~ /(\d+)$/)[0] || 0) <=> (($b =~ /(\d+)$/)[0] ||
 
 if($frags){
 	# add non modified sequences
-	foreach my $id_seq (keys %all_db_fasta_IDs){
+        foreach my $id_seq (sort keys %all_db_fasta_IDs){
 		my $seq_id_correct = $all_db_fasta_IDs{lc($id_seq)};
 
 		if (! exists_keys( $hash_sortBySeq, ($seq_id_correct) )){
@@ -311,10 +311,7 @@ if($frags){
 		my @shift_locations;
 
 		# make a list of location
-		foreach my $val (keys %{$gff_shift{$seqid}}) {
-			push @shift_locations, $val;
-		}
-		@shift_locations = sort { $a <=> $b} @shift_locations; # sort
+                @shift_locations = sort { $a <=> $b } keys %{$gff_shift{$seqid}};
 		$shift_location = shift @shift_locations; # get first value
 		if (exists_keys (\%gff_shift, ($seqid) ) ){
 			# loop over feature in order
@@ -881,11 +878,19 @@ sub retrieve_expected_protein_length{
 	}
 
 	#get original protein length
-	foreach my $id_obj_sub_gene (sort keys %{$obj_case->{hash_sub_gene_obj}}){
-		my $obj_sub_gene = $obj_case->{hash_sub_gene_obj}{$id_obj_sub_gene};
-		my $prot_name = $obj_sub_gene->{inference_value};
+       foreach my $id_obj_sub_gene (
+               sort {
+                       ncmp(
+                               $obj_case->{hash_sub_gene_obj}{$a}{inference_value} // '',
+                               $obj_case->{hash_sub_gene_obj}{$b}{inference_value} // ''
+                       )
+               }
+               keys %{$obj_case->{hash_sub_gene_obj}}
+       ){
+               my $obj_sub_gene = $obj_case->{hash_sub_gene_obj}{$id_obj_sub_gene};
+               my $prot_name    = $obj_sub_gene->{inference_value};
 
-		if (lc($obj_sub_gene->{inference_db}) eq "uniprotkb"){
+               if (lc($obj_sub_gene->{inference_db}) eq "uniprotkb"){
                         dual_print($log, "Inference made with Uniprot, looking for protein size: $prot_name\n");
 			if( exists $all_db_db_IDs{lc($prot_name)}){
 				my $protID_correct = $all_db_db_IDs{lc($prot_name)};

--- a/t/scripts_output/out/agat_sp_prokka_fix_fragmented_gene_annotations_1.gff.stdout
+++ b/t/scripts_output/out/agat_sp_prokka_fix_fragmented_gene_annotations_1.gff.stdout
@@ -1192,10 +1192,10 @@ db file parsed
 Based on their names and the fact they are conitguous, those 2 genes might be merged: mntB_1 mntB_2 
 mntB_1 has a AA size of: 294
 mntB_2 has a AA size of: 240
-Inference made with Uniprot, looking for protein size: Q55282
-AA length found 306 
 Inference made with Uniprot, looking for protein size: O34338
-AA length found 250 
+AA length found 250
+Inference made with Uniprot, looking for protein size: Q55282
+AA length found 306
 Average of the expected length = 278 
 Average of the expected length + 20 % = 305 
 current length adding all genes together (and removing overlaping part): 532
@@ -1228,10 +1228,10 @@ current length adding all genes together (and removing overlaping part): 599
 Based on their names and the fact they are conitguous, those 2 genes might be merged: gyrB_1 gyrB_2 
 gyrB_1 has a AA size of: 238
 gyrB_2 has a AA size of: 570
-Inference made with Uniprot, looking for protein size: P0A2I3
-AA length found 804 
 Inference made with Uniprot, looking for protein size: O67137
-AA length found 792 
+AA length found 792
+Inference made with Uniprot, looking for protein size: P0A2I3
+AA length found 804
 Average of the expected length = 798 
 Average of the expected length + 20 % = 877 
 current length adding all genes together (and removing overlaping part): 806
@@ -1243,12 +1243,12 @@ frame 2 contains protein2
 Based on their names and the fact they are conitguous, those 2 genes might be merged: uvrA_1 uvrA_2 
 uvrA_1 has a AA size of: 902
 uvrA_2 has a AA size of: 926
-Inference made with Uniprot, looking for protein size: Q9WYV0
-AA length found 916 
 Inference made with Uniprot, looking for protein size: P0A698
-AA length found 940 
-Average of the expected length = 928 
-Average of the expected length + 20 % = 1020 
+AA length found 940
+Inference made with Uniprot, looking for protein size: Q9WYV0
+AA length found 916
+Average of the expected length = 928
+Average of the expected length + 20 % = 1020
 current length adding all genes together (and removing overlaping part): 1787
 
 Based on their names and the fact they are conitguous, those 2 genes might be merged: dapA_1 dapA_2 
@@ -1304,10 +1304,10 @@ frame 3 contains protein2
 Based on their names and the fact they are conitguous, those 2 genes might be merged: gyrB_3 gyrB_4 
 gyrB_3 has a AA size of: 219
 gyrB_4 has a AA size of: 373
-Inference made with Uniprot, looking for protein size: Q5SHZ4
-AA length found 634 
 Inference made with Uniprot, looking for protein size: O67137
-AA length found 792 
+AA length found 792
+Inference made with Uniprot, looking for protein size: Q5SHZ4
+AA length found 634
 Average of the expected length = 713 
 Average of the expected length + 20 % = 784 
 current length adding all genes together (and removing overlaping part): 592
@@ -1320,11 +1320,11 @@ Based on their names and the fact they are conitguous, those 2 genes might be me
 lpxA_1 has a AA size of: 175
 lpxA_2 has a AA size of: 116
 Inference made with Uniprot, looking for protein size: P0A722
-AA length found 262 
+AA length found 262
 Inference made with Uniprot, looking for protein size: Q9PIM1
-AA length found 263 
-Average of the expected length = 262 
-Average of the expected length + 20 % = 288 
+AA length found 263
+Average of the expected length = 262
+Average of the expected length + 20 % = 288
 current length adding all genes together (and removing overlaping part): 270
 270 < 288 => Let's merge them. (The length of the appended proteins is shorter than the size of the protein use for the inference)
 


### PR DESCRIPTION
## Summary
- sort Uniprot inference loop by protein name so lengths print before averages
- revert OmniscientTool debug sorting for now
- update fragmented gene annotations fixture for new deterministic ordering

## Testing
- `prove -lr t/smoke` *(fails: Cannot detect source of 't/smoke')*
- `make test` *(fails: output /workspace/AGAT/bin/agat_convert_embl2gff.pl)*

------
https://chatgpt.com/codex/tasks/task_e_68aedfebecf4832a97b5c74d42cf1856