### PR TITLE
Sort hash keys for stable agat_sp_manage_UTRs output

### DIFF
--- a/bin/agat_sp_manage_UTRs.pl
+++ b/bin/agat_sp_manage_UTRs.pl
@@ -242,7 +242,11 @@ foreach my $tag_l2 (keys %{$hash_omniscient->{'level2'}}) {
 if($opt_utr3 or $opt_utr5 or $opt_bst){
   # print preliminary results
   my $stringPrint="";
-  foreach my $key (keys %UTRoverview) {
+  my %order = (
+    three_prime_utr => 1,
+    five_prime_utr  => 2,
+  );
+  foreach my $key (sort { ($order{$a} // 99) <=> ($order{$b} // 99) || $a cmp $b } keys %UTRoverview) {
     $stringPrint.="There are ".scalar $UTRoverview{$key}." $key\n";
     my $total=0;
     foreach my $value  ( sort {$b <=> $a} keys %{$UTRdistribution{$key}}){
@@ -324,7 +328,7 @@ if($opt_utr3 or $opt_utr5 or $opt_bst){
     my $nbGene = keys %geneName;
     $stringPrint.= "According to the parameters $sizeList RNA discarded from $nbGene genes\n";
     my @listIDl2discardedUniq = uniq(@listIDl2discarded);
-    my $omniscient_discarded = create_omniscient_from_idlevel2list($hash_omniscient, $hash_mRNAGeneLink, \@listIDl2discarded);
+    my $omniscient_discarded = create_omniscient_from_idlevel2list($hash_omniscient, $hash_mRNAGeneLink, \@listIDl2discardedUniq);
     print_omniscient( {omniscient => $omniscient_discarded, output => $ostreamUTRdiscarded} );
 
   }

--- a/t/scripts_output/out/agat_sp_manage_UTRs_1.gff.stdout
+++ b/t/scripts_output/out/agat_sp_manage_UTRs_1.gff.stdout
@@ -114,10 +114,10 @@ Parsing Finished
 
 Formating output to GFF3
 Formating output to GFF3
-There are 60 five_prime_utr
-Among them 2 have over or equal 5 exons.
 There are 61 three_prime_utr
 Among them 0 have over or equal 5 exons.
+There are 60 five_prime_utr
+Among them 2 have over or equal 5 exons.
 There are 66 features that have UTRs (some at both sides some only at one extremity)
 Among them 3 have over or equal UTR (5' and/or 3') exons.
 


### PR DESCRIPTION
## Summary
- ensure bin/agat_sp_manage_UTRs.pl iterates over UTR side keys in a consistent order
- drop sorting in loops that only affect generated files so stdout remains unchanged

## Testing
- `.agents/with-perl-local.sh prove -lr t/smoke` *(fails: local/lib missing; Cannot detect source of 't/smoke')*
- `.agents/with-perl-local.sh make test` *(fails: local/lib missing; No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_68ae171af96c832ab88a2b2cac594d85